### PR TITLE
feat: filter tunneled jump targets by address family

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -773,9 +773,8 @@ with the family applied at the connect call. `ForwardingConfig` carries its own
 copy for the forwarding-target filter, since forwarders run detached from the
 connect config.
 
-**Scope.** The constraint is a hard filter where bssh opens the socket, a hint
-where the remote server does, and not yet applied past the first jump hop
-(issue #248):
+**Scope.** The constraint is a hard filter where bssh opens the socket, and a
+hint where the remote server does:
 
 | Path | Behavior |
 | --- | --- |
@@ -784,7 +783,7 @@ where the remote server does, and not yet applied past the first jump hop
 | `-L` / `-D` listener | Selects the implicit bind address (`::1` / `::` under `-6`); an explicit bind address wins |
 | `-L` / SOCKS5 `-D` target | Filters the `direct-tcpip` candidate list; the remote sshd still performs the connect, so this is advisory |
 | SOCKS4 `-D` target | Unfiltered; SOCKS4 carries a literal IPv4 destination by protocol definition |
-| Jump hops past the first, and the destination behind a chain | Not yet filtered; the target is resolved locally through the same `direct-tcpip` mechanism as `-L`/SOCKS5 `-D` targets, but this change does not apply the family constraint there (scope limitation, tracked as issue #248). The family still selects the address recorded for host key verification, so known_hosts diagnostics stay consistent |
+| Jump hops past the first, and the destination behind a chain | Filters the `direct-tcpip` candidate list through the same advisory mechanism as `-L`/SOCKS5 `-D` targets. The family also selects the address recorded for host key verification, so known_hosts diagnostics stay consistent |
 | `-R` listener | Not constrained; the server binds it |
 | `bssh-server` | Out of scope; separate CLI |
 

--- a/docs/man/bssh.1
+++ b/docs/man/bssh.1
@@ -1174,11 +1174,12 @@ bind address explicitly always overrides the flag.
 
 .SS What the constraint only hints at
 .IP \[bu] 2
-Forwarding targets. bssh resolves the target of a
+Forwarding targets and tunneled jump-chain targets. bssh resolves the target of a
 .B \-L
 forward or a SOCKS5
 .B \-D
-request locally to decide which address to name in the
+request, later jump-chain hop, or final destination behind a jump chain locally
+to decide which address to name in the
 .I direct-tcpip
 channel request, and the address family filters that candidate list. The remote
 SSH server performs the actual connection and may resolve the name differently,
@@ -1187,21 +1188,6 @@ literal IPv4 destination by protocol definition and are passed through
 unfiltered.
 
 .SS What the constraint does not cover
-.IP \[bu] 2
-Jump host hops after the first one, and the final destination reached through a
-jump chain. Those connections still ride a
-.I direct-tcpip
-channel opened through the previous hop, resolved locally by bssh the same way
-a
-.B \-L
-or SOCKS5
-.B \-D
-target is, but this change does not yet apply the address family filter to
-that resolution. That is a scope limitation of this change, not a technical
-one, and is tracked as a follow-up (issue #248). The address family is still
-applied when selecting the address recorded for host key verification on
-those hops, so known_hosts diagnostics name the family that was requested.
-.IP \[bu] 2
 The remote listener created by
 .BR \-R ,
 which the server binds. Its default stays IPv4 loopback.

--- a/src/jump/chain/tunnel.rs
+++ b/src/jump/chain/tunnel.rs
@@ -31,14 +31,11 @@ use tracing::debug;
 /// Hops past the first one connect over an already-open channel, so this
 /// particular address is never dialed: it only supplies host key verification
 /// context and display text. The channel itself is still opened locally
-/// through `open_direct_tcpip_channel` on the previous hop, but that call does
-/// not yet take the address family filter (issue #248), so the family
-/// preference resolved here has no effect on which candidate that call picks.
-/// When a family is forced, this function still prefers a candidate of that
-/// family so known_hosts diagnostics name the family the user asked for. If no
-/// candidate matches, fall back to the first resolved address rather than
-/// failing, since the connection this address describes is never dialed
-/// regardless.
+/// through `open_direct_tcpip_channel_with_family` on the previous hop. When a
+/// family is forced, this function mirrors that preference for the address
+/// recorded in known_hosts diagnostics. If no candidate matches, fall back to
+/// the first resolved address rather than failing here; the channel-open path
+/// is the authoritative family filter for the real connection attempt.
 // `host:port` is deliberately left out of the messages below: every caller
 // already wraps this function with a `.with_context()` that names the host
 // and port, and repeating it here would print the same wording twice in the
@@ -100,8 +97,11 @@ pub(super) async fn connect_through_tunnel(
     // Create a direct-tcpip channel through the previous connection
     let channel = tokio::time::timeout(
         connect_timeout,
-        previous_client
-            .open_direct_tcpip_channel((jump_host.host.as_str(), jump_host.effective_port()), None),
+        previous_client.open_direct_tcpip_channel_with_family(
+            (jump_host.host.as_str(), jump_host.effective_port()),
+            None,
+            ssh_connection_config.address_family,
+        ),
     )
     .await
     .with_context(|| {
@@ -238,7 +238,11 @@ pub(super) async fn connect_to_destination(
     // Create a direct-tcpip channel to the final destination
     let channel = tokio::time::timeout(
         connect_timeout,
-        jump_client.open_direct_tcpip_channel((destination_host, destination_port), None),
+        jump_client.open_direct_tcpip_channel_with_family(
+            (destination_host, destination_port),
+            None,
+            ssh_connection_config.address_family,
+        ),
     )
     .await
     .with_context(|| {

--- a/src/ssh/tokio_client/channel_manager.rs
+++ b/src/ssh/tokio_client/channel_manager.rs
@@ -147,6 +147,25 @@ pub struct CommandExecutedResult {
 }
 
 impl Client {
+    fn direct_tcpip_targets<T: ToSocketAddrsWithHostname>(
+        target: &T,
+        address_family: AddressFamily,
+    ) -> Result<Vec<SocketAddr>, super::Error> {
+        let resolved = target
+            .to_socket_addrs()
+            .map_err(super::Error::AddressInvalid)?;
+        let targets = address_family.filter(resolved);
+
+        if address_family.is_forced() && targets.is_empty() {
+            return Err(super::Error::NoAddressForFamily {
+                host: target.hostname(),
+                family: address_family,
+            });
+        }
+
+        Ok(targets)
+    }
+
     /// Get a new SSH channel for communication.
     pub async fn get_channel(&self) -> Result<Channel<Msg>, super::Error> {
         self.connection_handle
@@ -190,17 +209,7 @@ impl Client {
         src: S,
         address_family: AddressFamily,
     ) -> Result<Channel<Msg>, super::Error> {
-        let resolved = target
-            .to_socket_addrs()
-            .map_err(super::Error::AddressInvalid)?;
-        let targets = address_family.filter(resolved);
-
-        if address_family.is_forced() && targets.is_empty() {
-            return Err(super::Error::NoAddressForFamily {
-                host: target.hostname(),
-                family: address_family,
-            });
-        }
+        let targets = Self::direct_tcpip_targets(&target, address_family)?;
 
         let src = src
             .into()
@@ -655,5 +664,57 @@ impl Client {
             .window_change(width, height, 0, 0)
             .await
             .map_err(super::Error::SshError)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn v4(s: &str) -> SocketAddr {
+        s.parse().expect("valid IPv4 socket address")
+    }
+
+    fn v6(s: &str) -> SocketAddr {
+        s.parse().expect("valid IPv6 socket address")
+    }
+
+    fn multi_hop_candidates() -> Vec<SocketAddr> {
+        vec![
+            v6("[2001:db8::10]:22"),
+            v4("192.0.2.10:22"),
+            v6("[2001:db8::11]:22"),
+            v4("192.0.2.11:22"),
+        ]
+    }
+
+    #[test]
+    fn direct_tcpip_targets_preserve_any_family_candidates_for_tunneled_hops() {
+        let candidates = multi_hop_candidates();
+        let targets = Client::direct_tcpip_targets(&candidates.as_slice(), AddressFamily::Any)
+            .expect("unconstrained direct-tcpip target selection must succeed");
+
+        assert_eq!(targets, candidates);
+    }
+
+    #[test]
+    fn direct_tcpip_targets_filter_ipv4_candidates_for_tunneled_hops() {
+        let candidates = multi_hop_candidates();
+        let targets = Client::direct_tcpip_targets(&candidates.as_slice(), AddressFamily::V4)
+            .expect("IPv4 direct-tcpip target selection must succeed");
+
+        assert_eq!(targets, vec![v4("192.0.2.10:22"), v4("192.0.2.11:22")]);
+    }
+
+    #[test]
+    fn direct_tcpip_targets_filter_ipv6_candidates_for_tunneled_hops() {
+        let candidates = multi_hop_candidates();
+        let targets = Client::direct_tcpip_targets(&candidates.as_slice(), AddressFamily::V6)
+            .expect("IPv6 direct-tcpip target selection must succeed");
+
+        assert_eq!(
+            targets,
+            vec![v6("[2001:db8::10]:22"), v6("[2001:db8::11]:22")]
+        );
     }
 }


### PR DESCRIPTION
## Summary

Route later jump-chain hops and chained destinations through the existing family-aware direct-tcpip opener so -4/-6 and AddressFamily filter the locally resolved address named in the channel request.

## What changed

- Updated intermediate jump-hop and chained destination tunnel opens to call open_direct_tcpip_channel_with_family with the resolved SshConnectionConfig address family.
- Added deterministic mixed-family direct-tcpip target-selection tests covering AddressFamily::Any, IPv4, and IPv6 behavior.
- Updated ARCHITECTURE.md and docs/man/bssh.1 so they no longer document later jump hops as unfiltered.

## Test plan

- [x] cargo fmt
- [x] cargo test --lib ssh::tokio_client::channel_manager
- [x] cargo test --lib jump::chain::tunnel
- [x] cargo check --lib --tests
- [x] cargo clippy --lib --tests -- -D warnings

Closes #248
