### PR TITLE
docs: state native Windows client support is not supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,12 +36,17 @@ A high-performance SSH client with **SSH-compatible syntax** for both single-hos
 - **Progress Tracking**: Real-time progress indicators with smart detection (percentages, fractions, apt/dpkg)
 - **Flexible Authentication**: Support for SSH keys, SSH agent, password authentication, and encrypted key passphrases
 - **Host Key Verification**: Secure host key checking with known_hosts support
-- **Cross-Platform**: Works on Linux and macOS
+- **Cross-Platform**: Works on Linux and macOS (see [Platform Support](#platform-support) for Windows status)
 - **Output Management**: Multiple output modes (TUI, stream, file, normal) with auto-detection
 - **Interactive Mode**: Interactive shell sessions with single-node or multiplexed multi-node support
 - **SSH Config Caching**: High-performance caching of SSH configurations with TTL and file modification detection
 - **Configurable Timeouts**: Set both connection timeout (`--connect-timeout`) and command execution timeout (`--timeout`) with support for unlimited execution
 - **SSH Keepalive**: Configurable keepalive settings (`--server-alive-interval`, `--server-alive-count-max`) to prevent idle connection timeouts
+
+## Platform Support
+
+- **Linux and macOS**: Fully supported, including SSH agent authentication (`-A`), PTY-based interactive sessions, and every CLI feature documented here.
+- **Windows (native)**: Not currently supported as a client. The `bssh` crate does not build for a Windows target today because of unconditional Unix-only dependencies (`nix`, `signal-hook`, `libc`) and un-gated PTY/agent code; there is no Windows CI job or release artifact. Use **WSL2** to run `bssh` on Windows in the meantime. See [#213](https://github.com/lablup/bssh/issues/213) for the current status and the known blockers to native Windows client support.
 
 ## Installation
 

--- a/docs/architecture/ssh-client.md
+++ b/docs/architecture/ssh-client.md
@@ -615,7 +615,7 @@ let auth_method = auth_ctx.determine_method?;
 - Uses `zeroize` crate to clear passwords and passphrases from memory
 - Secure passphrase prompts via `rpassword` crate
 - No credential caching or storage
-- Platform-specific handling (SSH agent not supported on Windows)
+- Platform-specific handling (SSH agent not supported on Windows; native Windows client execution is not currently supported at all, see the README's [Platform Support](../../README.md#platform-support) section and [#213](https://github.com/lablup/bssh/issues/213))
 
 **Code Reduction:**
 - Eliminated ~130 lines of duplicated authentication logic


### PR DESCRIPTION
## Summary

Documents that native Windows client execution is not currently supported, answering the inquiry in #213 without attempting the (explicitly out-of-scope) native Windows port itself.

## What changed

- `README.md`: adds a new "Platform Support" section stating that Linux and macOS are fully supported, native Windows client execution is not currently supported, and WSL2 is the recommended path today, linking to #213 for the full blocker list; the existing "Cross-Platform" feature bullet now points at this section.
- `docs/architecture/ssh-client.md`: extends the existing "SSH agent not supported on Windows" note so it also cross-references the broader native-Windows-client status and links to the README section and #213.
- No code changes. The known blockers (unconditional `nix`/`signal-hook`/`libc` dependencies, un-gated PTY/agent/keygen code, no Windows CI/release target) are already captured in #213 itself; native Windows support remains an optional, separately-scoped follow-up.

## Test plan

- [x] Manual review of rendered Markdown (heading anchors, relative links) for both changed files.
- [x] `git diff` reviewed to confirm only the two documentation files changed.

Closes #213
