### PR TITLE
feat: use Backend.AI cluster SSH key for auto-detected environments

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -225,7 +225,10 @@ impl Config {
 
         Some(Cluster {
             nodes: filtered_nodes,
-            defaults: ClusterDefaults::default(),
+            defaults: ClusterDefaults {
+                ssh_key: Some("/home/config/ssh/id_cluster".to_string()),
+                ..ClusterDefaults::default()
+            },
             interactive: None,
         })
     }

--- a/tests/backendai_env_test.rs
+++ b/tests/backendai_env_test.rs
@@ -51,6 +51,13 @@ async fn test_backendai_env_auto_detection() {
     // Get the bai_auto cluster
     let cluster = config.clusters.get("bai_auto").unwrap();
 
+    // Verify SSH key is set to Backend.AI cluster key
+    assert_eq!(
+        cluster.defaults.ssh_key,
+        Some("/home/config/ssh/id_cluster".to_string()),
+        "Backend.AI cluster should use /home/config/ssh/id_cluster as SSH key"
+    );
+
     // Verify nodes were parsed correctly
     assert_eq!(cluster.nodes.len(), 3);
 
@@ -65,6 +72,13 @@ async fn test_backendai_env_auto_detection() {
     assert_eq!(nodes[0].port, 2200); // Backend.AI default port
     assert_eq!(nodes[1].host, "node2.ai");
     assert_eq!(nodes[2].host, "node3.ai");
+
+    // Verify get_ssh_key returns the correct key for Backend.AI cluster
+    assert_eq!(
+        config.get_ssh_key(Some("bai_auto")),
+        Some("/home/config/ssh/id_cluster".to_string()),
+        "get_ssh_key should return Backend.AI cluster key path"
+    );
 
     // Restore original env vars
     unsafe {


### PR DESCRIPTION
## Summary
- Configure Backend.AI auto-detected clusters to use `/home/config/ssh/id_cluster` as the SSH key
- Update `from_backendai_env()` function to set the correct SSH key path in cluster defaults
- Add tests to verify the SSH key configuration for Backend.AI environments

## Changes
- Modified `src/config.rs`: Set SSH key to `/home/config/ssh/id_cluster` when creating clusters from Backend.AI environment variables
- Updated `tests/backendai_env_test.rs`: Added assertions to verify the SSH key is correctly configured

## Context
When bssh auto-detects a Backend.AI cluster environment through `BACKENDAI_CLUSTER_*` environment variables, it now uses the standard Backend.AI cluster SSH key location (`/home/config/ssh/id_cluster`) instead of default user SSH keys.

This ensures proper authentication in Backend.AI multi-node cluster environments where the cluster-specific key is required.