### PR TITLE
fix: accept bracketed IPv6 host literals (#251)

### DIFF
--- a/docs/man/bssh.1
+++ b/docs/man/bssh.1
@@ -152,7 +152,13 @@ Hostlist expressions (range expansion):
 .IP \[bu] 2
 -H "admin@web[1-3]:22" \[->] expands with user and port preserved
 .IP \[bu] 2
+-H "[2001:db8::1]:2222" \[->] one IPv6 host with an explicit port
+.IP \[bu] 2
+-H "user@[::1]" \[->] the IPv6 loopback address with an explicit user
+.IP \[bu] 2
 -H "^/path/to/hostfile" \[->] read hosts from file
+.PP
+IPv6 address literals must be enclosed in brackets. A bracket group is interpreted as IPv6 only when its complete contents are a syntactically valid IPv6 address; numeric groups such as [1] and [1-3] remain hostlist ranges. Bare forms such as ::1 are rejected with guidance to use [::1], because a trailing numeric IPv6 segment cannot otherwise be distinguished from a port.
 .RE
 
 .TP
@@ -1332,6 +1338,10 @@ expands to web1.example.com, web2.example.com, web3.example.com
 .B With user and port
 .B admin@server[1-3]:2222
 expands to admin@server1:2222, admin@server2:2222, admin@server3:2222
+.TP
+.B IPv6 literal
+.B user@[2001:db8::1]:2222
+selects one IPv6 host. Brackets are required and are distinct from range brackets because their contents parse as a complete IPv6 address.
 
 .SS File Input
 .TP

--- a/src/app/nodes.rs
+++ b/src/app/nodes.rs
@@ -143,6 +143,39 @@ mod ipv6_tests {
 
         assert!(format!("{error:#}").contains("must be enclosed in brackets"));
     }
+
+    #[tokio::test]
+    async fn ssh_destination_resolves_bracketed_ipv6() {
+        for (destination, expected_user, expected_port) in [
+            ("[::1]", None, 22),
+            ("[::1]:2222", None, 2222),
+            ("user@[::1]", Some("user"), 22),
+            ("user@[::1]:2222", Some("user"), 2222),
+            ("ssh://user@[::1]:2222", Some("user"), 2222),
+        ] {
+            let cli = Cli::parse_from(["bssh", destination]);
+            let (nodes, _) = resolve_nodes(&cli, &Config::default(), &SshConfig::new())
+                .await
+                .unwrap();
+
+            assert_eq!(nodes.len(), 1);
+            assert_eq!(nodes[0].host, "::1");
+            assert_eq!(nodes[0].port, expected_port);
+            if let Some(user) = expected_user {
+                assert_eq!(nodes[0].username, user);
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn ssh_destination_rejects_bare_ipv6_with_bracket_guidance() {
+        let cli = Cli::parse_from(["bssh", "::1"]);
+        let error = resolve_nodes(&cli, &Config::default(), &SshConfig::new())
+            .await
+            .unwrap_err();
+
+        assert!(format!("{error:#}").contains("must be enclosed in brackets"));
+    }
 }
 
 /// Resolve nodes from CLI arguments and configuration
@@ -157,7 +190,7 @@ pub async fn resolve_nodes(
     // Handle SSH compatibility mode (single host)
     if cli.is_ssh_mode() {
         let (user, host, port) = cli
-            .parse_destination()
+            .parse_destination_result()?
             .ok_or_else(|| anyhow::anyhow!("Invalid destination format"))?;
 
         // Resolve using SSH config with CLI taking precedence

--- a/src/app/nodes.rs
+++ b/src/app/nodes.rs
@@ -15,7 +15,13 @@
 //! Node resolution and filtering functionality
 
 use anyhow::{Context, Result};
-use bssh::{cli::Cli, config::Config, hostlist, node::Node, ssh::SshConfig};
+use bssh::{
+    cli::Cli,
+    config::Config,
+    hostlist,
+    node::{Node, parse_node_spec},
+    ssh::SshConfig,
+};
 use glob::Pattern;
 
 /// Parse a node string with SSH config integration
@@ -37,22 +43,10 @@ pub fn parse_node_with_ssh_config(node_str: &str, ssh_config: &SshConfig) -> Res
     }
 
     // First parse the raw node string to extract user, host, port from CLI
-    let (user_part, host_part) = if let Some(at_pos) = node_str.find('@') {
-        let user = &node_str[..at_pos];
-        let rest = &node_str[at_pos + 1..];
-        (Some(user), rest)
-    } else {
-        (None, node_str)
-    };
-
-    let (raw_host, cli_port) = if let Some(colon_pos) = host_part.rfind(':') {
-        let host = &host_part[..colon_pos];
-        let port_str = &host_part[colon_pos + 1..];
-        let port = port_str.parse::<u16>().context("Invalid port number")?;
-        (host, Some(port))
-    } else {
-        (host_part, None)
-    };
+    let spec = parse_node_spec(node_str)?;
+    let user_part = spec.user;
+    let raw_host = spec.host;
+    let cli_port = spec.port;
 
     // Security: Validate hostname
     let validated_host = bssh::security::validate_hostname(raw_host)
@@ -86,6 +80,69 @@ pub fn parse_node_with_ssh_config(node_str: &str, ssh_config: &SshConfig) -> Res
         effective_port,
         effective_user,
     ))
+}
+
+#[cfg(test)]
+mod ipv6_tests {
+    use super::*;
+    use clap::Parser;
+
+    #[test]
+    fn cli_node_parser_accepts_all_bracketed_ipv6_forms() {
+        let ssh_config = SshConfig::new();
+
+        for (spec, expected_user, expected_port) in [
+            ("[::1]", None, 22),
+            ("[::1]:2222", None, 2222),
+            ("user@[::1]", Some("user"), 22),
+            ("user@[::1]:2222", Some("user"), 2222),
+        ] {
+            let node = parse_node_with_ssh_config(spec, &ssh_config).unwrap();
+            assert_eq!(node.host, "::1");
+            assert_eq!(node.port, expected_port);
+            if let Some(user) = expected_user {
+                assert_eq!(node.username, user);
+            }
+        }
+    }
+
+    #[test]
+    fn cli_node_parser_rejects_unbracketed_ipv6_with_guidance() {
+        let error = parse_node_with_ssh_config("::1", &SshConfig::new()).unwrap_err();
+        assert!(error.to_string().contains("must be enclosed in brackets"));
+    }
+
+    #[tokio::test]
+    async fn hosts_option_resolves_bracketed_ipv6_through_the_real_flow() {
+        for (host_spec, expected_user, expected_port) in [
+            ("[::1]", None, 22),
+            ("[::1]:2222", None, 2222),
+            ("user@[::1]", Some("user"), 22),
+            ("user@[::1]:2222", Some("user"), 2222),
+        ] {
+            let cli = Cli::parse_from(["bssh", "-H", host_spec, "true"]);
+            let (nodes, _) = resolve_nodes(&cli, &Config::default(), &SshConfig::new())
+                .await
+                .unwrap();
+
+            assert_eq!(nodes.len(), 1);
+            assert_eq!(nodes[0].host, "::1");
+            assert_eq!(nodes[0].port, expected_port);
+            if let Some(user) = expected_user {
+                assert_eq!(nodes[0].username, user);
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn hosts_option_rejects_bare_ipv6_with_bracket_guidance() {
+        let cli = Cli::parse_from(["bssh", "-H", "::1", "true"]);
+        let error = resolve_nodes(&cli, &Config::default(), &SshConfig::new())
+            .await
+            .unwrap_err();
+
+        assert!(format!("{error:#}").contains("must be enclosed in brackets"));
+    }
 }
 
 /// Resolve nodes from CLI arguments and configuration

--- a/src/app/nodes.rs
+++ b/src/app/nodes.rs
@@ -189,17 +189,20 @@ pub async fn resolve_nodes(
 
     // Handle SSH compatibility mode (single host)
     if cli.is_ssh_mode() {
-        let (user, host, port) = cli
+        let spec = cli
             .parse_destination_result()?
             .ok_or_else(|| anyhow::anyhow!("Invalid destination format"))?;
+        let user = spec.user;
+        let host = spec.host;
+        let port = spec.port;
 
         // Resolve using SSH config with CLI taking precedence
-        let effective_hostname = ssh_config.get_effective_hostname(&host);
+        let effective_hostname = ssh_config.get_effective_hostname(host);
         let effective_user = if let Some(u) = user {
-            u
+            u.to_string()
         } else if let Some(cli_user) = cli.get_effective_user() {
             cli_user
-        } else if let Some(ssh_user) = ssh_config.get_effective_user(&host, None) {
+        } else if let Some(ssh_user) = ssh_config.get_effective_user(host, None) {
             ssh_user
         } else if let Ok(env_user) = std::env::var("USER") {
             env_user
@@ -207,7 +210,7 @@ pub async fn resolve_nodes(
             "root".to_string()
         };
         let effective_port =
-            ssh_config.get_effective_port(&host, port.or_else(|| cli.get_effective_port()));
+            ssh_config.get_effective_port(host, port.or_else(|| cli.get_effective_port()));
 
         let node = Node::new(effective_hostname, effective_port, effective_user);
         nodes.push(node);

--- a/src/cli/bssh.rs
+++ b/src/cli/bssh.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use anyhow::Context;
+use anyhow::{Context, Result};
 use clap::{Parser, Subcommand};
 use std::path::PathBuf;
 
@@ -512,15 +512,24 @@ impl Cli {
 
     /// Parse destination string into components (user, host, port)
     pub fn parse_destination(&self) -> Option<(Option<String>, String, Option<u16>)> {
-        let destination = self.destination.as_ref()?;
-        let destination = destination.strip_prefix("ssh://").unwrap_or(destination);
-        let spec = crate::node::parse_node_spec(destination).ok()?;
+        self.parse_destination_result().ok().flatten()
+    }
 
-        Some((
+    /// Parse destination string into components while preserving parse errors.
+    pub fn parse_destination_result(
+        &self,
+    ) -> Result<Option<(Option<String>, String, Option<u16>)>> {
+        let Some(destination) = self.destination.as_ref() else {
+            return Ok(None);
+        };
+        let destination = destination.strip_prefix("ssh://").unwrap_or(destination);
+        let spec = crate::node::parse_node_spec(destination)?;
+
+        Ok(Some((
             spec.user.map(str::to_string),
             spec.host.to_string(),
             spec.port,
-        ))
+        )))
     }
 
     /// Get effective username (from -l option, destination, or environment)

--- a/src/cli/bssh.rs
+++ b/src/cli/bssh.rs
@@ -38,7 +38,7 @@ pub struct Cli {
         short = 'H',
         long,
         value_delimiter = ',',
-        help = "Comma-separated list of hosts with hostlist expansion support\nFormat: [user@]hostname[:port] with optional range expressions\nRange expressions:\n  node[1-5]        -> node1, node2, node3, node4, node5\n  node[01-03]      -> node01, node02, node03 (zero-padded)\n  node[1,3,5]      -> node1, node3, node5\n  rack[1-2]-node[1-3] -> 6 hosts (cartesian product)\n  ^/path/to/file   -> read hosts from file\nExamples:\n  'web[1-3].example.com' for web1-web3\n  'admin@db[01-03]:5432' for db01-db03 with user and port"
+        help = "Comma-separated list of hosts with hostlist expansion support\nFormat: [user@]hostname[:port] with optional range expressions\nIPv6 literals must be bracketed, for example '[::1]' or 'user@[::1]:2222'. A bracket group is IPv6 only when its contents parse as an IPv6 address; numeric groups remain ranges.\nRange expressions:\n  node[1-5]        -> node1, node2, node3, node4, node5\n  node[01-03]      -> node01, node02, node03 (zero-padded)\n  node[1,3,5]      -> node1, node3, node5\n  rack[1-2]-node[1-3] -> 6 hosts (cartesian product)\n  ^/path/to/file   -> read hosts from file\nExamples:\n  'web[1-3].example.com' for web1-web3\n  'admin@db[01-03]:5432' for db01-db03 with user and port\n  '[2001:db8::1]:2222' for an IPv6 literal with a port"
     )]
     pub hosts: Option<Vec<String>>,
 
@@ -512,32 +512,15 @@ impl Cli {
 
     /// Parse destination string into components (user, host, port)
     pub fn parse_destination(&self) -> Option<(Option<String>, String, Option<u16>)> {
-        self.destination.as_ref().map(|dest| {
-            // Handle ssh:// prefix
-            let dest = dest.strip_prefix("ssh://").unwrap_or(dest);
+        let destination = self.destination.as_ref()?;
+        let destination = destination.strip_prefix("ssh://").unwrap_or(destination);
+        let spec = crate::node::parse_node_spec(destination).ok()?;
 
-            // Parse [user@]hostname[:port]
-            let parts: Vec<&str> = dest.splitn(2, '@').collect();
-            let (user, host_port) = if parts.len() == 2 {
-                (Some(parts[0].to_string()), parts[1])
-            } else {
-                (None, parts[0])
-            };
-
-            // Parse hostname[:port]
-            if let Some(idx) = host_port.rfind(':') {
-                // Check if this is actually a port number (not IPv6 address)
-                if let Ok(port) = host_port[idx + 1..].parse::<u16>() {
-                    let host = host_port[..idx].to_string();
-                    (user, host, Some(port))
-                } else {
-                    // Not a valid port, treat entire string as hostname
-                    (user, host_port.to_string(), None)
-                }
-            } else {
-                (user, host_port.to_string(), None)
-            }
-        })
+        Some((
+            spec.user.map(str::to_string),
+            spec.host.to_string(),
+            spec.port,
+        ))
     }
 
     /// Get effective username (from -l option, destination, or environment)

--- a/src/cli/bssh.rs
+++ b/src/cli/bssh.rs
@@ -512,24 +512,23 @@ impl Cli {
 
     /// Parse destination string into components (user, host, port)
     pub fn parse_destination(&self) -> Option<(Option<String>, String, Option<u16>)> {
-        self.parse_destination_result().ok().flatten()
+        let spec = self.parse_destination_result().ok().flatten()?;
+        Some((
+            spec.user.map(str::to_string),
+            spec.host.to_string(),
+            spec.port,
+        ))
     }
 
     /// Parse destination string into components while preserving parse errors.
-    pub fn parse_destination_result(
-        &self,
-    ) -> Result<Option<(Option<String>, String, Option<u16>)>> {
+    pub fn parse_destination_result(&self) -> Result<Option<crate::node::NodeSpec<'_>>> {
         let Some(destination) = self.destination.as_ref() else {
             return Ok(None);
         };
         let destination = destination.strip_prefix("ssh://").unwrap_or(destination);
         let spec = crate::node::parse_node_spec(destination)?;
 
-        Ok(Some((
-            spec.user.map(str::to_string),
-            spec.host.to_string(),
-            spec.port,
-        )))
+        Ok(Some(spec))
     }
 
     /// Get effective username (from -l option, destination, or environment)

--- a/src/config/resolver.rs
+++ b/src/config/resolver.rs
@@ -16,7 +16,7 @@
 
 use anyhow::Result;
 
-use crate::node::Node;
+use crate::node::{Node, parse_node_spec};
 use crate::ssh::ssh_config::SshConfig;
 
 use super::types::{Cluster, Config, JumpHostConfig, NodeConfig};
@@ -51,12 +51,18 @@ impl Config {
 
                     let default_port = cluster.defaults.port.or(self.defaults.port).unwrap_or(22);
 
-                    Node::parse(&expanded_host, default_user.as_deref()).map(|mut n| {
-                        if !expanded_host.contains(':') {
-                            n.port = default_port;
-                        }
-                        n
-                    })?
+                    let spec = parse_node_spec(&expanded_host)?;
+                    let username = spec
+                        .user
+                        .map(str::to_string)
+                        .or(default_user)
+                        .unwrap_or_else(get_current_username);
+
+                    Node::new(
+                        spec.host.to_string(),
+                        spec.port.unwrap_or(default_port),
+                        username,
+                    )
                 }
                 NodeConfig::Detailed {
                     host, port, user, ..
@@ -76,7 +82,13 @@ impl Config {
                         .or(self.defaults.port)
                         .unwrap_or(22);
 
-                    Node::new(expanded_host, port, username)
+                    let normalized_host = if expanded_host.starts_with('[') {
+                        parse_node_spec(&expanded_host)?.host.to_string()
+                    } else {
+                        expanded_host
+                    };
+
+                    Node::new(normalized_host, port, username)
                 }
             };
 

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -18,6 +18,7 @@ use std::path::{Path, PathBuf};
 
 use super::types::{Config, InteractiveMode, NodeConfig};
 use super::utils::{expand_env_vars, expand_tilde};
+use crate::node::Node;
 use crate::test_helpers::EnvGuard;
 use serial_test::serial;
 
@@ -220,6 +221,39 @@ fn test_backendai_env_parsing() {
         }
         _ => panic!("Expected Simple node config"),
     }
+}
+
+#[test]
+fn test_cluster_nodes_accept_bracketed_ipv6_literals() {
+    let yaml = r#"
+defaults:
+  user: default-user
+  port: 2200
+clusters:
+  ipv6:
+    nodes:
+      - "[::1]"
+      - "admin@[2001:db8::1]:2222"
+      - host: "[2001:db8::2]"
+        port: 2223
+        user: detailed-user
+"#;
+
+    let config: Config = serde_yaml::from_str(yaml).unwrap();
+    let nodes = config.resolve_nodes("ipv6").unwrap();
+
+    assert_eq!(
+        nodes[0],
+        Node::new("::1".into(), 2200, "default-user".into())
+    );
+    assert_eq!(
+        nodes[1],
+        Node::new("2001:db8::1".into(), 2222, "admin".into())
+    );
+    assert_eq!(
+        nodes[2],
+        Node::new("2001:db8::2".into(), 2223, "detailed-user".into())
+    );
 }
 
 #[test]

--- a/src/hostlist/error.rs
+++ b/src/hostlist/error.rs
@@ -76,6 +76,12 @@ pub enum HostlistError {
     /// IPv6 address disambiguation failure
     #[error("cannot distinguish IPv6 literal from range expression in '{expression}'")]
     Ipv6Ambiguity { expression: String },
+
+    /// An IPv6 literal was supplied without the brackets required by host specs.
+    #[error(
+        "IPv6 address literal '{expression}' must be enclosed in brackets, for example '[::1]'"
+    )]
+    UnbracketedIpv6 { expression: String },
 }
 
 #[cfg(test)]

--- a/src/hostlist/expander.rs
+++ b/src/hostlist/expander.rs
@@ -17,6 +17,8 @@
 //! This module expands parsed host patterns into lists of hostnames
 //! using cartesian product for multiple range expressions.
 
+use std::net::Ipv6Addr;
+
 use super::error::HostlistError;
 use super::parser::{PatternSegment, parse_host_pattern};
 
@@ -188,6 +190,12 @@ pub fn expand_host_spec(spec: &str) -> Result<Vec<String>, HostlistError> {
     } else {
         (None, spec)
     };
+
+    if rest.parse::<Ipv6Addr>().is_ok() {
+        return Err(HostlistError::UnbracketedIpv6 {
+            expression: spec.to_string(),
+        });
+    }
 
     // Parse port suffix (find last : that's not inside brackets)
     let (host_pattern, port_suffix) = parse_port_suffix(rest)?;
@@ -397,6 +405,35 @@ mod tests {
     fn test_expand_host_spec_no_expansion() {
         let hosts = expand_host_spec("user@host.com:2222").unwrap();
         assert_eq!(hosts, vec!["user@host.com:2222"]);
+    }
+
+    #[test]
+    fn test_expand_bracketed_ipv6_forms() {
+        for (spec, expected) in [
+            ("[::1]", "[::1]"),
+            ("[::1]:2222", "[::1]:2222"),
+            ("user@[::1]", "user@[::1]"),
+            ("user@[::1]:2222", "user@[::1]:2222"),
+            ("[2001:db8::1]", "[2001:db8::1]"),
+        ] {
+            assert_eq!(expand_host_spec(spec).unwrap(), vec![expected]);
+        }
+    }
+
+    #[test]
+    fn test_unbracketed_ipv6_requires_brackets() {
+        let error = expand_host_spec("::1").unwrap_err();
+        assert!(matches!(error, HostlistError::UnbracketedIpv6 { .. }));
+        assert!(error.to_string().contains("must be enclosed in brackets"));
+    }
+
+    #[test]
+    fn test_ipv6_capable_hostnames_remain_literals() {
+        assert_eq!(expand_host_spec("localhost").unwrap(), vec!["localhost"]);
+        assert_eq!(
+            expand_host_spec("ip6-localhost").unwrap(),
+            vec!["ip6-localhost"]
+        );
     }
 
     #[test]

--- a/src/hostlist/mod.rs
+++ b/src/hostlist/mod.rs
@@ -26,7 +26,12 @@
 //! - Mixed ranges and values: `node[1-3,7,9-10]` -> 7 hosts
 //! - Multiple ranges (cartesian product): `rack[1-2]-node[1-3]` -> 6 hosts
 //! - Domain suffix: `web[1-3].example.com` -> 3 hosts
+//! - IPv6 literal: `[2001:db8::1]` -> one literal host (brackets required)
 //! - File input: `^/path/to/file` -> read hosts from file
+//!
+//! A bracket group is treated as IPv6 only when its complete contents parse as
+//! an IPv6 address. Numeric groups such as `[1]` and `[1-3]` therefore retain
+//! their range meaning without ambiguity.
 //!
 //! # Examples
 //!

--- a/src/hostlist/parser.rs
+++ b/src/hostlist/parser.rs
@@ -17,8 +17,10 @@
 //! This module parses hostlist expressions into structured representations
 //! that can be expanded into lists of hostnames.
 
-use super::error::HostlistError;
+use std::net::Ipv6Addr;
 use std::path::Path;
+
+use super::error::HostlistError;
 
 /// Represents a parsed range item (single value or range)
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -162,12 +164,17 @@ pub fn parse_host_pattern(pattern: &str) -> Result<HostPattern, HostlistError> {
                     });
                 }
 
-                // Check for IPv6 literal (starts with digit or colon after [)
-                if let Some(&next_ch) = chars.peek()
-                    && is_ipv6_start(next_ch, &chars)
-                {
-                    // This might be an IPv6 literal, collect until matching ]
+                // A bracket group is an IPv6 literal only when its complete
+                // contents parse as IPv6. Numeric groups remain hostlist ranges,
+                // so inputs such as `[1]` and `[1-3]` are never ambiguous.
+                if current_literal.is_empty() && is_bracketed_ipv6(&chars) {
                     current_literal.push(ch);
+                    for ipv6_ch in chars.by_ref() {
+                        current_literal.push(ipv6_ch);
+                        if ipv6_ch == ']' {
+                            break;
+                        }
+                    }
                     continue;
                 }
 
@@ -233,13 +240,20 @@ pub fn parse_host_pattern(pattern: &str) -> Result<HostPattern, HostlistError> {
     Ok(HostPattern { segments })
 }
 
-/// Check if a character sequence might be the start of an IPv6 literal
-fn is_ipv6_start(next_ch: char, _chars: &std::iter::Peekable<std::str::Chars>) -> bool {
-    // IPv6 literals start with a colon (e.g., [::1] or [2001:db8::1])
-    // We use a conservative heuristic: only treat as IPv6 if we see a colon
-    // This means hex digits like 'a' will be treated as potential hostlist content
-    // and will fail with InvalidNumber if they're not valid numeric ranges
-    next_ch == ':'
+/// Return whether the characters after `[` contain a complete IPv6 literal.
+fn is_bracketed_ipv6(chars: &std::iter::Peekable<std::str::Chars<'_>>) -> bool {
+    let mut lookahead = chars.clone();
+    let mut address = String::new();
+
+    for ch in lookahead.by_ref() {
+        match ch {
+            ']' => return address.parse::<Ipv6Addr>().is_ok(),
+            '[' => return false,
+            _ => address.push(ch),
+        }
+    }
+
+    false
 }
 
 /// Parse a range expression (content between brackets)
@@ -541,6 +555,18 @@ mod tests {
         assert_eq!(pattern.segments.len(), 1);
         assert!(!pattern.has_ranges());
         assert_eq!(pattern.expansion_count(), 1);
+    }
+
+    #[test]
+    fn test_parse_bracketed_ipv6_as_literal() {
+        for address in ["[::1]", "[2001:db8::1]"] {
+            let pattern = parse_host_pattern(address).unwrap();
+            assert_eq!(
+                pattern.segments,
+                vec![PatternSegment::Literal(address.to_string())]
+            );
+            assert!(!pattern.has_ranges());
+        }
     }
 
     #[test]

--- a/src/node.rs
+++ b/src/node.rs
@@ -12,8 +12,65 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use anyhow::{Context, Result};
 use std::fmt;
+use std::net::Ipv6Addr;
+
+use anyhow::{Context, Result};
+
+/// Parsed components of a `[user@]host[:port]` node specification.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct NodeSpec<'a> {
+    pub user: Option<&'a str>,
+    pub host: &'a str,
+    pub port: Option<u16>,
+}
+
+/// Parse a node specification while preserving IPv6 address boundaries.
+///
+/// IPv6 literals must use brackets because an unbracketed trailing numeric
+/// segment is indistinguishable from a port. The returned host never includes
+/// the brackets, so callers can pass `(host, port)` directly to a resolver.
+pub fn parse_node_spec(node_str: &str) -> Result<NodeSpec<'_>> {
+    let (user, host_part) = if let Some((user, host)) = node_str.split_once('@') {
+        (Some(user), host)
+    } else {
+        (None, node_str)
+    };
+
+    if let Some(bracketed) = host_part.strip_prefix('[') {
+        let closing = bracketed
+            .find(']')
+            .context("Bracketed IPv6 address is missing a closing ']'")?;
+        let host = &bracketed[..closing];
+        host.parse::<Ipv6Addr>()
+            .context("Invalid bracketed IPv6 address")?;
+
+        let suffix = &bracketed[closing + 1..];
+        let port = if suffix.is_empty() {
+            None
+        } else {
+            let port_str = suffix
+                .strip_prefix(':')
+                .context("Unexpected text after bracketed IPv6 address")?;
+            Some(port_str.parse::<u16>().context("Invalid port number")?)
+        };
+
+        return Ok(NodeSpec { user, host, port });
+    }
+
+    if host_part.parse::<Ipv6Addr>().is_ok() {
+        anyhow::bail!("IPv6 address literals must be enclosed in brackets, for example '[::1]'");
+    }
+
+    let (host, port) = if let Some((host, port_str)) = host_part.rsplit_once(':') {
+        let port = port_str.parse::<u16>().context("Invalid port number")?;
+        (host, Some(port))
+    } else {
+        (host_part, None)
+    };
+
+    Ok(NodeSpec { user, host, port })
+}
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct Node {
@@ -38,24 +95,10 @@ impl Node {
         // - user@host
         // - user@host:port
 
-        let (user_part, host_part) = if let Some(at_pos) = node_str.find('@') {
-            let user = &node_str[..at_pos];
-            let rest = &node_str[at_pos + 1..];
-            (Some(user), rest)
-        } else {
-            (None, node_str)
-        };
+        let spec = parse_node_spec(node_str)?;
 
-        let (host, port) = if let Some(colon_pos) = host_part.rfind(':') {
-            let host = &host_part[..colon_pos];
-            let port_str = &host_part[colon_pos + 1..];
-            let port = port_str.parse::<u16>().context("Invalid port number")?;
-            (host, port)
-        } else {
-            (host_part, 22)
-        };
-
-        let username = user_part
+        let username = spec
+            .user
             .or(default_user)
             .map(|s| s.to_string())
             .unwrap_or_else(|| {
@@ -66,20 +109,28 @@ impl Node {
             });
 
         Ok(Node {
-            host: host.to_string(),
-            port,
+            host: spec.host.to_string(),
+            port: spec.port.unwrap_or(22),
             username,
         })
     }
 
     pub fn address(&self) -> String {
-        format!("{}:{}", self.host, self.port)
+        if self.host.parse::<Ipv6Addr>().is_ok() {
+            format!("[{}]:{}", self.host, self.port)
+        } else {
+            format!("{}:{}", self.host, self.port)
+        }
     }
 }
 
 impl fmt::Display for Node {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}@{}:{}", self.username, self.host, self.port)
+        if self.host.parse::<Ipv6Addr>().is_ok() {
+            write!(f, "{}@[{}]:{}", self.username, self.host, self.port)
+        } else {
+            write!(f, "{}@{}:{}", self.username, self.host, self.port)
+        }
     }
 }
 
@@ -115,6 +166,27 @@ mod tests {
         assert_eq!(node.username, "admin");
         assert_eq!(node.host, "example.com");
         assert_eq!(node.port, 2222);
+    }
+
+    #[test]
+    fn test_parse_bracketed_ipv6_forms() {
+        let node = Node::parse("[::1]", Some("default_user")).unwrap();
+        assert_eq!(node.host, "::1");
+        assert_eq!(node.port, 22);
+        assert_eq!(node.username, "default_user");
+        assert_eq!(node.address(), "[::1]:22");
+        assert_eq!(node.to_string(), "default_user@[::1]:22");
+
+        let node = Node::parse("admin@[2001:db8::1]:2222", None).unwrap();
+        assert_eq!(node.host, "2001:db8::1");
+        assert_eq!(node.port, 2222);
+        assert_eq!(node.username, "admin");
+    }
+
+    #[test]
+    fn test_parse_unbracketed_ipv6_explains_required_syntax() {
+        let error = Node::parse("::1", None).unwrap_err();
+        assert!(error.to_string().contains("must be enclosed in brackets"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Accept bracketed IPv6 address literals in hostlist expressions and preserve their host, user, and port boundaries through CLI and YAML node resolution.

## What changed

- Disambiguate bracket groups by parsing their full contents as IPv6, while preserving numeric hostlist ranges such as `node[1-3]`.
- Normalize bracketed IPv6 hosts before resolver calls and reject bare literals with bracket-specific guidance.
- Apply the same parsing rules to `-H`, SSH-style destinations, and simple or detailed cluster node entries.
- Document accepted IPv6 forms and the disambiguation rule in CLI help and the bssh man page.
- Add parser, expander, node, config, and real `resolve_nodes` regression coverage.

## Test plan

- [x] `cargo test --lib ipv6` (18 passed)
- [x] `cargo test --lib hostlist::expander::tests::test_expand_simple_range` (1 passed)
- [x] `cargo test --bin bssh ipv6_tests` (6 passed)
- [x] `cargo check --lib --tests`
- [x] `cargo clippy --lib --tests -- -D warnings`

Closes #251