### PR TITLE
fix: bump time to 0.3.47 for RUSTSEC-2026-0009

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2591,9 +2591,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.1.0"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-derive"
@@ -4448,9 +4448,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.45"
+version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9e442fc33d7fdb45aa9bfeb312c095964abdf596f7567261062b2a7107aaabd"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
  "libc",
@@ -4463,9 +4463,9 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b36ee98fd31ec7426d599183e8fe26932a8dc1fb76ddb6214d05493377d34ca"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
 name = "tinystr"


### PR DESCRIPTION
## Summary

Resolves **RUSTSEC-2026-0009** (medium, 6.8 — denial of service via stack exhaustion) in `time 0.3.45`, which is pulled transitively via `ratatui 0.30 → ratatui-widgets → time`. This is a lockfile-only bump — `time 0.3.45 → 0.3.47`, `num-conv 0.1.0 → 0.2.2`, `time-core 0.1.7 → 0.1.8` — with no manifest change, since ratatui's requirement already permits it.

## Verification

- `cargo audit` — 0 vulnerabilities (was 1 before this change)
- `cargo build` — green

## Risk

Minimal: patch-level transitive bump within the existing semver requirement; no source or manifest changes.
