### PR TITLE
fix: use cluster SSH key config and simplify BACKENDAI environment handling

### DIFF
--- a/tests/backendai_env_test.rs
+++ b/tests/backendai_env_test.rs
@@ -45,19 +45,19 @@ async fn test_backendai_env_auto_detection() {
         .await
         .expect("Config should load with Backend.AI env");
 
-    // Check that backendai cluster was created
-    assert!(config.clusters.contains_key("backendai"));
+    // Check that bai_auto cluster was created
+    assert!(config.clusters.contains_key("bai_auto"));
 
-    // Get the backendai cluster
-    let cluster = config.clusters.get("backendai").unwrap();
+    // Get the bai_auto cluster
+    let cluster = config.clusters.get("bai_auto").unwrap();
 
     // Verify nodes were parsed correctly
     assert_eq!(cluster.nodes.len(), 3);
 
-    // Resolve nodes for the backendai cluster
+    // Resolve nodes for the bai_auto cluster
     let nodes = config
-        .resolve_nodes("backendai")
-        .expect("Should resolve backendai nodes");
+        .resolve_nodes("bai_auto")
+        .expect("Should resolve bai_auto nodes");
     assert_eq!(nodes.len(), 3);
 
     // Check node details
@@ -114,11 +114,11 @@ async fn test_backendai_env_with_single_host() {
         .await
         .expect("Config should load");
 
-    // Verify backendai cluster exists
-    assert!(config.clusters.contains_key("backendai"));
+    // Verify bai_auto cluster exists
+    assert!(config.clusters.contains_key("bai_auto"));
 
     let nodes = config
-        .resolve_nodes("backendai")
+        .resolve_nodes("bai_auto")
         .expect("Should resolve nodes");
     assert_eq!(nodes.len(), 1);
     assert_eq!(nodes[0].host, "single-node.ai");


### PR DESCRIPTION
## Summary
- Fixed SSH key configuration to properly use cluster-specific SSH keys from config file
- Simplified BACKENDAI environment variable handling by removing complex cluster matching logic
- Changed auto-generated cluster name from 'backendai' to 'bai_auto' to avoid naming conflicts

## Problem
1. When using `bssh -c <cluster>`, the SSH key specified in cluster configuration was ignored
2. BACKENDAI environment detection had unnecessarily complex logic for matching existing clusters
3. Auto-generated cluster name 'backendai' could conflict with user-defined clusters

## Solution
1. **SSH Key Resolution**: Modified all command handlers to properly resolve SSH keys with priority:
   - CLI `-i` flag (highest priority)
   - Cluster-specific `ssh_key` from config
   - Default SSH key fallback

2. **BACKENDAI Simplification**: Removed complex cluster matching logic. Now when BACKENDAI environment variables are detected:
   - Simply creates a 'bai_auto' cluster with default settings
   - Uses port 2200 and current username
   - Falls back to standard SSH key locations

3. **Naming**: Changed auto-generated cluster name to 'bai_auto' to clearly indicate it's automatically generated and avoid conflicts

## Test Results
- ✅ `bssh -c orin ls` now correctly uses `~/.ssh/id_rsa_orin` from config
- ✅ BACKENDAI environment creates independent 'bai_auto' cluster
- ✅ Path expansion (`~`) works correctly for SSH keys
- ✅ Users can still create their own 'backendai' cluster without conflicts