### PR TITLE
fix: align interactive mode authentication with exec mode

### DIFF
--- a/examples/interactive_demo.rs
+++ b/examples/interactive_demo.rs
@@ -17,6 +17,7 @@
 use bssh::commands::interactive::InteractiveCommand;
 use bssh::config::{Config, InteractiveConfig};
 use bssh::node::Node;
+use bssh::ssh::known_hosts::StrictHostKeyChecking;
 use std::path::PathBuf;
 
 #[tokio::main]
@@ -48,6 +49,10 @@ async fn main() -> anyhow::Result<()> {
         config: Config::default(),
         interactive_config: InteractiveConfig::default(),
         cluster_name: None,
+        key_path: None,
+        use_agent: false,
+        use_password: false,
+        strict_mode: StrictHostKeyChecking::AcceptNew,
     };
 
     println!("Starting interactive session...");

--- a/tests/interactive_integration_test.rs
+++ b/tests/interactive_integration_test.rs
@@ -17,6 +17,7 @@
 use bssh::commands::interactive::InteractiveCommand;
 use bssh::config::{Config, InteractiveConfig};
 use bssh::node::Node;
+use bssh::ssh::known_hosts::StrictHostKeyChecking;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::Arc;
@@ -41,6 +42,10 @@ fn test_interactive_command_builder() {
         config: Config::default(),
         interactive_config: InteractiveConfig::default(),
         cluster_name: None,
+        key_path: None,
+        use_agent: false,
+        use_password: false,
+        strict_mode: StrictHostKeyChecking::AcceptNew,
     };
 
     assert!(!cmd.single_node);
@@ -66,6 +71,10 @@ fn test_history_file_handling() {
         config: Config::default(),
         interactive_config: InteractiveConfig::default(),
         cluster_name: None,
+        key_path: None,
+        use_agent: false,
+        use_password: false,
+        strict_mode: StrictHostKeyChecking::AcceptNew,
     };
 
     assert_eq!(cmd.history_file, history_path);
@@ -154,6 +163,10 @@ async fn test_interactive_with_unreachable_nodes() {
         config: Config::default(),
         interactive_config: InteractiveConfig::default(),
         cluster_name: None,
+        key_path: None,
+        use_agent: false,
+        use_password: false,
+        strict_mode: StrictHostKeyChecking::AcceptNew,
     };
 
     // This should fail to connect
@@ -179,6 +192,10 @@ async fn test_interactive_with_no_nodes() {
         config: Config::default(),
         interactive_config: InteractiveConfig::default(),
         cluster_name: None,
+        key_path: None,
+        use_agent: false,
+        use_password: false,
+        strict_mode: StrictHostKeyChecking::AcceptNew,
     };
 
     let result = cmd.execute().await;
@@ -214,6 +231,10 @@ fn test_mode_configuration() {
         config: Config::default(),
         interactive_config: InteractiveConfig::default(),
         cluster_name: None,
+        key_path: None,
+        use_agent: false,
+        use_password: false,
+        strict_mode: StrictHostKeyChecking::AcceptNew,
     };
 
     assert!(single_cmd.single_node);
@@ -230,6 +251,10 @@ fn test_mode_configuration() {
         config: Config::default(),
         interactive_config: InteractiveConfig::default(),
         cluster_name: None,
+        key_path: None,
+        use_agent: false,
+        use_password: false,
+        strict_mode: StrictHostKeyChecking::AcceptNew,
     };
 
     assert!(!multi_cmd.single_node);
@@ -249,6 +274,10 @@ fn test_working_directory_config() {
         config: Config::default(),
         interactive_config: InteractiveConfig::default(),
         cluster_name: None,
+        key_path: None,
+        use_agent: false,
+        use_password: false,
+        strict_mode: StrictHostKeyChecking::AcceptNew,
     };
 
     assert_eq!(cmd_with_dir.work_dir, Some("/var/www".to_string()));
@@ -263,6 +292,10 @@ fn test_working_directory_config() {
         config: Config::default(),
         interactive_config: InteractiveConfig::default(),
         cluster_name: None,
+        key_path: None,
+        use_agent: false,
+        use_password: false,
+        strict_mode: StrictHostKeyChecking::AcceptNew,
     };
 
     assert_eq!(cmd_without_dir.work_dir, None);
@@ -289,6 +322,10 @@ fn test_prompt_format() {
             config: Config::default(),
             interactive_config: InteractiveConfig::default(),
             cluster_name: None,
+            key_path: None,
+            use_agent: false,
+            use_password: false,
+            strict_mode: StrictHostKeyChecking::AcceptNew,
         };
 
         assert_eq!(cmd.prompt_format, format);

--- a/tests/interactive_test.rs
+++ b/tests/interactive_test.rs
@@ -15,6 +15,7 @@
 use bssh::commands::interactive::InteractiveCommand;
 use bssh::config::{Config, InteractiveConfig};
 use bssh::node::Node;
+use bssh::ssh::known_hosts::StrictHostKeyChecking;
 use std::path::PathBuf;
 
 #[tokio::test]
@@ -29,6 +30,10 @@ async fn test_interactive_command_creation() {
         config: Config::default(),
         interactive_config: InteractiveConfig::default(),
         cluster_name: None,
+        key_path: None,
+        use_agent: false,
+        use_password: false,
+        strict_mode: StrictHostKeyChecking::AcceptNew,
     };
 
     assert!(!cmd.single_node);
@@ -48,6 +53,10 @@ async fn test_interactive_with_no_nodes() {
         config: Config::default(),
         interactive_config: InteractiveConfig::default(),
         cluster_name: None,
+        key_path: None,
+        use_agent: false,
+        use_password: false,
+        strict_mode: StrictHostKeyChecking::AcceptNew,
     };
 
     let result = cmd.execute().await;


### PR DESCRIPTION
## Summary
- Fixed interactive mode connection failures when using cluster configurations with SSH keys
- Aligned authentication behavior between interactive and exec modes for consistency

## Changes
- Added authentication parameters (`key_path`, `use_agent`, `use_password`, `strict_mode`) to `InteractiveCommand` struct
- Refactored `determine_auth_method()` in interactive mode to use the same logic as exec mode
- Updated CLI to pass authentication parameters from command-line arguments and config to interactive mode
- Updated all tests and examples to include the new authentication fields

## Problem Solved
Previously, interactive mode ignored CLI authentication parameters and cluster SSH key configurations, causing connection failures when running commands like `bssh -c orin interactive`. The mode had its own simplified authentication logic that only checked for SSH agent and default key locations.

Now interactive mode respects:
- Cluster-specific SSH keys from config files
- CLI parameters like `-i/--identity`, `--use-agent`, `--password`
- The same authentication priority order as exec mode

## Test Plan
- [x] Code builds successfully with `cargo build --all-targets`
- [x] All clippy warnings resolved
- [x] Code formatted with `cargo fmt`
- [ ] Manual testing with cluster configurations
- [ ] Interactive mode connects successfully with SSH key authentication