### PR TITLE
build: standardize Rust toolchain on 1.93 (PPA build, MSRV, CI verification)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,3 +39,40 @@ jobs:
         run: |
           cargo test --lib --verbose
           cargo test --tests --verbose -- --skip integration_test
+
+  msrv:
+    name: MSRV (cargo check on declared rust-version)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      # Read the MSRV from Cargo.toml so this job never drifts from the
+      # declared rust-version. The hard floor is 1.89 (rustyline 18 uses
+      # File::lock, stabilized in 1.89); the declared value tracks the
+      # Launchpad PPA build toolchain.
+      - name: Read MSRV from Cargo.toml
+        id: msrv
+        run: |
+          version=$(grep -m1 '^rust-version' Cargo.toml | sed -E 's/.*"([0-9.]+)".*/\1/')
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "Declared MSRV: $version"
+
+      - name: Install Rust ${{ steps.msrv.outputs.version }} (declared MSRV)
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ steps.msrv.outputs.version }}
+
+      - name: Cache cargo
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-msrv-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-msrv-
+
+      - name: Verify workspace builds on MSRV
+        run: cargo check --workspace --locked

--- a/.github/workflows/launchpad_ppa.yml
+++ b/.github/workflows/launchpad_ppa.yml
@@ -25,14 +25,14 @@ jobs:
       matrix:
         include:
           - distro: jammy
-            vendor_rust: "1.92.0"
+            vendor_rust: "1.93.1"
             toolchain_source: "Requires backend-ai PPA dependency on ~lablup/+archive/ubuntu/rustc-release"
           - distro: noble
-            vendor_rust: "1.92.0"
+            vendor_rust: "1.93.1"
             toolchain_source: "Requires backend-ai PPA dependency on ~lablup/+archive/ubuntu/rustc-release"
           - distro: resolute
-            vendor_rust: "1.92.0"
-            toolchain_source: "Uses the official Ubuntu 26.04 archive Rust 1.92+ toolchain"
+            vendor_rust: "1.93.1"
+            toolchain_source: "Uses the official Ubuntu 26.04 archive Rust 1.93+ toolchain"
 
     steps:
     - name: Checkout code

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,9 +16,11 @@ readme = "README.md"
 keywords = ["cli", "rust"]
 categories = ["command-line-utilities"]
 edition = "2024"
-# 1.88 is required by `time` 0.3.47 (the RUSTSEC-2026-0009 fix). Keeping this
-# declared keeps the MSRV-aware resolver from reverting `time` to 0.3.45.
-rust-version = "1.88"
+# MSRV 1.93: aligned with the Launchpad PPA build toolchain (rustc-1.93 on
+# jammy/noble, Ubuntu 26.04 archive on resolute). Hard floor is 1.89
+# (`rustyline` 18 uses `File::lock`, stabilized in 1.89); `time` 0.3.47
+# (RUSTSEC-2026-0009) requires >= 1.88. Verified with `cargo +1.93.0 check`.
+rust-version = "1.93"
 
 [dependencies]
 bytes = "1.11.1"

--- a/crates/bssh-russh/Cargo.toml
+++ b/crates/bssh-russh/Cargo.toml
@@ -10,7 +10,7 @@ keywords = ["ssh"]
 license = "Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/lablup/bssh"
-rust-version = "1.88"
+rust-version = "1.93"
 
 # Internal lib name matches upstream (`russh`) so vendored source and the
 # regression test in tests/ reference it as `russh::...`; the crate is still
@@ -28,8 +28,8 @@ doctest = false
 # ./sync-upstream.sh preserves, so this survives future syncs.
 [lints.clippy]
 manual_saturating_arithmetic = "allow"
-# collapsible_if fires across upstream's nested `if`s now that rust-version 1.88
-# tells clippy let-chains are stable; upstream russh has not collapsed them.
+# collapsible_if fires across upstream's nested `if`s because rust-version >= 1.88
+# makes clippy treat let-chains as stable; upstream russh has not collapsed them.
 collapsible_if = "allow"
 
 [features]

