### PR TITLE
refactor: resolve clippy warnings and update Rust edition to 2021

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/lablup/bssh"
 readme = "README.md"
 keywords = ["cli", "rust"]
 categories = ["command-line-utilities"]
-edition = "2024"
+edition = "2021"
 
 [dependencies]
 tokio = { version = "1.47.1", features = ["full"] }

--- a/src/commands/download.rs
+++ b/src/commands/download.rs
@@ -30,9 +30,12 @@ pub async fn download_file(
 ) -> Result<()> {
     // Create destination directory if it doesn't exist
     if !destination.exists() {
-        fs::create_dir_all(destination)
-            .await
-            .with_context(|| format!("Failed to create destination directory: {destination:?}"))?;
+        fs::create_dir_all(destination).await.with_context(|| {
+            format!(
+                "Failed to create destination directory: {}",
+                destination.display()
+            )
+        })?;
     }
 
     let key_path_str = params.key_path.map(|p| p.to_string_lossy().to_string());
@@ -168,7 +171,7 @@ pub async fn download_file(
         let remote_files: Vec<String> = String::from_utf8_lossy(&glob_result.output)
             .lines()
             .filter(|line| !line.is_empty())
-            .map(|s| s.to_string())
+            .map(std::string::ToString::to_string)
             .collect();
 
         if remote_files.is_empty() {
@@ -184,7 +187,7 @@ pub async fn download_file(
         for file in &remote_files {
             println!("  {} {}", "•".dimmed(), file.cyan());
         }
-        println!("{} {:?}\n", "Destination:".bold(), destination);
+        println!("{} {}\n", "Destination:".bold(), destination.display());
 
         // Download each file
         let results = executor
@@ -219,12 +222,12 @@ pub async fn download_file(
     } else {
         // Single file download
         println!(
-            "\n{} {} {} from {} nodes to {:?} {}\n",
+            "\n{} {} {} from {} nodes to {} {}\n",
             "▶".cyan(),
             "Downloading".cyan().bold(),
             source.green(),
             params.nodes.len().to_string().yellow(),
-            destination,
+            destination.display(),
             "(SFTP)".dimmed()
         );
 

--- a/src/commands/interactive_signal.rs
+++ b/src/commands/interactive_signal.rs
@@ -15,8 +15,8 @@
 //! Signal handling for interactive mode
 
 use anyhow::Result;
-use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
 use tokio::signal;
 use tracing::{debug, info};
 

--- a/src/commands/upload.rs
+++ b/src/commands/upload.rs
@@ -58,9 +58,8 @@ pub async fn upload_file(
     );
     for file in &files {
         let size = std::fs::metadata(file)
-            .map(|m| format_bytes(m.len()))
-            .unwrap_or_else(|_| "unknown".to_string());
-        println!("  {} {:?} ({})", "•".dimmed(), file, size.yellow());
+            .map_or_else(|_| "unknown".to_string(), |m| format_bytes(m.len()));
+        println!("  {} {} ({})", "•".dimmed(), file.display(), size.yellow());
     }
     println!("{} {}\n", "Destination:".bold(), destination.green());
 
@@ -98,17 +97,17 @@ pub async fn upload_file(
                     let remote_relative = relative_path.to_string_lossy();
 
                     // Create remote directory structure if needed
-                    if let Some(parent) = relative_path.parent()
-                        && !parent.as_os_str().is_empty()
-                    {
-                        let remote_dir = if destination.ends_with('/') {
-                            format!("{destination}{}", parent.display())
-                        } else {
-                            format!("{destination}/{}", parent.display())
-                        };
-                        // Create remote directory using SSH command
-                        let mkdir_cmd = format!("mkdir -p '{remote_dir}'");
-                        let _ = executor.execute(&mkdir_cmd).await;
+                    if let Some(parent) = relative_path.parent() {
+                        if !parent.as_os_str().is_empty() {
+                            let remote_dir = if destination.ends_with('/') {
+                                format!("{destination}{}", parent.display())
+                            } else {
+                                format!("{destination}/{}", parent.display())
+                            };
+                            // Create remote directory using SSH command
+                            let mkdir_cmd = format!("mkdir -p '{remote_dir}'");
+                            let _ = executor.execute(&mkdir_cmd).await;
+                        }
                     }
 
                     if destination.ends_with('/') {
@@ -146,10 +145,10 @@ pub async fn upload_file(
         };
 
         println!(
-            "\n{} {} {:?} {} {}",
+            "\n{} {} {} {} {}",
             "▶".cyan(),
             "Uploading".cyan(),
-            file,
+            file.display(),
             "→".dimmed(),
             remote_path.green()
         );

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -21,7 +21,7 @@ use std::sync::Arc;
 use tokio::sync::Semaphore;
 
 use crate::node::Node;
-use crate::ssh::{SshClient, client::CommandResult, known_hosts::StrictHostKeyChecking};
+use crate::ssh::{client::CommandResult, known_hosts::StrictHostKeyChecking, SshClient};
 use crate::ui::OutputFormatter;
 
 pub struct ParallelExecutor {

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,11 +21,11 @@ use bssh::{
     cli::{Cli, Commands},
     commands::{
         download::download_file,
-        exec::{ExecuteCommandParams, execute_command},
+        exec::{execute_command, ExecuteCommandParams},
         interactive::InteractiveCommand,
         list::list_clusters,
         ping::ping_nodes,
-        upload::{FileTransferParams, upload_file},
+        upload::{upload_file, FileTransferParams},
     },
     config::{Config, InteractiveMode},
     node::Node,

--- a/src/ssh/client.rs
+++ b/src/ssh/client.rs
@@ -437,12 +437,11 @@ impl SshClient {
                 if std::env::var("SSH_AUTH_SOCK").is_ok() {
                     tracing::debug!("Using SSH agent for authentication");
                     return Ok(AuthMethod::Agent);
-                } else {
-                    tracing::warn!(
-                        "SSH agent requested but SSH_AUTH_SOCK environment variable not set"
-                    );
-                    // Fall through to key file authentication
                 }
+                tracing::warn!(
+                    "SSH agent requested but SSH_AUTH_SOCK environment variable not set"
+                );
+                // Fall through to key file authentication
             }
             #[cfg(target_os = "windows")]
             {

--- a/src/ssh/tokio_client/client.rs
+++ b/src/ssh/tokio_client/client.rs
@@ -1,7 +1,7 @@
 use russh::client::KeyboardInteractiveAuthResponse;
 use russh::{
-    Channel,
     client::{Config, Handle, Handler, Msg},
+    Channel,
 };
 use russh_sftp::{client::SftpSession, protocol::OpenFlags};
 use std::net::SocketAddr;
@@ -398,11 +398,11 @@ impl Client {
                         )
                         .await;
 
-                    if let Ok(auth_result) = result
-                        && auth_result.success()
-                    {
-                        auth_success = true;
-                        break;
+                    if let Ok(auth_result) = result {
+                        if auth_result.success() {
+                            auth_success = true;
+                            break;
+                        }
                     }
                 }
 

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -352,11 +352,11 @@ impl OutputFormatter {
 }
 
 pub fn print_welcome_banner() {
-    let banner = r#"
+    let banner = r"
 ╭───────────────────────────────────────╮
 │      bssh - Backend.AI SSH Tool       │
 │     Parallel Command Execution        │
 ╰───────────────────────────────────────╯
-"#;
+";
     println!("{}", banner.cyan());
 }

--- a/tests/interactive_integration_test.rs
+++ b/tests/interactive_integration_test.rs
@@ -18,8 +18,8 @@ use bssh::commands::interactive::InteractiveCommand;
 use bssh::config::{Config, InteractiveConfig};
 use bssh::node::Node;
 use std::path::PathBuf;
-use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::Arc;
 use std::time::Duration;
 use tempfile::tempdir;
 

--- a/tests/interactive_signal_test.rs
+++ b/tests/interactive_signal_test.rs
@@ -13,10 +13,10 @@
 // limitations under the License.
 
 use bssh::commands::interactive_signal::{
-    TerminalGuard, is_interrupted, reset_interrupt, setup_signal_handlers,
+    is_interrupted, reset_interrupt, setup_signal_handlers, TerminalGuard,
 };
-use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
 use std::time::Duration;
 
 #[test]


### PR DESCRIPTION
## Summary

This PR resolves all clippy warnings and errors across the codebase while updating the Rust edition from 2024 to 2021 for broader compatibility.

## Changes

- Updated Rust edition from 2024 to 2021 in Cargo.toml
- Fixed all clippy warnings related to if-let chains and pattern matching
- Improved error message formatting to use Display trait instead of Debug
- Simplified conditional logic and removed unnecessary pattern matches
- Fixed unused variable warnings and unreachable code
- Standardized import ordering and formatting
- Updated string conversions to use more idiomatic approaches
- Resolved path handling to use display() instead of debug formatting

## Testing

All existing functionality remains unchanged. The refactoring focuses on code quality improvements without altering behavior.