### PR TITLE
docs: add Apache-2.0 NOTICE and align tool naming to Broadcast SSH

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-bssh (Backend.AI SSH / Broadcast SSH) is a high-performance parallel SSH command execution tool with SSH-compatible interface. This document provides a high-level architecture overview. For detailed component documentation, see [docs/architecture/](./docs/architecture/).
+bssh (Broadcast SSH / Backend.AI SSH) is a high-performance parallel SSH command execution tool with SSH-compatible interface. This document provides a high-level architecture overview. For detailed component documentation, see [docs/architecture/](./docs/architecture/).
 
 ### Core Capabilities
 

--- a/LICENSE
+++ b/LICENSE
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2024 Jeongkyu Shin
+   Copyright 2024-2026 Jeongkyu Shin
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,59 @@
+bssh (Broadcast SSH)
+Copyright 2024-2026 Jeongkyu Shin
+
+Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+this product except in compliance with the License. A copy of the License is
+provided in the LICENSE file and is also available at
+http://www.apache.org/licenses/LICENSE-2.0.
+
+bssh is part of the Backend.AI project family developed by Lablup Inc.
+(https://www.lablup.com).
+
+================================================================================
+Bundled third-party source
+================================================================================
+
+This product vendors modified source code from the projects below. Each lives
+under crates/ as a thin fork that tracks an upstream release verbatim and adds
+the bssh-specific patches noted here. Both upstream projects are licensed under
+the Apache License, Version 2.0.
+
+--------------------------------------------------------------------------------
+russh  (vendored as crates/bssh-russh, Cargo package "bssh-russh")
+--------------------------------------------------------------------------------
+
+Upstream : https://github.com/Eugeny/russh  (tracking release 0.61.1)
+License  : Apache-2.0
+
+    Copyright 2016 Pierre-Étienne Meunier
+    Copyright the russh authors and contributors
+
+russh began as Thrussh by Pierre-Étienne Meunier and is currently maintained by
+Eugeny Pankov and the russh contributors. The vendored copy is unmodified
+upstream source plus a single change that drains pending Handle::data() messages
+before the server session select loop (patches/handle-data-fix.patch), so
+high-frequency PTY output is delivered reliably.
+
+--------------------------------------------------------------------------------
+russh-sftp  (vendored as crates/bssh-russh-sftp, Cargo package "bssh-russh-sftp")
+--------------------------------------------------------------------------------
+
+Upstream : https://github.com/AspectUnk/russh-sftp  (tracking release 2.3.0)
+License  : Apache-2.0
+
+    Copyright the russh-sftp authors and contributors (AspectUnk)
+
+The vendored copy is unmodified upstream source plus pipelined SFTP file I/O
+helpers (write_all_pipelined / read_to_writer_pipelined) that keep multiple
+requests in flight to hide per-request round-trip latency
+(patches/pipelined-file-io.patch).
+
+================================================================================
+Linked third-party crates
+================================================================================
+
+bssh also links many third-party Rust crates at build time (see Cargo.toml and
+Cargo.lock). Those crates are distributed under their own permissive licenses
+(Apache-2.0, MIT, BSD, and similar); their license texts are available through
+their respective source repositories and the Rust crate registry at
+https://crates.io.

--- a/src/bin/bssh_keygen.rs
+++ b/src/bin/bssh_keygen.rs
@@ -40,7 +40,7 @@ use clap::{ArgAction, Parser};
 use std::io::{self, Write};
 use std::path::PathBuf;
 
-/// Backend.AI SSH Key Generator - Generate SSH key pairs in OpenSSH format
+/// Broadcast SSH Key Generator - Generate SSH key pairs in OpenSSH format
 #[derive(Parser, Debug)]
 #[command(name = "bssh-keygen")]
 #[command(version)]

--- a/src/bin/bssh_server.rs
+++ b/src/bin/bssh_server.rs
@@ -25,11 +25,11 @@ use std::fs;
 use std::io::{self, Write};
 use std::path::PathBuf;
 
-/// Backend.AI SSH Server - A lightweight SSH server for containers
+/// Broadcast SSH Server - A lightweight SSH server for containers
 #[derive(Parser, Debug)]
 #[command(name = "bssh-server")]
 #[command(version)]
-#[command(about = "Backend.AI SSH Server - A lightweight SSH server for containers", long_about = None)]
+#[command(about = "Broadcast SSH Server - A lightweight SSH server for containers", long_about = None)]
 struct Cli {
     /// Subcommand to execute
     #[command(subcommand)]
@@ -426,7 +426,7 @@ fn gen_host_key(key_type: &str, output: &PathBuf, _bits: u32) -> Result<()> {
 /// Show version and build information
 fn show_version() -> Result<()> {
     println!("bssh-server {}", env!("CARGO_PKG_VERSION"));
-    println!("Backend.AI SSH Server");
+    println!("Broadcast SSH Server");
     println!();
     println!("A lightweight SSH server for containers");
     println!();


### PR DESCRIPTION
## Summary

Adds an Apache-2.0 `NOTICE` file and aligns the auxiliary binaries with the existing "Broadcast SSH" branding.

- **NOTICE (new):** Records bssh's own copyright and attributes the two vendored upstream forks whose source is redistributed in-tree: `russh` (`crates/bssh-russh`, originally Thrussh by Pierre-Étienne Meunier, maintained by Eugeny Pankov) and `russh-sftp` (`crates/bssh-russh-sftp`, by AspectUnk), both Apache-2.0. Neither upstream ships a NOTICE file, so there is nothing to propagate under section 4(d); this attribution covers the vendored copies and the bssh-specific patches noted per crate.
- **LICENSE:** Extends the copyright span to `2024-2026` to match active maintenance.
- **Naming cleanup:** `bssh-server` and `bssh-keygen` still surfaced "Backend.AI SSH" in their `--help`/`version` output, while the main `bssh` CLI already said "Broadcast SSH" since the v0.6.1 rebrand. Both are switched to "Broadcast SSH" so all tools are consistent.
- **ARCHITECTURE.md:** Keeps both names as "Broadcast SSH / Backend.AI SSH" to preserve the Backend.AI lineage in the design doc.

## Tests

- `cargo build --bins` passes.
- Verified rendered output: `bssh --help`, `bssh-server --help`, and `bssh-server version` all show "Broadcast SSH".
- Pre-commit hook (cargo fmt + clippy) passed.

## Risk

Low. Changes are limited to documentation, license metadata, and user-facing help/version strings; no functional or logic changes.
