### PR TITLE
build: bump Launchpad PPA toolchain and MSRV to Rust 1.96

### DIFF
--- a/.github/workflows/launchpad_ppa.yml
+++ b/.github/workflows/launchpad_ppa.yml
@@ -25,14 +25,14 @@ jobs:
       matrix:
         include:
           - distro: jammy
-            vendor_rust: "1.93.1"
+            vendor_rust: "1.96.1"
             toolchain_source: "Requires backend-ai PPA dependency on ~lablup/+archive/ubuntu/rustc-release"
           - distro: noble
-            vendor_rust: "1.93.1"
+            vendor_rust: "1.96.1"
             toolchain_source: "Requires backend-ai PPA dependency on ~lablup/+archive/ubuntu/rustc-release"
           - distro: resolute
-            vendor_rust: "1.93.1"
-            toolchain_source: "Uses the official Ubuntu 26.04 archive Rust 1.93+ toolchain"
+            vendor_rust: "1.96.1"
+            toolchain_source: "Uses the official Ubuntu 26.04 archive Rust 1.96+ toolchain"
 
     steps:
     - name: Checkout code

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,11 +15,12 @@ readme = "README.md"
 keywords = ["cli", "rust"]
 categories = ["command-line-utilities"]
 edition = "2024"
-# MSRV 1.93: aligned with the Launchpad PPA build toolchain (rustc-1.93 on
+# MSRV 1.96: aligned with the Launchpad PPA build toolchain (rustc-1.96 on
 # jammy/noble, Ubuntu 26.04 archive on resolute). Hard floor is 1.89
 # (`rustyline` 18 uses `File::lock`, stabilized in 1.89); `time` 0.3.47
-# (RUSTSEC-2026-0009) requires >= 1.88. Verified with `cargo +1.93.0 check`.
-rust-version = "1.93"
+# (RUSTSEC-2026-0009) requires >= 1.88. The declared value tracks the PPA
+# build toolchain, not the hard floor.
+rust-version = "1.96"
 
 [dependencies]
 bytes = "1.11.1"

--- a/debian/README.packaging
+++ b/debian/README.packaging
@@ -10,24 +10,24 @@ Launchpad build environments do NOT have internet access. This means:
 
 ### Build Dependencies
 The following packages are required and must be available to Launchpad through the Ubuntu archive or a configured dependency PPA:
-- `rustc-1.93` or `rustc (>= 1.93)` - Rust compiler
-- `cargo-1.93` or `cargo (>= 1.93)` - Rust package manager
+- `rustc-1.96` or `rustc (>= 1.96)` - Rust compiler
+- `cargo-1.96` or `cargo (>= 1.96)` - Rust package manager
 - `pkg-config` - For finding system libraries
 - `cmake` - Build system
 
 ### Rust Version Requirements
-This project currently requires Rust 1.93 or newer because the vendored dependency set no longer builds with Rust 1.85. This means:
-- Ubuntu 22.04 (Jammy): requires a versioned Rust 1.93 toolchain from the dependent PPA `~lablup/+archive/ubuntu/rustc-release`
-- Ubuntu 24.04 (Noble): requires a versioned Rust 1.93 toolchain from the dependent PPA `~lablup/+archive/ubuntu/rustc-release`
-- Ubuntu 26.04 (Resolute): can use the archive's Rust 1.93+ toolchain without the extra dependency PPA
+This project currently requires Rust 1.96 or newer because the vendored dependency set no longer builds with Rust 1.85. This means:
+- Ubuntu 22.04 (Jammy): requires a versioned Rust 1.96 toolchain from the dependent PPA `~lablup/+archive/ubuntu/rustc-release`
+- Ubuntu 24.04 (Noble): requires a versioned Rust 1.96 toolchain from the dependent PPA `~lablup/+archive/ubuntu/rustc-release`
+- Ubuntu 26.04 (Resolute): can use the archive's Rust 1.96+ toolchain without the extra dependency PPA
 
 If building for older Ubuntu versions, you may need to:
