### PR TITLE
feat: stream output of executed commands

### DIFF
--- a/src/ssh/tokio_client/error.rs
+++ b/src/ssh/tokio_client/error.rs
@@ -41,6 +41,8 @@ pub enum Error {
     SftpError(#[from] russh_sftp::client::error::Error),
     #[error("I/O error")]
     IoError(#[from] io::Error),
+    #[error("Task join error: {0}")]
+    JoinError(#[from] tokio::task::JoinError),
     #[error("Command validation failed: {0}")]
     CommandValidationFailed(String),
     #[error("Port forwarding request failed: {0}")]


### PR DESCRIPTION
Wanted to gauge interest in accepting a PR that would stream the output of a command as it executes, rather than waiting for it to finish before returning its `stdout` / `stderr` output.

Useful for watching long running commands, such as for installing packages on a remote server.

Also useful for assessing if a remote command is hung, for example, if it is waiting for user input (which can happen when a dpkg install detects a changed config file and asks you if you want to keep or overwrite it, and you have not used the env vars or arguments to make that choice automatic).

So far this pr only adds two methods on public apis, and adds one test, but does not change the behavior of the cli tool.