### PR TITLE
fix: Correct cluster flag short form in help examples

### DIFF
--- a/docs/man/bssh.1
+++ b/docs/man/bssh.1
@@ -1232,11 +1232,11 @@ Specify target hosts:
 .TP
 .B --filter
 Include only matching hosts:
-.B bssh -c cluster --filter "web[1-5]" "systemctl status nginx"
+.B bssh -C cluster --filter "web[1-5]" "systemctl status nginx"
 .TP
 .B --exclude
 Exclude matching hosts:
-.B bssh -c cluster --exclude "node[1,3,5]" "df -h"
+.B bssh -C cluster --exclude "node[1,3,5]" "df -h"
 
 .SS Examples
 .nf

--- a/src/cli/bssh.rs
+++ b/src/cli/bssh.rs
@@ -387,7 +387,7 @@ pub enum Commands {
     #[command(
         about = "Start interactive shell session",
         long_about = "Opens an interactive shell session with one or more remote hosts.\nSupports both single-node and multiplex modes for efficient cluster management.\nIn multiplex mode, commands are sent to all active nodes simultaneously.\n\nSpecial commands (default prefix '!'):\n  !all              - Activate all connected nodes\n  !broadcast <cmd>  - Execute on all nodes temporarily\n  !node<N>          - Switch to specific node (e.g., !node1)\n  !list             - List all nodes and connection status\n  !status           - Show currently active nodes\n  !help             - Show special commands help\n  exit              - Exit interactive mode\n\nSettings can be configured globally or per-cluster in config file.\nCLI arguments override configuration file settings.",
-        after_help = "Examples:\n  bssh interactive                           # Auto-detect or use defaults\n  bssh -c prod interactive                   # Use production cluster\n  bssh interactive --single-node             # Connect to one node only\n  bssh interactive --prompt-format '{user}>' # Custom prompt\n  bssh interactive --work-dir /var/www       # Set initial directory"
+        after_help = "Examples:\n  bssh interactive                           # Auto-detect or use defaults\n  bssh -C prod interactive                   # Use production cluster\n  bssh interactive --single-node             # Connect to one node only\n  bssh interactive --prompt-format '{user}>' # Custom prompt\n  bssh interactive --work-dir /var/www       # Set initial directory"
     )]
     Interactive {
         #[arg(


### PR DESCRIPTION
## Summary
- The cluster flag is defined with `short = 'C'` (uppercase) in `src/cli/bssh.rs`, but help examples and the man page showed `-c` (lowercase)
- Running the examples verbatim (e.g. `bssh -c prod interactive`) would fail with clap's "unexpected argument" error
- Fixed three occurrences: one in the `interactive` subcommand's `after_help`, two in `docs/man/bssh.1`

## Test plan
- [x] `cargo fmt` / `cargo clippy` clean
- [ ] Verify `bssh interactive --help` now shows `-C prod` in examples