-1. Add a Launchpad PPA dependency on `~lablup/+archive/ubuntu/rustc-release` so Jammy and Noble can see `rustc-1.93` and `cargo-1.93`
-2. Limit support to distributions with Rust 1.93+
+1. Add a Launchpad PPA dependency on `~lablup/+archive/ubuntu/rustc-release` so Jammy and Noble can see `rustc-1.96` and `cargo-1.96`
+2. Limit support to distributions with Rust 1.96+
 
 ### Build Process
 1. GitHub Actions vendors crates into `vendor/` and generates `.cargo/config.toml`
-2. The `debian/rules` file requires Rust/Cargo 1.93+ and enables offline cargo mode
+2. The `debian/rules` file requires Rust/Cargo 1.96+ and enables offline cargo mode
 3. Launchpad builds the project with `cargo build --release --frozen --workspace`
 4. The binary is installed to `/usr/bin/bssh`
 
@@ -36,8 +36,8 @@ If the build fails on Launchpad:
 1. Check the build log for the exact error
 2. Common issues:
    - Missing build dependencies: Add them to debian/control
-   - Rust version incompatibility: Ensure Rust 1.93+ is available
-   - Missing PPA dependency: Jammy/Noble need access to `rustc-1.93` and `cargo-1.93`
+   - Rust version incompatibility: Ensure Rust 1.96+ is available
+   - Missing PPA dependency: Jammy/Noble need access to `rustc-1.96` and `cargo-1.96`
    - Missing vendored crates: Ensure `vendor/` and `.cargo/config.toml` are included in the source package
    - Cargo registry access: The build will fail if it tries to download crates
 

--- a/debian/control
+++ b/debian/control
@@ -4,8 +4,8 @@ Priority: optional
 Maintainer: Jeongkyu Shin <jshin@lablup.com>
 Build-Depends: debhelper-compat (= 13),
                build-essential,
-               rustc-1.93 | rustc (>= 1.93),
-               cargo-1.93 | cargo (>= 1.93),
+               rustc-1.96 | rustc (>= 1.96),
+               cargo-1.96 | cargo (>= 1.96),
                pkg-config,
                cmake
 Standards-Version: 4.6.2

--- a/debian/control.source
+++ b/debian/control.source
@@ -3,8 +3,8 @@ Section: utils
 Priority: optional
 Maintainer: Jeongkyu Shin <jshin@lablup.com>
 Build-Depends: debhelper-compat (= 13),
-               rustc-1.93 | rustc (>= 1.93),
-               cargo-1.93 | cargo (>= 1.93),
+               rustc-1.96 | rustc (>= 1.96),
+               cargo-1.96 | cargo (>= 1.96),
                pkg-config,
                cmake,
                build-essential

--- a/debian/rules
+++ b/debian/rules
@@ -9,8 +9,8 @@ export CARGO_HOME = $(HOME)/.cargo
 export CARGO_TARGET_DIR = $(CURDIR)/target
 export CARGO_NET_OFFLINE = true
 
-RUSTC := $(shell if command -v rustc-1.93 >/dev/null 2>&1; then printf '%s' rustc-1.93; else printf '%s' rustc; fi)
-CARGO := $(shell if command -v cargo-1.93 >/dev/null 2>&1; then printf '%s' cargo-1.93; else printf '%s' cargo; fi)
+RUSTC := $(shell if command -v rustc-1.96 >/dev/null 2>&1; then printf '%s' rustc-1.96; else printf '%s' rustc; fi)
+CARGO := $(shell if command -v cargo-1.96 >/dev/null 2>&1; then printf '%s' cargo-1.96; else printf '%s' cargo; fi)
 
 %:
 	dh $@
@@ -23,12 +23,12 @@ override_dh_auto_configure:
 	$(CARGO) --version
 	rustc_version=$$($(RUSTC) --version | awk '{print $$2}'); \
 	cargo_version=$$($(CARGO) --version | awk '{print $$2}'); \
