### PR TITLE
chore: bump GitHub Actions to Node.js 24-compatible versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,10 +15,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Cache cargo
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/registry

--- a/.github/workflows/debian_build.yml
+++ b/.github/workflows/debian_build.yml
@@ -93,7 +93,7 @@ jobs:
     # Step 1: Checkout source code
     # ───────────────────────────────────────────────────────────────
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         fetch-depth: 0  # Full history for changelog generation
 
@@ -244,7 +244,7 @@ jobs:
     # Step 11: Upload build artifacts
     # ───────────────────────────────────────────────────────────────
     - name: Upload build artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: ${{ matrix.package }}_${{ env.PACKAGE_VERSION }}_ubuntu${{ matrix.version }}.${{ matrix.distro }}_${{ matrix.arch }}
         path: artifacts/

--- a/.github/workflows/launchpad_ppa.yml
+++ b/.github/workflows/launchpad_ppa.yml
@@ -36,7 +36,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         fetch-depth: 0
 
@@ -73,7 +73,7 @@ jobs:
 
     - name: Check out release tag
       if: steps.check_distro.outputs.should_run == 'true'
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         ref: ${{ steps.get_tag.outputs.tag }}
         fetch-depth: 0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,11 +70,11 @@ jobs:
     steps:
       # 1) Checkout repository
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       # 2) Cache Cargo build artifacts
       - name: Cache cargo
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/registry
@@ -105,7 +105,7 @@ jobs:
       # 6) macOS code signing
       - name: Import Distribution certificate
         if: runner.os == 'macOS'
-        uses: apple-actions/import-codesign-certs@v3
+        uses: apple-actions/import-codesign-certs@v7
         with:
           p12-file-base64: ${{ secrets.DEV_ID_CERT_P12 }}
           p12-password: ${{ secrets.DEV_ID_CERT_PASSWORD }}
@@ -222,7 +222,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Convert pre-release to official release
         run: |

--- a/.github/workflows/update_homebrew_formula.yml
+++ b/.github/workflows/update_homebrew_formula.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
       - name: Checkout this repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install gnu-sed
         run: brew install gnu-sed


### PR DESCRIPTION
## Summary

Updates all GitHub Actions to versions that run on Node.js 24, addressing the deprecation warning that surfaces in workflow runs:

> Warning: Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/checkout@v4. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Node.js 20 will be removed from the runner on September 16th, 2026.

## Changes

| Action | Before | After |
|--------|--------|-------|
| `actions/checkout` | v4 | **v6** |
| `actions/cache` | v4 | **v5** |
| `actions/upload-artifact` | v4 | **v7** |
| `apple-actions/import-codesign-certs` | v3 | **v7** |

Workflows updated:
- `.github/workflows/ci.yml`
- `.github/workflows/release.yml`
- `.github/workflows/debian_build.yml`
- `.github/workflows/launchpad_ppa.yml`
- `.github/workflows/update_homebrew_formula.yml`

## Compatibility Notes

- `actions/cache@v5` and `actions/upload-artifact@v6+` require Actions Runner `2.327.1+`. GitHub-hosted runners already meet this; self-hosted runners (if any) need to be on a recent version.
- `upload-artifact@v7`'s new `archive: false` parameter is opt-in; existing usage is unaffected.
- `apple-actions/import-codesign-certs@v7` only changed its build tooling (ncc -> esbuild); inputs/outputs unchanged.

## Test plan

- [ ] CI workflow runs successfully on this PR
- [ ] No Node.js 20 deprecation warnings appear in workflow runs