--- a/debian/README.packaging
+++ b/debian/README.packaging
@@ -10,24 +10,24 @@ Launchpad build environments do NOT have internet access. This means:
 
 ### Build Dependencies
 The following packages are required and must be available to Launchpad through the Ubuntu archive or a configured dependency PPA:
-- `rustc-1.92` or `rustc (>= 1.92)` - Rust compiler
-- `cargo-1.92` or `cargo (>= 1.92)` - Rust package manager
+- `rustc-1.93` or `rustc (>= 1.93)` - Rust compiler
+- `cargo-1.93` or `cargo (>= 1.93)` - Rust package manager
 - `pkg-config` - For finding system libraries
 - `cmake` - Build system
 
 ### Rust Version Requirements
-This project currently requires Rust 1.92 or newer because the vendored dependency set no longer builds with Rust 1.85. This means:
-- Ubuntu 22.04 (Jammy): requires a versioned Rust 1.92 toolchain from the dependent PPA `~lablup/+archive/ubuntu/rustc-release`
-- Ubuntu 24.04 (Noble): requires a versioned Rust 1.92 toolchain from the dependent PPA `~lablup/+archive/ubuntu/rustc-release`
-- Ubuntu 26.04 (Resolute): can use the archive's Rust 1.92+ toolchain without the extra dependency PPA
+This project currently requires Rust 1.93 or newer because the vendored dependency set no longer builds with Rust 1.85. This means:
+- Ubuntu 22.04 (Jammy): requires a versioned Rust 1.93 toolchain from the dependent PPA `~lablup/+archive/ubuntu/rustc-release`
+- Ubuntu 24.04 (Noble): requires a versioned Rust 1.93 toolchain from the dependent PPA `~lablup/+archive/ubuntu/rustc-release`
+- Ubuntu 26.04 (Resolute): can use the archive's Rust 1.93+ toolchain without the extra dependency PPA
 
 If building for older Ubuntu versions, you may need to:
-1. Add a Launchpad PPA dependency on `~lablup/+archive/ubuntu/rustc-release` so Jammy and Noble can see `rustc-1.92` and `cargo-1.92`
-2. Limit support to distributions with Rust 1.92+
+1. Add a Launchpad PPA dependency on `~lablup/+archive/ubuntu/rustc-release` so Jammy and Noble can see `rustc-1.93` and `cargo-1.93`
+2. Limit support to distributions with Rust 1.93+
 
 ### Build Process
 1. GitHub Actions vendors crates into `vendor/` and generates `.cargo/config.toml`
-2. The `debian/rules` file requires Rust/Cargo 1.92+ and enables offline cargo mode
+2. The `debian/rules` file requires Rust/Cargo 1.93+ and enables offline cargo mode
 3. Launchpad builds the project with `cargo build --release --frozen --workspace`
 4. The binary is installed to `/usr/bin/bssh`
 
@@ -36,8 +36,8 @@ If the build fails on Launchpad:
 1. Check the build log for the exact error
 2. Common issues:
    - Missing build dependencies: Add them to debian/control
-   - Rust version incompatibility: Ensure Rust 1.92+ is available
-   - Missing PPA dependency: Jammy/Noble need access to `rustc-1.92` and `cargo-1.92`
+   - Rust version incompatibility: Ensure Rust 1.93+ is available
+   - Missing PPA dependency: Jammy/Noble need access to `rustc-1.93` and `cargo-1.93`
    - Missing vendored crates: Ensure `vendor/` and `.cargo/config.toml` are included in the source package
    - Cargo registry access: The build will fail if it tries to download crates
 

--- a/debian/control
+++ b/debian/control
@@ -4,8 +4,8 @@ Priority: optional
 Maintainer: Jeongkyu Shin <jshin@lablup.com>
 Build-Depends: debhelper-compat (= 13),
                build-essential,
-               rustc-1.92 | rustc (>= 1.92),
-               cargo-1.92 | cargo (>= 1.92),
+               rustc-1.93 | rustc (>= 1.93),
+               cargo-1.93 | cargo (>= 1.93),
                pkg-config,
                cmake
 Standards-Version: 4.6.2

