### PR TITLE
feat: show help message when no arguments provided

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -21,7 +21,7 @@ use std::path::PathBuf;
     version,
     before_help = "",
     about = "Backend.AI SSH - Parallel command execution across cluster nodes",
-    long_about = "bssh is a high-performance parallel SSH command execution tool for cluster management, built with Rust.\nIt enables efficient execution of commands across multiple nodes simultaneously with real-time output streaming.\nThe tool provides secure file transfer capabilities using SFTP protocol and supports multiple authentication\nmethods including SSH keys (with passphrase support), SSH agent, and password authentication.\nIt automatically detects Backend.AI multi-node session environments.",
+    long_about = "bssh is a high-performance parallel SSH command execution tool for cluster management.\nIt enables efficient execution of commands across multiple nodes simultaneously with real-time output streaming.\nThe tool provides secure file transfer capabilities using SFTP protocol and supports multiple authentication\nmethods including SSH keys (with passphrase support), SSH agent, and password authentication.\nIt automatically detects Backend.AI multi-node session environments.",
     after_help = "EXAMPLES:\n  Execute command on hosts:     bssh -H \"user@host1,host2\" \"uptime\"\n  Use cluster configuration:    bssh -c production \"df -h\"\n  Upload files with glob:       bssh -c staging upload \"*.log\" /tmp/\n  Download from all nodes:      bssh -c web download /var/log/app.log ./logs/\n  Interactive mode (multiplex): bssh -c production interactive\n  Test connectivity:            bssh -c staging ping\n\nDeveloped and maintained as part of the Backend.AI project.\nFor more examples and documentation, visit: https://github.com/lablup/bssh"
 )]
 pub struct Cli {

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use anyhow::Result;
-use clap::Parser;
+use clap::{CommandFactory, Parser};
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
@@ -32,6 +32,13 @@ use bssh::{
     ssh::known_hosts::StrictHostKeyChecking,
     utils::init_logging,
 };
+
+/// Show help message and exit
+fn show_help() {
+    let mut cmd = Cli::command();
+    let _ = cmd.print_help();
+    eprintln!(); // Add a newline after help
+}
 
 /// Format a Duration into a human-readable string
 fn format_duration(duration: Duration) -> String {
@@ -61,13 +68,20 @@ fn format_duration(duration: Duration) -> String {
 
 #[tokio::main]
 async fn main() -> Result<()> {
+    // Check if no arguments were provided
+    let args: Vec<String> = std::env::args().collect();
+    if args.len() == 1 {
+        // Show help when no arguments provided
+        show_help();
+        std::process::exit(0);
+    }
+
     let cli = Cli::parse();
 
     // Initialize logging
     init_logging(cli.verbose);
 
     // Check if user explicitly specified options
-    let args: Vec<String> = std::env::args().collect();
     let has_explicit_config = args.iter().any(|arg| arg == "--config");
     let has_explicit_parallel = args.iter().any(|arg| {
         arg == "-p"


### PR DESCRIPTION
## Summary
- Display help message when running `bssh` without any arguments, improving user experience
- Extract help display logic into a reusable `show_help()` function
- Remove unnecessary "built with Rust" text from help message

## Changes
- Show full help message when no arguments are provided (same as `--help`)
- Simplify help text by removing implementation details
- Better first-time user experience with immediate guidance

## Test plan
- [x] Run `bssh` without arguments - shows help message
- [x] Run `bssh --help` - shows the same help message
- [x] Run `bssh -H localhost` without command - shows error message
- [x] Run `bssh -c nonexistent` - shows appropriate error