-	dpkg --compare-versions "$$rustc_version" ge 1.93 || { \
-		echo "rustc 1.93+ is required for the current dependency set (found $$rustc_version)"; \
+	dpkg --compare-versions "$$rustc_version" ge 1.96 || { \
+		echo "rustc 1.96+ is required for the current dependency set (found $$rustc_version)"; \
 		exit 1; \
 	}; \
-	dpkg --compare-versions "$$cargo_version" ge 1.93 || { \
-		echo "cargo 1.93+ is required for the current dependency set (found $$cargo_version)"; \
+	dpkg --compare-versions "$$cargo_version" ge 1.96 || { \
+		echo "cargo 1.96+ is required for the current dependency set (found $$cargo_version)"; \
 		exit 1; \
 	}
 

--- a/debian/rules.launchpad
+++ b/debian/rules.launchpad
@@ -9,8 +9,8 @@ export CARGO_HOME = $(HOME)/.cargo
 export CARGO_TARGET_DIR = $(CURDIR)/target
 export CARGO_NET_OFFLINE = true
 
-RUSTC := $(shell if command -v rustc-1.93 >/dev/null 2>&1; then printf '%s' rustc-1.93; else printf '%s' rustc; fi)
-CARGO := $(shell if command -v cargo-1.93 >/dev/null 2>&1; then printf '%s' cargo-1.93; else printf '%s' cargo; fi)
+RUSTC := $(shell if command -v rustc-1.96 >/dev/null 2>&1; then printf '%s' rustc-1.96; else printf '%s' rustc; fi)
+CARGO := $(shell if command -v cargo-1.96 >/dev/null 2>&1; then printf '%s' cargo-1.96; else printf '%s' cargo; fi)
 
 %:
 	dh $@
@@ -23,12 +23,12 @@ override_dh_auto_configure:
 	$(CARGO) --version
 	rustc_version=$$($(RUSTC) --version | awk '{print $$2}'); \
 	cargo_version=$$($(CARGO) --version | awk '{print $$2}'); \
-	dpkg --compare-versions "$$rustc_version" ge 1.93 || { \
-		echo "rustc 1.93+ is required for the current dependency set (found $$rustc_version)"; \
+	dpkg --compare-versions "$$rustc_version" ge 1.96 || { \
+		echo "rustc 1.96+ is required for the current dependency set (found $$rustc_version)"; \
 		exit 1; \
 	}; \
-	dpkg --compare-versions "$$cargo_version" ge 1.93 || { \
-		echo "cargo 1.93+ is required for the current dependency set (found $$cargo_version)"; \
+	dpkg --compare-versions "$$cargo_version" ge 1.96 || { \
+		echo "cargo 1.96+ is required for the current dependency set (found $$cargo_version)"; \
 		exit 1; \
 	}
 

--- a/debian/rules.launchpad-simple
+++ b/debian/rules.launchpad-simple
@@ -9,8 +9,8 @@ export CARGO_HOME = $(HOME)/.cargo
 export CARGO_TARGET_DIR = $(CURDIR)/target
 export CARGO_NET_OFFLINE = true
 
-RUSTC := $(shell if command -v rustc-1.93 >/dev/null 2>&1; then printf '%s' rustc-1.93; else printf '%s' rustc; fi)
-CARGO := $(shell if command -v cargo-1.93 >/dev/null 2>&1; then printf '%s' cargo-1.93; else printf '%s' cargo; fi)
+RUSTC := $(shell if command -v rustc-1.96 >/dev/null 2>&1; then printf '%s' rustc-1.96; else printf '%s' rustc; fi)
+CARGO := $(shell if command -v cargo-1.96 >/dev/null 2>&1; then printf '%s' cargo-1.96; else printf '%s' cargo; fi)
 
 %:
 	dh $@
@@ -23,12 +23,12 @@ override_dh_auto_configure:
 	$(CARGO) --version
 	rustc_version=$$($(RUSTC) --version | awk '{print $$2}'); \
 	cargo_version=$$($(CARGO) --version | awk '{print $$2}'); \
-	dpkg --compare-versions "$$rustc_version" ge 1.93 || { \
-		echo "rustc 1.93+ is required for the current dependency set (found $$rustc_version)"; \
+	dpkg --compare-versions "$$rustc_version" ge 1.96 || { \
+		echo "rustc 1.96+ is required for the current dependency set (found $$rustc_version)"; \
 		exit 1; \
 	}; \
-	dpkg --compare-versions "$$cargo_version" ge 1.93 || { \
-		echo "cargo 1.93+ is required for the current dependency set (found $$cargo_version)"; \
+	dpkg --compare-versions "$$cargo_version" ge 1.96 || { \
+		echo "cargo 1.96+ is required for the current dependency set (found $$cargo_version)"; \
 		exit 1; \
 	}
 

--- a/debian/rules.source
+++ b/debian/rules.source
@@ -9,8 +9,8 @@ export CARGO_HOME = $(HOME)/.cargo
 export CARGO_TARGET_DIR = $(CURDIR)/target
 export CARGO_NET_OFFLINE = true
 
-RUSTC := $(shell if command -v rustc-1.93 >/dev/null 2>&1; then printf '%s' rustc-1.93; else printf '%s' rustc; fi)
-CARGO := $(shell if command -v cargo-1.93 >/dev/null 2>&1; then printf '%s' cargo-1.93; else printf '%s' cargo; fi)
+RUSTC := $(shell if command -v rustc-1.96 >/dev/null 2>&1; then printf '%s' rustc-1.96; else printf '%s' rustc; fi)
+CARGO := $(shell if command -v cargo-1.96 >/dev/null 2>&1; then printf '%s' cargo-1.96; else printf '%s' cargo; fi)
 
 %:
 	dh $@
@@ -23,12 +23,12 @@ override_dh_auto_configure:
 	$(CARGO) --version
 	rustc_version=$$($(RUSTC) --version | awk '{print $$2}'); \
 	cargo_version=$$($(CARGO) --version | awk '{print $$2}'); \
-	dpkg --compare-versions "$$rustc_version" ge 1.93 || { \
-		echo "rustc 1.93+ is required for the current dependency set (found $$rustc_version)"; \
+	dpkg --compare-versions "$$rustc_version" ge 1.96 || { \
+		echo "rustc 1.96+ is required for the current dependency set (found $$rustc_version)"; \
 		exit 1; \
 	}; \
-	dpkg --compare-versions "$$cargo_version" ge 1.93 || { \
-		echo "cargo 1.93+ is required for the current dependency set (found $$cargo_version)"; \
+	dpkg --compare-versions "$$cargo_version" ge 1.96 || { \
+		echo "cargo 1.96+ is required for the current dependency set (found $$cargo_version)"; \
 		exit 1; \
 	}
 


### PR DESCRIPTION
## Summary

Rust 1.96 has shipped (latest patch 1.96.1), so this moves the Debian/Launchpad packaging toolchain and the declared MSRV off 1.93 onto 1.96.

## Changes

- `Cargo.toml`: raise `rust-version` from 1.93 to 1.96, keeping the MSRV aligned with the Launchpad PPA build toolchain as documented in the surrounding comment. The CI `msrv` job reads this value from `Cargo.toml`, so it tracks the bump automatically.
- `debian/control`, `debian/control.source`: update build dependencies to `rustc-1.96 | rustc (>= 1.96)` and `cargo-1.96 | cargo (>= 1.96)`.
- `debian/rules`, `debian/rules.launchpad`, `debian/rules.launchpad-simple`, `debian/rules.source`: prefer the `rustc-1.96`/`cargo-1.96` toolchain and raise the `dpkg --compare-versions` gate to `ge 1.96`.
- `debian/README.packaging`: refresh the documented Rust version requirement to 1.96.
- `.github/workflows/launchpad_ppa.yml`: set `vendor_rust` to `1.96.1` for jammy, noble, and resolute, and update the resolute toolchain-source note to Rust 1.96+.

The exact patch `1.96.1` is used only for `vendor_rust` (the toolchain the CI runner installs to vendor crates); package build-deps and the MSRV correctly use the `1.96` minor series per Debian and Cargo conventions.

## Preconditions before the PPA workflow will build

- Jammy and Noble resolve their build toolchain from the `~lablup/+archive/ubuntu/rustc-release` dependency PPA. That PPA must publish `rustc-1.96` and `cargo-1.96` before those builds can resolve the dependency.
- Resolute (26.04) is assumed to carry Rust 1.96+ in its archive; if the archive Rust is older, resolute will also need the dependency PPA.

## Verification

Config, packaging, and workflow only; no Rust source changed. `cargo fmt --check` is clean. CI `test` uses the stable toolchain and `msrv` fetches 1.96 via `dtolnay/rust-toolchain`.
