### PR TITLE
build: source resolute toolchain from rustc-release PPA and pin vendor_rust to 1.96.0

### DIFF
--- a/.github/workflows/launchpad_ppa.yml
+++ b/.github/workflows/launchpad_ppa.yml
@@ -25,14 +25,14 @@ jobs:
       matrix:
         include:
           - distro: jammy
-            vendor_rust: "1.96.1"
+            vendor_rust: "1.96.0"
             toolchain_source: "Requires backend-ai PPA dependency on ~lablup/+archive/ubuntu/rustc-release"
           - distro: noble
-            vendor_rust: "1.96.1"
+            vendor_rust: "1.96.0"
             toolchain_source: "Requires backend-ai PPA dependency on ~lablup/+archive/ubuntu/rustc-release"
           - distro: resolute
-            vendor_rust: "1.96.1"
-            toolchain_source: "Uses the official Ubuntu 26.04 archive Rust 1.96+ toolchain"
+            vendor_rust: "1.96.0"
+            toolchain_source: "Requires backend-ai PPA dependency on ~lablup/+archive/ubuntu/rustc-release"
 
     steps:
     - name: Checkout code

--- a/debian/README.packaging
+++ b/debian/README.packaging
@@ -19,10 +19,10 @@ The following packages are required and must be available to Launchpad through t
 This project currently requires Rust 1.96 or newer because the vendored dependency set no longer builds with Rust 1.85. This means:
 - Ubuntu 22.04 (Jammy): requires a versioned Rust 1.96 toolchain from the dependent PPA `~lablup/+archive/ubuntu/rustc-release`
 - Ubuntu 24.04 (Noble): requires a versioned Rust 1.96 toolchain from the dependent PPA `~lablup/+archive/ubuntu/rustc-release`
-- Ubuntu 26.04 (Resolute): can use the archive's Rust 1.96+ toolchain without the extra dependency PPA
+- Ubuntu 26.04 (Resolute): requires a versioned Rust 1.96 toolchain from the dependent PPA `~lablup/+archive/ubuntu/rustc-release`
 
 If building for older Ubuntu versions, you may need to:
-1. Add a Launchpad PPA dependency on `~lablup/+archive/ubuntu/rustc-release` so Jammy and Noble can see `rustc-1.96` and `cargo-1.96`
+1. Add a Launchpad PPA dependency on `~lablup/+archive/ubuntu/rustc-release` so Jammy, Noble, and Resolute can see `rustc-1.96` and `cargo-1.96`
 2. Limit support to distributions with Rust 1.96+
 
 ### Build Process
@@ -37,7 +37,7 @@ If the build fails on Launchpad:
 2. Common issues:
    - Missing build dependencies: Add them to debian/control
    - Rust version incompatibility: Ensure Rust 1.96+ is available
-   - Missing PPA dependency: Jammy/Noble need access to `rustc-1.96` and `cargo-1.96`
+   - Missing PPA dependency: Jammy/Noble/Resolute need access to `rustc-1.96` and `cargo-1.96`
    - Missing vendored crates: Ensure `vendor/` and `.cargo/config.toml` are included in the source package
    - Cargo registry access: The build will fail if it tries to download crates
 


### PR DESCRIPTION
## Summary

Follow-up to #231. Verified the actual state of the `~lablup/+archive/ubuntu/rustc-release` PPA and adjusted the packaging config to match reality.

## PPA verification

Queried the Launchpad API (`getPublishedSources`). `rustc-1.96` is published for all three target series:

| Source | Version | Series |
| --- | --- | --- |
| rustc-1.96 | 1.96.0+dfsg1-0ubuntu1~22.04.1 | jammy |
| rustc-1.96 | 1.96.0+dfsg1-0ubuntu1~24.04.1 | noble |
| rustc-1.96 | 1.96.0+dfsg1-0ubuntu1~26.04.2 | resolute |

So the #231 precondition (PPA must ship `rustc-1.96`/`cargo-1.96`) is already satisfied, and the PPA serves Resolute (26.04) as well. The PPA patch is 1.96.0, not 1.96.1.

## Changes

- Resolute now documents the same dependent-PPA toolchain source as jammy and noble in `launchpad_ppa.yml` and `debian/README.packaging`, instead of claiming it builds from the 26.04 archive without the dependency PPA. `debian/control` already prefers the versioned `rustc-1.96` alternative, so no control change is needed.
- `vendor_rust` drops from 1.96.1 to 1.96.0 for all distros so the runner-side lockfile validation and `cargo vendor` step run on the exact patch Launchpad compiles with, removing any patch-level skew between the vendoring toolchain and the build toolchain.

## Verification

Workflow and docs only; no Rust source or `debian/control` build-deps changed.
