### PR TITLE
fix: drop useless .into_iter() on chain arg in synced sftp session

### DIFF
--- a/crates/bssh-russh-sftp/src/client/session.rs
+++ b/crates/bssh-russh-sftp/src/client/session.rs
@@ -191,7 +191,7 @@ impl SftpSession {
                         .files
                         .into_iter()
                         .map(|f| (f.filename, f.attrs))
-                        .chain(files.into_iter())
+                        .chain(files)
                         .collect();
                 }
                 Err(Error::Status(status)) if status.status_code == StatusCode::Eof => break,


### PR DESCRIPTION
## Summary

Unbreaks CI on rustc 1.95 after PR #203's russh-sftp 2.1.2 sync. One-line fix: `Iterator::chain` already accepts any `IntoIterator`, so `.chain(files.into_iter())` is flagged by `clippy::useless_conversion` (a lint that became more aggressive in 1.95). The line was imported verbatim from upstream russh-sftp 2.1.2 in PR #203, and upstream has the same lint waiting to fire whenever they bump their MSRV.

```
error: explicit call to `.into_iter()` in function argument accepting `IntoIterator`
   --> crates/bssh-russh-sftp/src/client/session.rs:194:32
    |
194 |                         .chain(files.into_iter())
    |                                ^^^^^^^^^^^^^^^^^
```

Fix: `.chain(files)` instead of `.chain(files.into_iter())`. Functionally identical, just lets the `IntoIterator` trait do its job.

## Why we missed it locally

PR #203 was developed on rustc 1.93.1 where this particular `useless_conversion` case wasn't lint-equivalent. After bumping local toolchain to 1.95.0 via `rustup update stable`, `cargo clippy -- -D warnings` (the exact invocation CI runs from `.github/workflows/ci.yml`) now reproduces the failure — and after this one-line fix, comes back clean.

## Verification on rustc 1.95.0 (matches CI)

- `rustc --version` → `rustc 1.95.0 (59807616e 2026-04-14)`
- `cargo clippy -- -D warnings` (CI's command) → clean
- `cargo clippy --workspace --lib -- -D warnings` → clean
- `cargo test --lib --verbose` (CI's test step #1) → 1233 passed / 0 failed / 9 ignored

No other `useless_conversion` hits in the workspace's lib targets under 1.95.

## Follow-up worth filing

The same change is worth filing upstream against `AspectUnk/russh-sftp` so future syncs don't have to re-port this. Tracking that as a separate follow-up rather than blocking this CI fix.

## Test plan

- [x] `rustup update stable` to 1.95.0
- [x] `cargo clippy -- -D warnings` — clean (reproduces CI invocation exactly)
- [x] `cargo test --lib` — 1233 passed
- [x] `cargo fmt` — applied (no changes)