### PR TITLE
Fix PPA workflow packaging overlay

### DIFF
--- a/.github/workflows/launchpad_ppa.yml
+++ b/.github/workflows/launchpad_ppa.yml
@@ -55,12 +55,25 @@ jobs:
       env:
         GH_TOKEN: ${{ github.token }}
 
+    - name: Preserve current packaging overlay
+      if: steps.check_distro.outputs.should_run == 'true'
+      run: |
+        rm -rf /tmp/bssh-packaging
+        mkdir -p /tmp/bssh-packaging
+        cp -a debian /tmp/bssh-packaging/debian
+
     - name: Check out release tag
       if: steps.check_distro.outputs.should_run == 'true'
       uses: actions/checkout@v4
       with:
         ref: ${{ steps.get_tag.outputs.tag }}
         fetch-depth: 0
+
+    - name: Restore current packaging overlay
+      if: steps.check_distro.outputs.should_run == 'true'
+      run: |
+        rm -rf debian
+        cp -a /tmp/bssh-packaging/debian debian
 
     - name: Update debian/changelog from release
       if: steps.check_distro.outputs.should_run == 'true'


### PR DESCRIPTION
## Summary
- preserve the current `debian/` packaging tree before checking out the release tag
- restore that packaging overlay after tag checkout so source uploads use current PPA rules
- keep upstream source on the requested tag while allowing packaging-only iteration

## Root cause
The PPA workflow checked out the release tag before building the source package, which reverted `debian/` to the old packaging embedded in the tag. That caused Launchpad to build `v2.1.0` with outdated Rust 1.75 requirements.

## Validation
- GitHub Actions YAML parsed successfully
- local commit hook ran `cargo fmt` and `cargo clippy` successfully during commit