### PR TITLE
fix: Debian changelog generation for Ubuntu PPA builds

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,10 +1,33 @@
-bssh (0.3.0-1~jammy1) jammy; urgency=medium
+bssh (0.6.1-1~jammy1) jammy; urgency=medium
 
-  * Initial Debian packaging
-  * Add native SFTP directory operations and recursive file transfer support
-  * Modern UI with semantic colors and Unicode symbols
-  * Full XDG Base Directory specification compliance
-  * Backend.AI multi-node session auto-detection
-  * Multiple authentication methods support
+  * v0.6.1
+  ### New Features
+  None
+  
+  ### Improvements
+  - **Branding Update**: Rebranded from 'Backend.AI SSH' to 'Broadcast SSH' to better reflect the tool's core functionality of broadcast/parallel command execution
+  - **Documentation**: Updated all help text, manpages, and package descriptions with the new branding
+  
+  ### Bug Fixes
+  None
+  
+  ### CI/CD Improvements
+  None
+  
+  ### Technical Details
+  - Maintained Backend.AI project association in documentation while emphasizing the tool's broader utility
+  - Updated project branding across CLI help output, UI banners, man pages, and Debian package metadata
+  
+  ### Dependencies
+  None
+  
+  ### Breaking Changes
+  None
+  
+  ### Known Issues
+  None
+  
+  **Full Changelog**: https://github.com/lablup/bssh/compare/v0.6.0...v0.6.1
 
- -- Jeongkyu Shin <inureyes@gmail.com>  Fri, 22 Aug 2025 22:59:16 +0900
+ -- Jeongkyu Shin <inureyes@gmail.com>  Thu, 28 Aug 2025 13:57:13 +0900
+

--- a/debian/update-changelog.sh
+++ b/debian/update-changelog.sh
@@ -57,7 +57,13 @@ for TAG in "${TAGS[@]}"; do
   BODY=$(echo "$rel_json" | jq -r '.body')
 
   # Debian date format
-  FORMATTED_DATE=$(date -d "$DATE" "+%a, %d %b %Y %H:%M:%S %z")
+  if date --version >/dev/null 2>&1; then
+    # GNU date (Linux)
+    FORMATTED_DATE=$(date -d "$DATE" "+%a, %d %b %Y %H:%M:%S %z")
+  else
+    # BSD date (macOS)
+    FORMATTED_DATE=$(date -j -f "%Y-%m-%dT%H:%M:%SZ" "$DATE" "+%a, %d %b %Y %H:%M:%S %z")
+  fi
 
   # Determine version suffix
   if [[ "$AUTO_INCREMENT" == "true" ]]; then


### PR DESCRIPTION
## Summary
Fix changelog generation script and update changelog for Ubuntu PPA/Launchpad builds.

## Changes
- **Fix date command compatibility**: Add cross-platform support for date formatting (GNU date on Linux, BSD date on macOS)
- **Update changelog content**: Include proper release notes from v0.6.1 with the rebrand from 'Backend.AI SSH' to 'Broadcast SSH'
- **Improve script robustness**: Handle both Linux and macOS environments in the changelog update script

## Technical Details
The `debian/update-changelog.sh` script now detects the system's date command type and uses appropriate syntax:
- GNU date (Linux): `date -d "$DATE"`
- BSD date (macOS): `date -j -f "%Y-%m-%dT%H:%M:%SZ" "$DATE"`

This ensures the changelog can be generated correctly on both development machines (macOS) and CI/CD environments (Linux).

## Testing
- Script tested on both macOS and Linux environments
- Changelog format validated for Debian/Ubuntu packaging standards
- Date formatting verified for both GNU and BSD date commands