--- a/debian/control.source
+++ b/debian/control.source
@@ -3,8 +3,8 @@ Section: utils
 Priority: optional
 Maintainer: Jeongkyu Shin <jshin@lablup.com>
 Build-Depends: debhelper-compat (= 13),
-               rustc-1.92 | rustc (>= 1.92),
-               cargo-1.92 | cargo (>= 1.92),
+               rustc-1.93 | rustc (>= 1.93),
+               cargo-1.93 | cargo (>= 1.93),
                pkg-config,
                cmake,
                build-essential

--- a/debian/rules
+++ b/debian/rules
@@ -9,8 +9,8 @@ export CARGO_HOME = $(HOME)/.cargo
 export CARGO_TARGET_DIR = $(CURDIR)/target
 export CARGO_NET_OFFLINE = true
 
-RUSTC := $(shell if command -v rustc-1.92 >/dev/null 2>&1; then printf '%s' rustc-1.92; else printf '%s' rustc; fi)
-CARGO := $(shell if command -v cargo-1.92 >/dev/null 2>&1; then printf '%s' cargo-1.92; else printf '%s' cargo; fi)
+RUSTC := $(shell if command -v rustc-1.93 >/dev/null 2>&1; then printf '%s' rustc-1.93; else printf '%s' rustc; fi)
+CARGO := $(shell if command -v cargo-1.93 >/dev/null 2>&1; then printf '%s' cargo-1.93; else printf '%s' cargo; fi)
 
 %:
 	dh $@
@@ -23,12 +23,12 @@ override_dh_auto_configure:
 	$(CARGO) --version
 	rustc_version=$$($(RUSTC) --version | awk '{print $$2}'); \
 	cargo_version=$$($(CARGO) --version | awk '{print $$2}'); \
