### PR TITLE
fix: use parallel config value from configuration file

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -133,6 +133,7 @@ pub struct ClusterDefaults {
     pub user: Option<String>,
     pub port: Option<u16>,
     pub ssh_key: Option<String>,
+    pub parallel: Option<usize>,
     pub timeout: Option<u64>,
 }
 
@@ -420,6 +421,18 @@ impl Config {
         }
 
         self.defaults.timeout
+    }
+
+    pub fn get_parallel(&self, cluster_name: Option<&str>) -> Option<usize> {
+        if let Some(cluster_name) = cluster_name {
+            if let Some(cluster) = self.get_cluster(cluster_name) {
+                if let Some(parallel) = cluster.defaults.parallel {
+                    return Some(parallel);
+                }
+            }
+        }
+
+        self.defaults.parallel
     }
 
     /// Get interactive configuration for a cluster (with fallback to global)


### PR DESCRIPTION
## Summary
- Fixed the issue where `parallel` configuration values were completely ignored
- Implemented proper config file support for the `parallel` option

## Problem
The `parallel` field existed in config files but was never actually used. The application always used CLI's default value (10) regardless of config settings.

```yaml
# This was ignored:
defaults:
  parallel: 50
```

## Solution  
- Added `get_parallel()` method to Config struct (follows same pattern as `get_timeout()`)
- Added `parallel` field to `ClusterDefaults` struct for cluster-specific settings
- Detect if user explicitly specified `-p/--parallel` in CLI arguments
- Use config value when CLI option is not explicitly provided

## Priority Order
1. CLI option (if explicitly specified with `-p` or `--parallel`)
2. Cluster-specific config (`clusters.<name>.parallel`)
3. Global defaults config (`defaults.parallel`)
4. CLI default value (10)

## Usage Examples
```yaml
# Global default
defaults:
  parallel: 50

# Cluster-specific override
clusters:
  production:
    nodes: [...]
    parallel: 100  # Use up to 100 parallel connections for production
  dev:
    nodes: [...]
    parallel: 5    # Limit to 5 for dev environment
```

```bash
# Uses config value (50 from defaults or cluster-specific)
bssh -c production "uptime"

# Overrides config with explicit CLI value
bssh -c production -p 200 "uptime"
```

## Test Plan
- [x] Code builds successfully
- [x] Clippy checks pass
- [x] Code formatted with cargo fmt
- [x] Manual testing with config files
- [x] Verify CLI override still works
- [x] Verify cluster-specific parallel values work