### PR TITLE
fix: use parallel config value from configuration file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -323,7 +323,7 @@ dependencies = [
 
 [[package]]
 name = "bssh"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bssh"
-version = "0.5.3"
+version = "0.5.4"
 authors = ["Jeongkyu Shin <inureyes@gmail.com>"]
 description = "Parallel SSH command execution tool for cluster management"
 license = "Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -526,6 +526,7 @@ See the [LICENSE](./LICENSE) file for details.
 ## Changelog
 
 ### Recent Updates
+- **v0.5.4 (2025/08/27):** Fix parallel config value handling and align interactive mode authentication with exec mode
 - **v0.5.3 (2025/08/27):** Use Backend.AI cluster SSH key for auto-detected environments
 - **v0.5.2 (2025/08/27):** Fix config file loading priority, improve BACKENDAI environment handling, use cluster SSH key config
 - **v0.5.1 (2025/08/25):** Add configurable command timeout with support for unlimited execution (timeout=0), configurable via CLI and config file

--- a/src/config.rs
+++ b/src/config.rs
@@ -133,6 +133,7 @@ pub struct ClusterDefaults {
     pub user: Option<String>,
     pub port: Option<u16>,
     pub ssh_key: Option<String>,
+    pub parallel: Option<usize>,
     pub timeout: Option<u64>,
 }
 
@@ -420,6 +421,18 @@ impl Config {
         }
 
         self.defaults.timeout
+    }
+
+    pub fn get_parallel(&self, cluster_name: Option<&str>) -> Option<usize> {
+        if let Some(cluster_name) = cluster_name {
+            if let Some(cluster) = self.get_cluster(cluster_name) {
+                if let Some(parallel) = cluster.defaults.parallel {
+                    return Some(parallel);
+                }
+            }
+        }
+
+        self.defaults.parallel
     }
 
     /// Get interactive configuration for a cluster (with fallback to global)


### PR DESCRIPTION
Previously, the parallel setting in config files was completely ignored.
This fix implements proper config support for the parallel option:

- Add get_parallel() method to Config struct (follows same pattern as get_timeout)
- Add parallel field to ClusterDefaults struct
- Check if user explicitly specified -p/--parallel in CLI args
- Use config value when CLI option not explicitly provided
- Priority: CLI (if explicit) > Cluster config > Global defaults > CLI default (10)

Now users can set parallel in their config files:
  defaults:
    parallel: 50
  clusters:
    production:
      parallel: 100

Fixes the issue where config parallel values were defined but never used.