-	dpkg --compare-versions "$$rustc_version" ge 1.92 || { \
-		echo "rustc 1.92+ is required for the current dependency set (found $$rustc_version)"; \
+	dpkg --compare-versions "$$rustc_version" ge 1.93 || { \
+		echo "rustc 1.93+ is required for the current dependency set (found $$rustc_version)"; \
 		exit 1; \
 	}; \
-	dpkg --compare-versions "$$cargo_version" ge 1.92 || { \
-		echo "cargo 1.92+ is required for the current dependency set (found $$cargo_version)"; \
+	dpkg --compare-versions "$$cargo_version" ge 1.93 || { \
+		echo "cargo 1.93+ is required for the current dependency set (found $$cargo_version)"; \
 		exit 1; \
 	}
 

--- a/debian/rules.launchpad
+++ b/debian/rules.launchpad
@@ -9,8 +9,8 @@ export CARGO_HOME = $(HOME)/.cargo
 export CARGO_TARGET_DIR = $(CURDIR)/target
 export CARGO_NET_OFFLINE = true
 
-RUSTC := $(shell if command -v rustc-1.92 >/dev/null 2>&1; then printf '%s' rustc-1.92; else printf '%s' rustc; fi)
-CARGO := $(shell if command -v cargo-1.92 >/dev/null 2>&1; then printf '%s' cargo-1.92; else printf '%s' cargo; fi)
+RUSTC := $(shell if command -v rustc-1.93 >/dev/null 2>&1; then printf '%s' rustc-1.93; else printf '%s' rustc; fi)
+CARGO := $(shell if command -v cargo-1.93 >/dev/null 2>&1; then printf '%s' cargo-1.93; else printf '%s' cargo; fi)
 
 %:
 	dh $@
@@ -23,12 +23,12 @@ override_dh_auto_configure:
 	$(CARGO) --version
 	rustc_version=$$($(RUSTC) --version | awk '{print $$2}'); \
 	cargo_version=$$($(CARGO) --version | awk '{print $$2}'); \
-	dpkg --compare-versions "$$rustc_version" ge 1.92 || { \
-		echo "rustc 1.92+ is required for the current dependency set (found $$rustc_version)"; \
+	dpkg --compare-versions "$$rustc_version" ge 1.93 || { \
+		echo "rustc 1.93+ is required for the current dependency set (found $$rustc_version)"; \
 		exit 1; \
 	}; \
-	dpkg --compare-versions "$$cargo_version" ge 1.92 || { \
-		echo "cargo 1.92+ is required for the current dependency set (found $$cargo_version)"; \
+	dpkg --compare-versions "$$cargo_version" ge 1.93 || { \
+		echo "cargo 1.93+ is required for the current dependency set (found $$cargo_version)"; \
 		exit 1; \
 	}
 

--- a/debian/rules.launchpad-simple
+++ b/debian/rules.launchpad-simple
@@ -9,8 +9,8 @@ export CARGO_HOME = $(HOME)/.cargo
 export CARGO_TARGET_DIR = $(CURDIR)/target
 export CARGO_NET_OFFLINE = true
 
-RUSTC := $(shell if command -v rustc-1.92 >/dev/null 2>&1; then printf '%s' rustc-1.92; else printf '%s' rustc; fi)
-CARGO := $(shell if command -v cargo-1.92 >/dev/null 2>&1; then printf '%s' cargo-1.92; else printf '%s' cargo; fi)
+RUSTC := $(shell if command -v rustc-1.93 >/dev/null 2>&1; then printf '%s' rustc-1.93; else printf '%s' rustc; fi)
+CARGO := $(shell if command -v cargo-1.93 >/dev/null 2>&1; then printf '%s' cargo-1.93; else printf '%s' cargo; fi)
 
 %:
 	dh $@
@@ -23,12 +23,12 @@ override_dh_auto_configure:
 	$(CARGO) --version
 	rustc_version=$$($(RUSTC) --version | awk '{print $$2}'); \
 	cargo_version=$$($(CARGO) --version | awk '{print $$2}'); \
-	dpkg --compare-versions "$$rustc_version" ge 1.92 || { \
-		echo "rustc 1.92+ is required for the current dependency set (found $$rustc_version)"; \
+	dpkg --compare-versions "$$rustc_version" ge 1.93 || { \
+		echo "rustc 1.93+ is required for the current dependency set (found $$rustc_version)"; \
 		exit 1; \
 	}; \
-	dpkg --compare-versions "$$cargo_version" ge 1.92 || { \
-		echo "cargo 1.92+ is required for the current dependency set (found $$cargo_version)"; \
+	dpkg --compare-versions "$$cargo_version" ge 1.93 || { \
+		echo "cargo 1.93+ is required for the current dependency set (found $$cargo_version)"; \
 		exit 1; \
 	}
 

--- a/debian/rules.source
+++ b/debian/rules.source
@@ -9,8 +9,8 @@ export CARGO_HOME = $(HOME)/.cargo
 export CARGO_TARGET_DIR = $(CURDIR)/target
 export CARGO_NET_OFFLINE = true
 
-RUSTC := $(shell if command -v rustc-1.92 >/dev/null 2>&1; then printf '%s' rustc-1.92; else printf '%s' rustc; fi)
-CARGO := $(shell if command -v cargo-1.92 >/dev/null 2>&1; then printf '%s' cargo-1.92; else printf '%s' cargo; fi)
+RUSTC := $(shell if command -v rustc-1.93 >/dev/null 2>&1; then printf '%s' rustc-1.93; else printf '%s' rustc; fi)
+CARGO := $(shell if command -v cargo-1.93 >/dev/null 2>&1; then printf '%s' cargo-1.93; else printf '%s' cargo; fi)
 
 %:
 	dh $@
@@ -23,12 +23,12 @@ override_dh_auto_configure:
 	$(CARGO) --version
 	rustc_version=$$($(RUSTC) --version | awk '{print $$2}'); \
 	cargo_version=$$($(CARGO) --version | awk '{print $$2}'); \
-	dpkg --compare-versions "$$rustc_version" ge 1.92 || { \
-		echo "rustc 1.92+ is required for the current dependency set (found $$rustc_version)"; \
+	dpkg --compare-versions "$$rustc_version" ge 1.93 || { \
+		echo "rustc 1.93+ is required for the current dependency set (found $$rustc_version)"; \
 		exit 1; \
 	}; \
-	dpkg --compare-versions "$$cargo_version" ge 1.92 || { \
-		echo "cargo 1.92+ is required for the current dependency set (found $$cargo_version)"; \
+	dpkg --compare-versions "$$cargo_version" ge 1.93 || { \
+		echo "cargo 1.93+ is required for the current dependency set (found $$cargo_version)"; \
 		exit 1; \
 	}
 


### PR DESCRIPTION
## Summary

Standardize the project's Rust toolchain handling on **1.93**, across three areas:

1. **Launchpad PPA build toolchain → rustc-1.93 (1.93.1).** The `~lablup/+archive/ubuntu/rustc-release` PPA now publishes `rustc-1.93` (1.93.1) for jammy and noble, and Ubuntu 26.04 (resolute) ships 1.93.1 in its archive — so jammy/noble no longer need to stay on `rustc-1.92`.
2. **Workspace MSRV → 1.93.** The previously declared MSRV (`1.88`) was inaccurate (see below).
3. **New CI `msrv` job** that verifies the declared MSRV so it can no longer silently drift.

## Why the MSRV bump (the important part)

`rustyline` 18 (a direct dependency) calls `File::lock`/`File::lock_shared` — the `file_lock` feature, stabilized in **Rust 1.89**. So the workspace has **not compiled on 1.88** since rustyline was adopted, even though we declared `rust-version = "1.88"`.

Verified locally with `cargo check --workspace --locked`:

| Toolchain | Result |
|-----------|--------|
| 1.88.0 | ❌ `error[E0658]: use of unstable library feature 'file_lock'` |
| 1.89.0 | ✅ |
| 1.93.0 | ✅ |

CI never caught this because it only builds on `stable`. The real hard floor is **1.89**; the declared MSRV is set to **1.93** to align with the Launchpad PPA build toolchain.

## Changes

**PPA toolchain (`39ff5b5f`)**
- `debian/control{,.source}`: Build-Depends `rustc-1.93 | rustc (>= 1.93)`, `cargo-1.93 | cargo (>= 1.93)`
- `debian/rules{,.source,.launchpad,.launchpad-simple}`: prefer `rustc-1.93`/`cargo-1.93`, require `>= 1.93`
- `.github/workflows/launchpad_ppa.yml`: `vendor_rust` `1.92.0` → `1.93.1` (all distros)
- `debian/README.packaging`: version references

**MSRV + CI (`255dc630`)**
- `Cargo.toml`, `crates/bssh-russh/Cargo.toml`: `rust-version` `1.88` → `1.93`
- `.github/workflows/ci.yml`: new `msrv` job — reads `rust-version` from `Cargo.toml` (so the job never drifts from the declaration) and runs `cargo check --workspace --locked` on that toolchain. The main `ci` job stays on `stable`.

## Distribution behavior (all converge on 1.93.1)

| Distro | rustc source |
|--------|-------------|
| jammy | PPA `rustc-1.93` (1.93.1) |
| noble | PPA `rustc-1.93` (1.93.1) |
| resolute | archive `rustc` 1.93.1 (`rust-defaults`) |

## Notes
- **No `rust-toolchain.toml`** was added intentionally: pinning would force all rustup builds (local/CI/release) onto one version and drop `stable` coverage, and it wouldn't affect the Launchpad build anyway (that uses the system `cargo-1.93`, not rustup).
- `crates/bssh-russh-sftp` does not declare a `rust-version`; left out of scope here but could be set to `1.93` for consistency since it is published.

## Test plan
- [x] `cargo +1.88.0 check --workspace --locked` → fails (E0658), confirming the floor
- [x] `cargo +1.89.0 check --workspace --locked` → passes
- [x] `cargo +1.93.0 check --workspace --locked` → passes
- [x] `ci.yml` / `launchpad_ppa.yml` YAML validated; MSRV extraction yields `1.93`
- [ ] CI `msrv` job green on this PR
