### PR TITLE
fix: add missing dev-dependencies to bssh-russh fork

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -494,6 +494,7 @@ dependencies = [
  "ed25519-dalek",
  "elliptic-curve 0.14.0-rc.31",
  "enum_dispatch",
+ "env_logger",
  "flate2",
  "futures",
  "generic-array 1.4.1",
@@ -528,6 +529,7 @@ dependencies = [
  "spki 0.8.0",
  "ssh-encoding",
  "subtle",
+ "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "typenum",
@@ -1483,6 +1485,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "env_filter"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e90c2accc4b07a8456ea0debdc2e7587bdd890680d71173a15d4ae604f6eef"
+dependencies = [
+ "log",
+ "regex",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.11.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0621c04f2196ac3f488dd583365b9c09be011a4ab8b9f37248ffcc8f6198b56a"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "env_filter",
+ "jiff",
+ "log",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2349,6 +2374,30 @@ name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "jiff"
+version = "0.2.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f00b5dbd620d61dfdcb6007c9c1f6054ebd75319f163d886a9055cec1155073d"
+dependencies = [
+ "jiff-static",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde_core",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e000de030ff8022ea1da3f466fbb0f3a809f5e51ed31f6dd931c35181ad8e6d7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "jobserver"
@@ -3351,6 +3400,15 @@ name = "portable-atomic"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
+dependencies = [
+ "portable-atomic",
+]
 
 [[package]]
 name = "potential_utf"

--- a/crates/bssh-russh/Cargo.toml
+++ b/crates/bssh-russh/Cargo.toml
@@ -101,3 +101,13 @@ ssh-key = { version = "=0.6.18", features = [
     "ppk",
     "hazmat-allow-insecure-rsa-keys",
 ], package = "internal-russh-forked-ssh-key" }
+
+[dev-dependencies]
+# Dev-deps required by the inline test modules imported from upstream russh
+# (src/client/test.rs, src/keys/mod.rs, src/tests.rs). Without these, the fork's
+# test target never compiles.
+env_logger = "0.11"
+tempfile = "3"
+# Additive: merges with the main tokio dep to add the `process` and `macros`
+# features needed by the spawn-ssh-agent helpers and #[tokio::test].
+tokio = { version = "1.52.1", features = ["process", "macros"] }


### PR DESCRIPTION
## Summary

Adds the missing `[dev-dependencies]` block to `crates/bssh-russh/Cargo.toml` so the fork's inline test modules — imported verbatim from upstream russh — can actually compile and run. Discovered while running the full test suite after PR #203 merged.

## Background

When the fork was created in `508aa3f0` ("Sync bssh-russh fork with upstream russh 0.60.0", PR #178), the `src/` tree was copied wholesale from upstream, including its `#[cfg(test)] mod` blocks in `src/client/test.rs`, `src/keys/mod.rs`, and `src/tests.rs`. The matching `[dev-dependencies]` section was never copied across, so `cargo test -p bssh-russh` has failed with `E0433: unresolved module env_logger` / `unresolved module tempfile` plus cascading `E0282` type-inference errors (spawn-agent helpers return `tempfile::TempDir`) from day one. Nothing in CI exercises that target so it stayed silently broken across ~10 months and several dependency-bump cycles. PR #203 first surfaced it as a side-effect of running `cargo clippy -p bssh-russh --all-targets`.

## Fix

Minimal `[dev-dependencies]` block covering only what the imported tests actually reference:

- `env_logger = "0.11"` — `env_logger::try_init()` in `src/client/test.rs:82` (`test_client_connects_to_protocol_1_99` logs init).
- `tempfile = "3"` — `tempfile::tempdir()` + `tempfile::TempDir` in `src/keys/mod.rs:996` and `src/tests.rs:734` (spawn-ssh-agent helpers).
- `tokio = { version = "1.52.1", features = ["process", "macros"] }` — additive merge with the main tokio dep. Adds `process` (`tokio::process::Command::new("ssh-agent").spawn()` in the spawn-agent helpers) and `macros` (`#[tokio::test]`). All other tokio surfaces the tests use — `tokio::net::{TcpStream, UnixListener, UnixStream}`, `tokio::sync::oneshot`, `tokio::time::sleep` — are already covered by the main dep's `net` / `sync` / `time` features.

No source changes; this is purely a Cargo.toml fix.

## Test results

`cargo test -p bssh-russh --lib` — **75 passed / 0 failed / 0 ignored** (was: did-not-compile). Coverage that comes back online:

- Agent client/server round-trip: `test_agent`, `test_client_agent_{ed25519,rsa,openssh_rsa}`, `test_request_identities_full_with_keys_and_certs`, `test_sign_request_{,cert,cert_rsa,cert_rsa_sha512,cert_missing_key_returns_agent_failure,missing_key_returns_agent_failure}`.
- PKCS#8 / OpenSSH key decoding: `test_decode_pkcs8_p{256,384,521}_secret_key`, `test_decode_ed25519_{,aesctr}_secret_key`, `test_pkcs8_encrypted`, `keys::format::test_ec_private_key`.
- Channel lifecycle: `tests::channels::{test_channel_objects,test_channel_streams,test_server_channels,test_channel_window_size,test_server_receives_close_on_client_close}`.
- Protocol paths: `tests::gex::peer_request_accepts_rfc4419_minimum_when_server_can_choose_stronger_group`, `tests::gex::local_client_config_still_rejects_minimum_below_2048`, `tests::compress::compress_local_test`, `tests::future_certificate::test_future_certificate_auth_full_flow`, `tests::server_kex_junk::server_kex_junk_test`.

Notably the agent tests directly exercise the SSH-agent frame-length cap forward-port from PR #203 (`CVE-2026-46673` mitigation) by spawning a real `ssh-agent` over a Unix-domain socket and pumping signed requests through it — giving us real coverage for that fix for the first time.

Full workspace aggregate: **1871 passed / 0 failed / 10 ignored** (was 1796 on PR #203's main; the 75 newly-runnable tests account for the delta).

## Out of scope

`cargo clippy --workspace --tests -- -D warnings` reports ~250 warnings on the newly-reachable test code, dominated by `clippy::panic` on `panic!("Unexpected message ...")` arms and other idioms upstream russh writes routinely in their test scaffolding. These are inherited verbatim from upstream and don't affect runtime behavior; cleaning them up belongs to a separate follow-up so this PR stays focused on unblocking the test target.

## Test plan

- [x] `cargo build` — clean
- [x] `cargo fmt` — applied (no changes needed)
- [x] `cargo clippy --workspace --lib -- -D warnings` — clean
- [x] `cargo test -p bssh-russh --lib` — 75 passed
- [x] `cargo test --workspace --lib --tests` — 1871 passed / 0 failed / 10 ignored