### PR TITLE
update: Bump rand 0.8 -> 0.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -427,7 +427,7 @@ dependencies = [
  "opentelemetry-otlp",
  "opentelemetry_sdk",
  "owo-colors",
- "rand 0.8.5",
+ "rand 0.9.3",
  "ratatui",
  "regex",
  "rpassword",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,7 +67,7 @@ libc = "0.2"
 ipnetwork = "0.21"
 bcrypt = "0.19"
 argon2 = "0.5"
-rand = "0.8"
+rand = "0.9"
 ssh-key = { version = "0.6", features = ["std"] }
 async-compression = { version = "0.4", features = ["tokio", "gzip"] }
 serde_json = "1.0"

--- a/src/bin/bssh_server.rs
+++ b/src/bin/bssh_server.rs
@@ -359,12 +359,13 @@ fn check_config(cli: &Cli) -> Result<()> {
 /// Generate SSH host keys
 fn gen_host_key(key_type: &str, output: &PathBuf, _bits: u32) -> Result<()> {
     use russh::keys::PrivateKey;
+    use ssh_key::rand_core::OsRng;
     use ssh_key::LineEnding;
 
     let key = match key_type.to_lowercase().as_str() {
         "ed25519" => {
             tracing::info!("Generating Ed25519 host key");
-            PrivateKey::random(&mut rand::thread_rng(), russh::keys::Algorithm::Ed25519)
+            PrivateKey::random(&mut OsRng, russh::keys::Algorithm::Ed25519)
                 .context("Failed to generate Ed25519 key")?
         }
         "rsa" => {
@@ -373,7 +374,7 @@ fn gen_host_key(key_type: &str, output: &PathBuf, _bits: u32) -> Result<()> {
             }
             tracing::info!(bits = _bits, "Generating RSA host key");
             PrivateKey::random(
-                &mut rand::thread_rng(),
+                &mut OsRng,
                 russh::keys::Algorithm::Rsa {
                     hash: Some(russh::keys::HashAlg::Sha256),
                 },

--- a/src/keygen/ed25519.rs
+++ b/src/keygen/ed25519.rs
@@ -24,6 +24,7 @@
 use super::GeneratedKey;
 use anyhow::{Context, Result};
 use russh::keys::{Algorithm, HashAlg, PrivateKey};
+use ssh_key::rand_core::OsRng;
 use ssh_key::LineEnding;
 use std::io::Write;
 use std::path::Path;
@@ -42,7 +43,7 @@ pub fn generate(output_path: &Path, comment: Option<&str>) -> Result<GeneratedKe
     tracing::info!("Generating Ed25519 key pair");
 
     // Generate key pair using cryptographically secure RNG
-    let keypair = PrivateKey::random(&mut rand::thread_rng(), Algorithm::Ed25519)
+    let keypair = PrivateKey::random(&mut OsRng, Algorithm::Ed25519)
         .context("Failed to generate Ed25519 key")?;
 
     // Get public key and fingerprint

--- a/src/keygen/rsa.rs
+++ b/src/keygen/rsa.rs
@@ -26,6 +26,7 @@
 use super::GeneratedKey;
 use anyhow::{bail, Context, Result};
 use russh::keys::{Algorithm, HashAlg, PrivateKey};
+use ssh_key::rand_core::OsRng;
 use ssh_key::LineEnding;
 use std::io::Write;
 use std::path::Path;
@@ -76,7 +77,7 @@ pub fn generate(output_path: &Path, bits: u32, comment: Option<&str>) -> Result<
     // Generate key pair using cryptographically secure RNG
     // Use SHA-256 for the RSA signature hash algorithm
     let keypair = PrivateKey::random(
-        &mut rand::thread_rng(),
+        &mut OsRng,
         Algorithm::Rsa {
             hash: Some(HashAlg::Sha256),
         },


### PR DESCRIPTION
## Summary
Aligns our root crate with \`bssh-russh\` which already depends on rand 0.9, eliminating a duplicate \`rand\`/\`rand_core\` copy from the dependency tree.

rand 0.9's \`ThreadRng\` does not implement rand_core 0.6 traits, which is what \`ssh-key::PrivateKey::random\` still requires. Key-generation call sites (\`src/keygen/{ed25519,rsa}.rs\`, \`src/bin/bssh_server.rs\`) now use \`ssh_key::rand_core::OsRng\` — OS entropy is the correct source for long-lived key material anyway, and \`thread_rng\` added no value there.

## Why not rand 0.10?
\`bssh-russh\` pins \`rand_core = \"=0.10.0-rc-3\"\` (pre-release) via its crypto chain. Stable rand 0.10 requires stable \`rand_core 0.10.0\`, which conflicts with that pin. Revisit once the upstream \`ssh-key\` / \`rsa\` / \`ed25519-dalek\` chain stabilizes on rand_core 0.10.

## Test plan
- [x] \`cargo build\` clean
- [x] \`cargo clippy --all-targets\` clean