### PR TITLE
fix: resolve ssh config per connection target

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -754,24 +754,24 @@ implements the OpenSSH precedence rule: command line flag, then config keyword,
 then the `any` default. `AddressFamily::from_config_value` accepts
 `any | inet | inet6` case-insensitively and warns (via `tracing`) rather than
 failing on an unrecognized value, so a configuration file OpenSSH would tolerate
-does not become a hard error. The dispatcher resolves the preference once per
-dispatch path in `app::dispatcher::resolve_address_family`.
+does not become a hard error. The dispatcher builds an
+`SshConnectionConfigResolver` from CLI overrides, YAML defaults, and the parsed
+ssh_config; exec, ping, upload, and download resolve that object for each
+target node so per-host `Host` blocks apply to the actual connection target.
 
 **Threading.** The preference rides on `SshConnectionConfig`, the struct every
 connection path already carries. `Client::connect_with_ssh_config` passes it to
 `connect_with_config_inner`, which resolves the target, filters the candidate
 list, and connects. `Any` returns the resolver's list untouched, which is what
 keeps the unflagged path byte-for-byte identical to the previous behavior.
-`JumpHostChain` and the exec, interactive, ping, and port-forwarding paths all
-inherit the setting from the same struct.
-
-The SFTP paths (`upload` / `download`) never carried a `SshConnectionConfig`;
-they relied on `establish_connection` substituting the default. They thread the
-`AddressFamily` value alone (it is `Copy`, so it crosses the per-node
-`tokio::spawn` boundary without an allocation) and rebuild that same default
-with the family applied at the connect call. `ForwardingConfig` carries its own
-copy for the forwarding-target filter, since forwarders run detached from the
-connect config.
+`JumpHostChain` receives the same resolver and resolves each jump hop against
+that hop's own host name instead of inheriting the destination's settings.
+The SFTP paths (`upload` / `download`) now receive the full resolved
+`SshConnectionConfig`, so `AddressFamily`, `Compression`,
+`ServerAliveInterval`, and `ServerAliveCountMax` follow the same per-host path
+as exec and ping. `ForwardingConfig` carries its own copy of the resolved
+address family for the forwarding-target filter, since forwarders run detached
+from the connect config.
 
 **Scope.** The constraint is a hard filter where bssh opens the socket, and a
 hint where the remote server does:

--- a/src/app/dispatcher.rs
+++ b/src/app/dispatcher.rs
@@ -28,9 +28,7 @@ use bssh::{
     config::InteractiveMode,
     pty::PtyConfig,
     security::{Password, get_password, get_sudo_password},
-    ssh::tokio_client::{
-        AddressFamily, DEFAULT_KEEPALIVE_INTERVAL, DEFAULT_KEEPALIVE_MAX, SshConnectionConfig,
-    },
+    ssh::tokio_client::{AddressFamily, SshConnectionConfigResolver},
 };
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -44,71 +42,24 @@ use super::utils::format_duration;
 /// report.
 const EXIT_SUCCESS: i32 = 0;
 
-/// Build SSH connection config with keepalive, compression, and address
-/// family settings.
+/// Build an SSH connection config resolver with keepalive, compression, and
+/// address family settings.
 /// Precedence: CLI > SSH config > YAML config > defaults.
 /// `Compression` has no CLI or YAML override; it is read from ssh_config only.
 /// `AddressFamily` has no YAML override; `-4`/`-6` beat the ssh_config keyword,
 /// which beats the `any` default.
-fn build_ssh_connection_config(
+fn build_ssh_connection_config_resolver(
     cli: &Cli,
     ctx: &AppContext,
-    hostname: Option<&str>,
     cluster_name: Option<&str>,
-) -> SshConnectionConfig {
-    let keepalive_interval = cli
-        .server_alive_interval
-        .or_else(|| {
-            ctx.ssh_config
-                .get_int_option(hostname, "serveraliveinterval")
-                .map(|v| v as u64)
-        })
-        .or_else(|| ctx.config.get_server_alive_interval(cluster_name))
-        .unwrap_or(DEFAULT_KEEPALIVE_INTERVAL);
-
-    let keepalive_max = cli
-        .server_alive_count_max
-        .or_else(|| {
-            ctx.ssh_config
-                .get_int_option(hostname, "serveralivecountmax")
-                .map(|v| v as usize)
-        })
-        .or_else(|| ctx.config.get_server_alive_count_max(cluster_name))
-        .unwrap_or(DEFAULT_KEEPALIVE_MAX);
-
-    let compression = ctx
-        .ssh_config
-        .get_compression(hostname.unwrap_or("*"))
-        .unwrap_or(false);
-
-    let address_family = resolve_address_family(cli, ctx, hostname);
-
-    let ssh_connection_config = SshConnectionConfig::new()
-        .with_keepalive_interval(if keepalive_interval == 0 {
-            None
-        } else {
-            Some(keepalive_interval)
-        })
-        .with_keepalive_max(keepalive_max)
-        .with_compression(compression)
-        .with_address_family(address_family);
-
-    tracing::debug!(
-        "SSH keepalive config: interval={:?}s, max={}, compression={}, address_family={}",
-        ssh_connection_config.keepalive_interval,
-        ssh_connection_config.keepalive_max,
-        ssh_connection_config.compression,
-        ssh_connection_config.address_family
-    );
-
-    ssh_connection_config
-}
-
-/// Resolve the effective address family with OpenSSH precedence:
-/// `-4`/`-6` beat the ssh_config `AddressFamily` keyword, which beats `any`.
-fn resolve_address_family(cli: &Cli, ctx: &AppContext, hostname: Option<&str>) -> AddressFamily {
-    let config_value = ctx.ssh_config.get_address_family(hostname.unwrap_or("*"));
-    AddressFamily::resolve(cli.ipv4, cli.ipv6, config_value.as_deref())
+) -> SshConnectionConfigResolver {
+    SshConnectionConfigResolver::new()
+        .with_ssh_config(Some(ctx.ssh_config.clone()))
+        .with_cli_keepalive_interval(cli.server_alive_interval)
+        .with_cli_keepalive_max(cli.server_alive_count_max)
+        .with_yaml_keepalive_interval(ctx.config.get_server_alive_interval(cluster_name))
+        .with_yaml_keepalive_max(ctx.config.get_server_alive_count_max(cluster_name))
+        .with_cli_address_family(AddressFamily::from_flags(cli.ipv4, cli.ipv6))
 }
 
 /// Decide whether `-S` (sudo-password) is meaningful for the given dispatch path.
@@ -250,10 +201,9 @@ pub async fn dispatch_command(cli: &Cli, ctx: &AppContext) -> Result<i32> {
                     .get_cluster_jump_host(ctx.cluster_name.as_deref().or(cli.cluster.as_deref()))
             });
 
-            let ssh_connection_config = build_ssh_connection_config(
+            let ssh_connection_config_resolver = build_ssh_connection_config_resolver(
                 cli,
                 ctx,
-                hostname_for_ssh_config.as_deref(),
                 ctx.cluster_name.as_deref().or(cli.cluster.as_deref()),
             );
 
@@ -273,7 +223,7 @@ pub async fn dispatch_command(cli: &Cli, ctx: &AppContext) -> Result<i32> {
                 Some(cli.connect_timeout),
                 jump_hosts,
                 ssh_password.clone(),
-                ssh_connection_config,
+                ssh_connection_config_resolver,
             )
             .await?;
 
@@ -309,10 +259,10 @@ pub async fn dispatch_command(cli: &Cli, ctx: &AppContext) -> Result<i32> {
                 recursive: *recursive,
                 ssh_config: Some(&ctx.ssh_config),
                 jump_hosts,
-                address_family: resolve_address_family(
+                ssh_connection_config_resolver: build_ssh_connection_config_resolver(
                     cli,
                     ctx,
-                    hostname_for_ssh_config.as_deref(),
+                    ctx.cluster_name.as_deref().or(cli.cluster.as_deref()),
                 ),
             };
             upload_file(params, source, destination).await?;
@@ -348,10 +298,10 @@ pub async fn dispatch_command(cli: &Cli, ctx: &AppContext) -> Result<i32> {
                 recursive: *recursive,
                 ssh_config: Some(&ctx.ssh_config),
                 jump_hosts,
-                address_family: resolve_address_family(
+                ssh_connection_config_resolver: build_ssh_connection_config_resolver(
                     cli,
                     ctx,
-                    hostname_for_ssh_config.as_deref(),
+                    ctx.cluster_name.as_deref().or(cli.cluster.as_deref()),
                 ),
             };
             download_file(params, source, destination).await?;
@@ -479,8 +429,13 @@ async fn handle_interactive_command(
 
     // Build SSH connection config with keepalive settings for interactive mode
     let effective_cluster_name = ctx.cluster_name.as_deref().or(cli.cluster.as_deref());
-    let ssh_connection_config =
-        build_ssh_connection_config(cli, ctx, hostname.as_deref(), effective_cluster_name);
+    let ssh_connection_config_resolver =
+        build_ssh_connection_config_resolver(cli, ctx, effective_cluster_name);
+    let config_hostname = hostname
+        .as_deref()
+        .or_else(|| ctx.nodes.first().map(|node| node.host.as_str()))
+        .unwrap_or("*");
+    let ssh_connection_config = ssh_connection_config_resolver.resolve_for_host(config_hostname);
 
     let interactive_cmd = InteractiveCommand {
         single_node: merged_mode.0,
@@ -559,8 +514,14 @@ async fn handle_exec_command(
 
         // Build SSH connection config with keepalive settings for SSH mode interactive session
         let effective_cluster_name = ctx.cluster_name.as_deref().or(cli.cluster.as_deref());
+        let ssh_connection_config_resolver =
+            build_ssh_connection_config_resolver(cli, ctx, effective_cluster_name);
+        let config_hostname = hostname
+            .as_deref()
+            .or_else(|| ctx.nodes.first().map(|node| node.host.as_str()))
+            .unwrap_or("*");
         let ssh_connection_config =
-            build_ssh_connection_config(cli, ctx, hostname.as_deref(), effective_cluster_name);
+            ssh_connection_config_resolver.resolve_for_host(config_hostname);
 
         let interactive_cmd = InteractiveCommand {
             single_node: true,
@@ -653,9 +614,18 @@ async fn handle_exec_command(
             tracing::info!("Using jump host: {}", jh);
         }
 
-        // Build SSH connection config with keepalive settings for exec mode
-        let ssh_connection_config =
-            build_ssh_connection_config(cli, ctx, hostname.as_deref(), effective_cluster_name);
+        // Build SSH connection config resolver for exec mode. Each executor
+        // task resolves it against that task's node host.
+        let ssh_connection_config_resolver =
+            build_ssh_connection_config_resolver(cli, ctx, effective_cluster_name);
+        let forwarding_config_hostname = ctx
+            .nodes
+            .first()
+            .map(|node| node.host.as_str())
+            .or(hostname.as_deref())
+            .unwrap_or("*");
+        let forwarding_ssh_connection_config =
+            ssh_connection_config_resolver.resolve_for_host(forwarding_config_hostname);
 
         let params = ExecuteCommandParams {
             nodes: ctx.nodes.clone(),
@@ -676,7 +646,7 @@ async fn handle_exec_command(
             connect_timeout: Some(cli.connect_timeout),
             jump_hosts: jump_hosts.as_deref(),
             port_forwards: if cli.has_port_forwards() {
-                Some(cli.parse_port_forwards(ssh_connection_config.address_family)?)
+                Some(cli.parse_port_forwards(forwarding_ssh_connection_config.address_family)?)
             } else {
                 None
             },
@@ -686,7 +656,7 @@ async fn handle_exec_command(
             batch: cli.batch,
             fail_fast: cli.fail_fast,
             ssh_config: Some(&ctx.ssh_config),
-            ssh_connection_config,
+            ssh_connection_config_resolver,
         };
         execute_command(params).await
     }

--- a/src/commands/download.rs
+++ b/src/commands/download.rs
@@ -60,7 +60,7 @@ pub async fn download_file(
     )
     .with_jump_hosts(params.jump_hosts.clone())
     .with_ssh_password(params.ssh_password.clone())
-    .with_address_family(params.address_family);
+    .with_ssh_connection_config_resolver(params.ssh_connection_config_resolver.clone());
     if let Some(ssh_config) = params.ssh_config {
         executor = executor.with_ssh_config(Some(ssh_config.clone()));
     }
@@ -102,6 +102,9 @@ pub async fn download_file(
         // Download the entire directory from each node
         for node in &params.nodes {
             let node_dir = validated_destination.join(node.to_string());
+            let ssh_connection_config = params
+                .ssh_connection_config_resolver
+                .resolve_for_host(&node.host);
 
             println!(
                 "\n{} {} {} {} {:?}",
@@ -125,7 +128,8 @@ pub async fn download_file(
                 None,                         // Use default connect timeout
                 params.ssh_config,            // Pass ssh_config for ProxyJump resolution
                 params.ssh_password.clone(),
-                params.address_family,
+                &ssh_connection_config,
+                &params.ssh_connection_config_resolver,
             )
             .await;
 

--- a/src/commands/exec.rs
+++ b/src/commands/exec.rs
@@ -22,7 +22,7 @@ use crate::node::Node;
 use crate::security::{Password, SudoPassword};
 use crate::ssh::SshConfig;
 use crate::ssh::known_hosts::StrictHostKeyChecking;
-use crate::ssh::tokio_client::SshConnectionConfig;
+use crate::ssh::tokio_client::SshConnectionConfigResolver;
 use crate::ui::OutputFormatter;
 use crate::utils::output::save_outputs_to_files;
 
@@ -54,8 +54,8 @@ pub struct ExecuteCommandParams<'a> {
     pub batch: bool,
     pub fail_fast: bool,
     pub ssh_config: Option<&'a SshConfig>,
-    /// SSH connection configuration (keepalive settings)
-    pub ssh_connection_config: SshConnectionConfig,
+    /// Per-host SSH connection configuration resolver.
+    pub ssh_connection_config_resolver: SshConnectionConfigResolver,
 }
 
 pub async fn execute_command(params: ExecuteCommandParams<'_>) -> Result<()> {
@@ -97,8 +97,11 @@ async fn execute_command_with_forwarding(params: ExecuteCommandParams<'_>) -> Re
     // Create forwarding manager. The resolved address family narrows which
     // resolved target address bssh names in each `direct-tcpip` request; the
     // listener side was already constrained when the spec was parsed.
+    let ssh_connection_config = params
+        .ssh_connection_config_resolver
+        .resolve_for_host(&node.host);
     let forwarding_config = ForwardingConfig {
-        address_family: params.ssh_connection_config.address_family,
+        address_family: ssh_connection_config.address_family,
         ..ForwardingConfig::default()
     };
     let mut manager = ForwardingManager::new(forwarding_config);
@@ -175,7 +178,7 @@ async fn execute_command_with_forwarding(params: ExecuteCommandParams<'_>) -> Re
             &node.username,
             auth_method,
             server_check,
-            &params.ssh_connection_config,
+            &ssh_connection_config,
         )
         .await?,
     );
@@ -245,7 +248,7 @@ async fn execute_command_without_forwarding(params: ExecuteCommandParams<'_>) ->
     .with_batch_mode(params.batch)
     .with_fail_fast(params.fail_fast)
     .with_ssh_config(params.ssh_config.cloned())
-    .with_ssh_connection_config(params.ssh_connection_config);
+    .with_ssh_connection_config_resolver(params.ssh_connection_config_resolver);
 
     // Set keychain usage if on macOS
     #[cfg(target_os = "macos")]

--- a/src/commands/ping.rs
+++ b/src/commands/ping.rs
@@ -22,7 +22,7 @@ use crate::executor::{ExecutionResult, ParallelExecutor};
 use crate::node::Node;
 use crate::security::Password;
 use crate::ssh::known_hosts::StrictHostKeyChecking;
-use crate::ssh::tokio_client::SshConnectionConfig;
+use crate::ssh::tokio_client::SshConnectionConfigResolver;
 use crate::ui::OutputFormatter;
 
 /// Exit code reported when bssh itself could not complete the connectivity
@@ -94,9 +94,9 @@ impl PingOutcome {
 
 /// Test connectivity to every node.
 ///
-/// `ssh_connection_config` carries the resolved keepalive, compression, and
-/// address family settings so `bssh ping -6` tests the same address family the
-/// real connection would use.
+/// `ssh_connection_config_resolver` carries the keepalive, compression, and
+/// address family sources so every ping target resolves settings against its
+/// own ssh_config Host block.
 ///
 /// Returns the per-host tally as a [`PingOutcome`]; the caller turns it into the
 /// process exit status. An `Err` means bssh failed before it could evaluate any
@@ -115,7 +115,7 @@ pub async fn ping_nodes(
     connect_timeout: Option<u64>,
     jump_hosts: Option<String>,
     ssh_password: Option<Arc<Password>>,
-    ssh_connection_config: SshConnectionConfig,
+    ssh_connection_config_resolver: SshConnectionConfigResolver,
 ) -> Result<PingOutcome> {
     println!(
         "{}",
@@ -140,7 +140,7 @@ pub async fn ping_nodes(
     .with_connect_timeout(connect_timeout)
     .with_jump_hosts(jump_hosts)
     .with_ssh_password(ssh_password)
-    .with_ssh_connection_config(ssh_connection_config);
+    .with_ssh_connection_config_resolver(ssh_connection_config_resolver);
 
     #[cfg(target_os = "macos")]
     let executor = executor.with_keychain(use_keychain);

--- a/src/commands/upload.rs
+++ b/src/commands/upload.rs
@@ -22,7 +22,7 @@ use crate::node::Node;
 use crate::security::Password;
 use crate::ssh::SshConfig;
 use crate::ssh::known_hosts::StrictHostKeyChecking;
-use crate::ssh::tokio_client::AddressFamily;
+use crate::ssh::tokio_client::SshConnectionConfigResolver;
 use crate::ui::OutputFormatter;
 use crate::utils::fs::{format_bytes, resolve_source_files};
 
@@ -41,11 +41,8 @@ pub struct FileTransferParams<'a> {
     pub ssh_config: Option<&'a SshConfig>,
     /// Jump hosts specification for connections.
     pub jump_hosts: Option<String>,
-    /// Resolved address family preference (`-4`/`-6`, ssh_config
-    /// `AddressFamily`). SFTP transfers never carried a full
-    /// `SshConnectionConfig`, so only the family is threaded down to the
-    /// connect call.
-    pub address_family: AddressFamily,
+    /// Per-host SSH connection configuration resolver.
+    pub ssh_connection_config_resolver: SshConnectionConfigResolver,
 }
 
 pub async fn upload_file(
@@ -102,7 +99,7 @@ pub async fn upload_file(
     )
     .with_jump_hosts(params.jump_hosts.clone())
     .with_ssh_password(params.ssh_password.clone())
-    .with_address_family(params.address_family);
+    .with_ssh_connection_config_resolver(params.ssh_connection_config_resolver.clone());
     if let Some(ssh_config) = params.ssh_config {
         executor = executor.with_ssh_config(Some(ssh_config.clone()));
     }

--- a/src/executor/connection_manager.rs
+++ b/src/executor/connection_manager.rs
@@ -24,7 +24,7 @@ use crate::ssh::{
     SshClient, SshConfig,
     client::{CommandResult, ConnectionConfig},
     known_hosts::StrictHostKeyChecking,
-    tokio_client::{AddressFamily, SshConnectionConfig},
+    tokio_client::{SshConnectionConfig, SshConnectionConfigResolver},
 };
 
 /// Configuration for node execution.
@@ -49,6 +49,9 @@ pub(crate) struct ExecutionConfig<'a> {
     /// Threaded through to `Client::connect_with_ssh_config` so user-configured
     /// `server_alive_interval` / `server_alive_count_max` apply to exec mode.
     pub ssh_connection_config: Option<&'a SshConnectionConfig>,
+    /// Per-host resolver used by jump chains so each hop consults its own
+    /// ssh_config Host block instead of inheriting the destination's settings.
+    pub ssh_connection_config_resolver: Option<&'a SshConnectionConfigResolver>,
 }
 
 /// Execute a command on a node with jump host support.
@@ -86,6 +89,7 @@ pub(crate) async fn execute_on_node_with_jump_hosts(
         connect_timeout_seconds: config.connect_timeout,
         jump_hosts_spec: effective_jump_hosts,
         ssh_connection_config: config.ssh_connection_config,
+        ssh_connection_config_resolver: config.ssh_connection_config_resolver,
         ssh_password: config.ssh_password.clone(),
     };
 
@@ -140,7 +144,8 @@ pub(crate) async fn upload_to_node(
     connect_timeout_seconds: Option<u64>,
     ssh_config: Option<&SshConfig>,
     pre_collected_password: Option<Arc<Password>>,
-    address_family: AddressFamily,
+    ssh_connection_config: &SshConnectionConfig,
+    ssh_connection_config_resolver: &SshConnectionConfigResolver,
 ) -> Result<()> {
     let mut client = SshClient::new(node.host.clone(), node.port, node.username.clone());
 
@@ -169,7 +174,8 @@ pub(crate) async fn upload_to_node(
                 effective_jump_hosts,
                 connect_timeout_seconds,
                 pre_collected_password,
-                address_family,
+                ssh_connection_config,
+                Some(ssh_connection_config_resolver),
             )
             .await
     } else {
@@ -184,7 +190,8 @@ pub(crate) async fn upload_to_node(
                 effective_jump_hosts,
                 connect_timeout_seconds,
                 pre_collected_password,
-                address_family,
+                ssh_connection_config,
+                Some(ssh_connection_config_resolver),
             )
             .await
     }
@@ -204,7 +211,8 @@ pub(crate) async fn download_from_node(
     connect_timeout_seconds: Option<u64>,
     ssh_config: Option<&SshConfig>,
     pre_collected_password: Option<Arc<Password>>,
-    address_family: AddressFamily,
+    ssh_connection_config: &SshConnectionConfig,
+    ssh_connection_config_resolver: &SshConnectionConfigResolver,
 ) -> Result<PathBuf> {
     let mut client = SshClient::new(node.host.clone(), node.port, node.username.clone());
 
@@ -233,7 +241,8 @@ pub(crate) async fn download_from_node(
             effective_jump_hosts,
             connect_timeout_seconds,
             pre_collected_password,
-            address_family,
+            ssh_connection_config,
+            Some(ssh_connection_config_resolver),
         )
         .await?;
 
@@ -254,7 +263,8 @@ pub async fn download_dir_from_node(
     connect_timeout_seconds: Option<u64>,
     ssh_config: Option<&SshConfig>,
     pre_collected_password: Option<Arc<Password>>,
-    address_family: AddressFamily,
+    ssh_connection_config: &SshConnectionConfig,
+    ssh_connection_config_resolver: &SshConnectionConfigResolver,
 ) -> Result<PathBuf> {
     let mut client = SshClient::new(node.host.clone(), node.port, node.username.clone());
 
@@ -281,7 +291,8 @@ pub async fn download_dir_from_node(
             effective_jump_hosts,
             connect_timeout_seconds,
             pre_collected_password,
-            address_family,
+            ssh_connection_config,
+            Some(ssh_connection_config_resolver),
         )
         .await?;
 

--- a/src/executor/execution_strategy.rs
+++ b/src/executor/execution_strategy.rs
@@ -23,7 +23,7 @@ use tokio::sync::Semaphore;
 
 use crate::node::Node;
 use crate::security::Password;
-use crate::ssh::tokio_client::AddressFamily;
+use crate::ssh::tokio_client::{SshConnectionConfig, SshConnectionConfigResolver};
 
 use super::connection_manager::{
     ExecutionConfig, download_from_node, execute_on_node_with_jump_hosts, upload_to_node,
@@ -120,7 +120,8 @@ pub(crate) async fn upload_file_task(
     connect_timeout: Option<u64>,
     ssh_config: Option<crate::ssh::SshConfig>,
     ssh_password: Option<Arc<Password>>,
-    address_family: AddressFamily,
+    ssh_connection_config: SshConnectionConfig,
+    ssh_connection_config_resolver: SshConnectionConfigResolver,
     semaphore: Arc<Semaphore>,
     pb: ProgressBar,
 ) -> UploadResult {
@@ -149,7 +150,8 @@ pub(crate) async fn upload_file_task(
         connect_timeout,
         ssh_config.as_ref(),
         ssh_password,
-        address_family,
+        &ssh_connection_config,
+        &ssh_connection_config_resolver,
     )
     .await;
 
@@ -186,7 +188,8 @@ pub(crate) async fn download_file_task(
     connect_timeout: Option<u64>,
     ssh_config: Option<crate::ssh::SshConfig>,
     ssh_password: Option<Arc<Password>>,
-    address_family: AddressFamily,
+    ssh_connection_config: SshConnectionConfig,
+    ssh_connection_config_resolver: SshConnectionConfigResolver,
     semaphore: Arc<Semaphore>,
     pb: ProgressBar,
 ) -> DownloadResult {
@@ -227,7 +230,8 @@ pub(crate) async fn download_file_task(
         connect_timeout,
         ssh_config.as_ref(),
         ssh_password,
-        address_family,
+        &ssh_connection_config,
+        &ssh_connection_config_resolver,
     )
     .await;
 

--- a/src/executor/parallel.rs
+++ b/src/executor/parallel.rs
@@ -25,7 +25,7 @@ use crate::node::Node;
 use crate::security::{Password, SudoPassword};
 use crate::ssh::SshConfig;
 use crate::ssh::known_hosts::StrictHostKeyChecking;
-use crate::ssh::tokio_client::{AddressFamily, SshConnectionConfig};
+use crate::ssh::tokio_client::{AddressFamily, SshConnectionConfig, SshConnectionConfigResolver};
 
 use super::connection_manager::{ExecutionConfig, download_from_node};
 use super::execution_strategy::{
@@ -57,8 +57,8 @@ pub struct ParallelExecutor {
     pub(crate) batch: bool,
     pub(crate) fail_fast: bool,
     pub(crate) ssh_config: Option<SshConfig>,
-    /// SSH connection configuration (keepalive settings)
-    pub(crate) ssh_connection_config: SshConnectionConfig,
+    /// Per-host SSH connection configuration resolver.
+    pub(crate) ssh_connection_config_resolver: SshConnectionConfigResolver,
 }
 
 impl ParallelExecutor {
@@ -96,7 +96,7 @@ impl ParallelExecutor {
             batch: false,
             fail_fast: false,
             ssh_config: None,
-            ssh_connection_config: SshConnectionConfig::default(),
+            ssh_connection_config_resolver: SshConnectionConfigResolver::default(),
         }
     }
 
@@ -125,7 +125,7 @@ impl ParallelExecutor {
             batch: false,
             fail_fast: false,
             ssh_config: None,
-            ssh_connection_config: SshConnectionConfig::default(),
+            ssh_connection_config_resolver: SshConnectionConfigResolver::default(),
         }
     }
 
@@ -155,7 +155,7 @@ impl ParallelExecutor {
             batch: false,
             fail_fast: false,
             ssh_config: None,
-            ssh_connection_config: SshConnectionConfig::default(),
+            ssh_connection_config_resolver: SshConnectionConfigResolver::default(),
         }
     }
 
@@ -253,7 +253,16 @@ impl ParallelExecutor {
     ///     .with_ssh_connection_config(config);
     /// ```
     pub fn with_ssh_connection_config(mut self, config: SshConnectionConfig) -> Self {
-        self.ssh_connection_config = config;
+        self.ssh_connection_config_resolver = SshConnectionConfigResolver::fixed(config);
+        self
+    }
+
+    /// Set a per-host SSH connection configuration resolver.
+    pub fn with_ssh_connection_config_resolver(
+        mut self,
+        resolver: SshConnectionConfigResolver,
+    ) -> Self {
+        self.ssh_connection_config_resolver = resolver;
         self
     }
 
@@ -265,8 +274,15 @@ impl ParallelExecutor {
     /// that never build a full `SshConnectionConfig` (the SFTP paths) can
     /// still honor the flag.
     pub fn with_address_family(mut self, family: AddressFamily) -> Self {
-        self.ssh_connection_config.address_family = family;
+        self.ssh_connection_config_resolver = self
+            .ssh_connection_config_resolver
+            .with_cli_address_family(Some(family));
         self
+    }
+
+    pub(crate) fn connection_config_for_node(&self, node: &Node) -> SshConnectionConfig {
+        self.ssh_connection_config_resolver
+            .resolve_for_host(&node.host)
     }
 
     /// Execute a command on all nodes in parallel.
@@ -304,7 +320,8 @@ impl ParallelExecutor {
                 let pb = setup_progress_bar(&multi_progress, &node, style.clone(), "Connecting...");
 
                 let ssh_config_ref = self.ssh_config.clone();
-                let ssh_connection_config = self.ssh_connection_config.clone();
+                let ssh_connection_config_resolver = self.ssh_connection_config_resolver.clone();
+                let ssh_connection_config = self.connection_config_for_node(&node);
 
                 tokio::spawn(async move {
                     let config = ExecutionConfig {
@@ -321,6 +338,7 @@ impl ParallelExecutor {
                         ssh_password: ssh_password.clone(),
                         ssh_config: ssh_config_ref.as_ref(),
                         ssh_connection_config: Some(&ssh_connection_config),
+                        ssh_connection_config_resolver: Some(&ssh_connection_config_resolver),
                     };
 
                     execute_command_task(node, command, config, semaphore, pb).await
@@ -413,7 +431,7 @@ impl ParallelExecutor {
             Vec::with_capacity(self.nodes.len());
 
         let ssh_config_for_tasks = self.ssh_config.clone();
-        let ssh_connection_config_for_tasks = self.ssh_connection_config.clone();
+        let ssh_connection_config_resolver_for_tasks = self.ssh_connection_config_resolver.clone();
 
         // Spawn tasks for each node
         for node in &self.nodes {
@@ -434,7 +452,9 @@ impl ParallelExecutor {
             let pb = setup_progress_bar(&multi_progress, &node, style.clone(), "Connecting...");
             let mut cancel_rx = cancel_rx.clone();
             let ssh_config_ref = ssh_config_for_tasks.clone();
-            let ssh_connection_config_ref = ssh_connection_config_for_tasks.clone();
+            let ssh_connection_config_resolver_ref =
+                ssh_connection_config_resolver_for_tasks.clone();
+            let ssh_connection_config = self.connection_config_for_node(&node);
 
             let handle = tokio::spawn(async move {
                 // Check if already cancelled before acquiring semaphore
@@ -499,7 +519,8 @@ impl ParallelExecutor {
                     sudo_password: sudo_password.clone(),
                     ssh_password: ssh_password.clone(),
                     ssh_config: ssh_config_ref.as_ref(),
-                    ssh_connection_config: Some(&ssh_connection_config_ref),
+                    ssh_connection_config: Some(&ssh_connection_config),
+                    ssh_connection_config_resolver: Some(&ssh_connection_config_resolver_ref),
                 };
 
                 // Execute the command (keeping the permit alive)
@@ -672,7 +693,8 @@ impl ParallelExecutor {
                 let pb = setup_progress_bar(&multi_progress, &node, style.clone(), "Connecting...");
 
                 let ssh_config_ref = self.ssh_config.clone();
-                let address_family = self.ssh_connection_config.address_family;
+                let ssh_connection_config_resolver = self.ssh_connection_config_resolver.clone();
+                let ssh_connection_config = self.connection_config_for_node(&node);
 
                 tokio::spawn(upload_file_task(
                     node,
@@ -686,7 +708,8 @@ impl ParallelExecutor {
                     connect_timeout,
                     ssh_config_ref,
                     ssh_password,
-                    address_family,
+                    ssh_connection_config,
+                    ssh_connection_config_resolver,
                     semaphore,
                     pb,
                 ))
@@ -788,7 +811,8 @@ impl ParallelExecutor {
                 let semaphore = Arc::clone(&semaphore);
                 let pb = setup_progress_bar(&multi_progress, &node, style.clone(), "Connecting...");
                 let ssh_config_ref = self.ssh_config.clone();
-                let address_family = self.ssh_connection_config.address_family;
+                let ssh_connection_config_resolver = self.ssh_connection_config_resolver.clone();
+                let ssh_connection_config = self.connection_config_for_node(&node);
 
                 tokio::spawn(download_file_task(
                     node,
@@ -802,7 +826,8 @@ impl ParallelExecutor {
                     connect_timeout,
                     ssh_config_ref,
                     ssh_password,
-                    address_family,
+                    ssh_connection_config,
+                    ssh_connection_config_resolver,
                     semaphore,
                     pb,
                 ))
@@ -925,7 +950,9 @@ impl ParallelExecutor {
                     let connect_timeout = self.connect_timeout;
                     let ssh_config_ref = self.ssh_config.clone();
                     let ssh_password = self.ssh_password.clone();
-                    let address_family = self.ssh_connection_config.address_family;
+                    let ssh_connection_config_resolver =
+                        self.ssh_connection_config_resolver.clone();
+                    let ssh_connection_config = self.connection_config_for_node(&node);
 
                     tokio::spawn(async move {
                         let _permit = match semaphore.acquire().await {
@@ -953,7 +980,8 @@ impl ParallelExecutor {
                             connect_timeout,
                             ssh_config_ref.as_ref(),
                             ssh_password,
-                            address_family,
+                            &ssh_connection_config,
+                            &ssh_connection_config_resolver,
                         )
                         .await;
 
@@ -1180,7 +1208,8 @@ impl ParallelExecutor {
             let sudo_password = self.sudo_password.clone();
             let ssh_password = self.ssh_password.clone();
             let semaphore = Arc::clone(&semaphore);
-            let ssh_connection_config = self.ssh_connection_config.clone();
+            let ssh_connection_config_resolver = self.ssh_connection_config_resolver.clone();
+            let ssh_connection_config = self.connection_config_for_node(node);
 
             let handle = tokio::spawn(async move {
                 // Use defer pattern to ensure cleanup even on panic
@@ -1227,6 +1256,7 @@ impl ParallelExecutor {
                     connect_timeout_seconds: connect_timeout,
                     jump_hosts_spec: jump_hosts.as_deref(),
                     ssh_connection_config: Some(&ssh_connection_config),
+                    ssh_connection_config_resolver: Some(&ssh_connection_config_resolver),
                     ssh_password: ssh_password.clone(),
                 };
 
@@ -1780,5 +1810,54 @@ impl ParallelExecutor {
         }
 
         self.collect_results(results.into_iter().map(Ok).collect())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ssh::SshConfig;
+
+    #[test]
+    fn connection_config_for_node_resolves_each_node_host_block() {
+        let ssh_config = SshConfig::parse(
+            r#"
+Host v4node
+    AddressFamily inet
+    Compression yes
+    ServerAliveInterval 11
+    ServerAliveCountMax 2
+
+Host v6node
+    AddressFamily inet6
+    Compression no
+    ServerAliveInterval 22
+    ServerAliveCountMax 4
+"#,
+        )
+        .expect("valid ssh_config");
+
+        let nodes = vec![
+            Node::new("v4node".to_string(), 22, "user".to_string()),
+            Node::new("v6node".to_string(), 22, "user".to_string()),
+        ];
+        let resolver = SshConnectionConfigResolver::new()
+            .with_ssh_config(Some(ssh_config))
+            .with_yaml_keepalive_interval(Some(30))
+            .with_yaml_keepalive_max(Some(3));
+        let executor = ParallelExecutor::new(nodes.clone(), 2, None)
+            .with_ssh_connection_config_resolver(resolver);
+
+        let v4 = executor.connection_config_for_node(&nodes[0]);
+        assert_eq!(v4.address_family, AddressFamily::V4);
+        assert!(v4.compression);
+        assert_eq!(v4.keepalive_interval, Some(11));
+        assert_eq!(v4.keepalive_max, 2);
+
+        let v6 = executor.connection_config_for_node(&nodes[1]);
+        assert_eq!(v6.address_family, AddressFamily::V6);
+        assert!(!v6.compression);
+        assert_eq!(v6.keepalive_interval, Some(22));
+        assert_eq!(v6.keepalive_max, 4);
     }
 }

--- a/src/jump/chain.rs
+++ b/src/jump/chain.rs
@@ -26,7 +26,7 @@ use super::parser::{JumpHost, get_max_jump_hosts};
 use super::rate_limiter::ConnectionRateLimiter;
 use crate::security::Password;
 use crate::ssh::known_hosts::StrictHostKeyChecking;
-use crate::ssh::tokio_client::{AuthMethod, SshConnectionConfig};
+use crate::ssh::tokio_client::{AuthMethod, SshConnectionConfig, SshConnectionConfigResolver};
 use anyhow::{Context, Result};
 use std::path::Path;
 use std::sync::Arc;
@@ -69,6 +69,8 @@ pub struct JumpHostChain {
     auth_mutex: Arc<Mutex<()>>,
     /// SSH connection configuration (keepalive settings)
     ssh_connection_config: SshConnectionConfig,
+    /// Per-host SSH connection configuration resolver.
+    ssh_connection_config_resolver: Option<SshConnectionConfigResolver>,
     /// Pre-collected SSH password (from the dispatcher's single up-front prompt).
     /// When `use_password` is set on a per-call basis, this is consumed by every
     /// jump-host auth step instead of prompting per-call, which would otherwise
@@ -111,6 +113,7 @@ impl JumpHostChain {
             max_connection_age: Duration::from_secs(1800), // 30 minutes
             auth_mutex: Arc::new(Mutex::new(())),
             ssh_connection_config: SshConnectionConfig::default(),
+            ssh_connection_config_resolver: None,
             ssh_password: None,
         }
     }
@@ -130,7 +133,24 @@ impl JumpHostChain {
     /// idle connection timeouts during jump host operations.
     pub fn with_ssh_connection_config(mut self, config: SshConnectionConfig) -> Self {
         self.ssh_connection_config = config;
+        self.ssh_connection_config_resolver = None;
         self
+    }
+
+    /// Set per-host SSH connection configuration resolver.
+    pub fn with_ssh_connection_config_resolver(
+        mut self,
+        resolver: SshConnectionConfigResolver,
+    ) -> Self {
+        self.ssh_connection_config_resolver = Some(resolver);
+        self
+    }
+
+    fn connection_config_for_host(&self, host: &str) -> SshConnectionConfig {
+        self.ssh_connection_config_resolver
+            .as_ref()
+            .map(|resolver| resolver.resolve_for_host(host))
+            .unwrap_or_else(|| self.ssh_connection_config.clone())
     }
 
     /// Create a direct connection chain (no jump hosts)
@@ -210,6 +230,7 @@ impl JumpHostChain {
         }
 
         if self.is_direct() {
+            let ssh_connection_config = self.connection_config_for_host(destination_host);
             chain_connection::connect_direct(
                 destination_host,
                 destination_port,
@@ -218,7 +239,7 @@ impl JumpHostChain {
                 dest_strict_mode,
                 self.connect_timeout,
                 &self.rate_limiter,
-                &self.ssh_connection_config,
+                &ssh_connection_config,
             )
             .await
         } else {
@@ -280,6 +301,7 @@ impl JumpHostChain {
 
         // Step 2: Chain through intermediate jump hosts
         for (i, jump_host) in self.jump_hosts.iter().skip(1).enumerate() {
+            let ssh_connection_config = self.connection_config_for_host(&jump_host.host);
             debug!(
                 "Connecting to intermediate jump host {} of {}: {}",
                 i + 2,
@@ -298,7 +320,7 @@ impl JumpHostChain {
                 self.connect_timeout,
                 &self.rate_limiter,
                 &self.auth_mutex,
-                &self.ssh_connection_config,
+                &ssh_connection_config,
             )
             .await
             .with_context(|| intermediate_jump_hop_context(jump_host, i + 2))?;
@@ -307,6 +329,7 @@ impl JumpHostChain {
         }
 
         // Step 3: Connect to final destination through the last jump host
+        let ssh_connection_config = self.connection_config_for_host(destination_host);
         let final_client = tunnel::connect_to_destination(
             &current_client,
             destination_host,
@@ -316,7 +339,7 @@ impl JumpHostChain {
             dest_strict_mode.unwrap_or(StrictHostKeyChecking::AcceptNew),
             self.connect_timeout,
             &self.rate_limiter,
-            &self.ssh_connection_config,
+            &ssh_connection_config,
         )
         .await
         .with_context(|| {
@@ -355,6 +378,7 @@ impl JumpHostChain {
         use_password: bool,
     ) -> Result<crate::ssh::tokio_client::Client> {
         let jump_host = &self.jump_hosts[0];
+        let ssh_connection_config = self.connection_config_for_host(&jump_host.host);
 
         debug!(
             "Connecting to first jump host: {} ({}:{})",
@@ -405,7 +429,7 @@ impl JumpHostChain {
                 &effective_user,
                 auth_method,
                 check_method,
-                &self.ssh_connection_config,
+                &ssh_connection_config,
             ),
         )
         .await
@@ -458,6 +482,8 @@ fn intermediate_jump_hop_context(jump_host: &JumpHost, hop: usize) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::ssh::SshConfig;
+    use crate::ssh::tokio_client::AddressFamily;
 
     #[test]
     fn test_jump_host_chain_creation() {
@@ -509,5 +535,41 @@ mod tests {
 
         assert!(message.contains("hop 3"));
         assert!(message.contains("relay.example.com"));
+    }
+
+    #[test]
+    fn test_chain_resolves_connection_config_per_jump_host() {
+        let ssh_config = SshConfig::parse(
+            r#"
+Host bastion
+    AddressFamily inet
+    Compression yes
+    ServerAliveInterval 11
+    ServerAliveCountMax 2
+
+Host target
+    AddressFamily inet6
+    Compression no
+    ServerAliveInterval 22
+    ServerAliveCountMax 4
+"#,
+        )
+        .expect("valid ssh_config");
+        let resolver = SshConnectionConfigResolver::new().with_ssh_config(Some(ssh_config));
+
+        let chain = JumpHostChain::new(vec![JumpHost::new("bastion".to_string(), None, None)])
+            .with_ssh_connection_config_resolver(resolver);
+
+        let bastion = chain.connection_config_for_host("bastion");
+        assert_eq!(bastion.address_family, AddressFamily::V4);
+        assert!(bastion.compression);
+        assert_eq!(bastion.keepalive_interval, Some(11));
+        assert_eq!(bastion.keepalive_max, 2);
+
+        let target = chain.connection_config_for_host("target");
+        assert_eq!(target.address_family, AddressFamily::V6);
+        assert!(!target.compression);
+        assert_eq!(target.keepalive_interval, Some(22));
+        assert_eq!(target.keepalive_max, 4);
     }
 }

--- a/src/ssh/client/command.rs
+++ b/src/ssh/client/command.rs
@@ -76,6 +76,7 @@ impl SshClient {
             connect_timeout_seconds: None, // Use default
             jump_hosts_spec: None,         // No jump hosts
             ssh_connection_config: None,
+            ssh_connection_config_resolver: None,
             ssh_password,
         };
 
@@ -118,6 +119,7 @@ impl SshClient {
                 config.use_password,
                 config.connect_timeout_seconds,
                 config.ssh_connection_config,
+                config.ssh_connection_config_resolver,
                 config.ssh_password.clone(),
             )
             .await?;
@@ -231,6 +233,7 @@ impl SshClient {
                 config.use_password,
                 config.connect_timeout_seconds,
                 config.ssh_connection_config,
+                config.ssh_connection_config_resolver,
                 config.ssh_password.clone(),
             )
             .await?;
@@ -345,6 +348,7 @@ impl SshClient {
                 config.use_password,
                 config.connect_timeout_seconds,
                 config.ssh_connection_config,
+                config.ssh_connection_config_resolver,
                 config.ssh_password.clone(),
             )
             .await?;

--- a/src/ssh/client/config.rs
+++ b/src/ssh/client/config.rs
@@ -14,7 +14,7 @@
 
 use crate::security::Password;
 use crate::ssh::known_hosts::StrictHostKeyChecking;
-use crate::ssh::tokio_client::SshConnectionConfig;
+use crate::ssh::tokio_client::{SshConnectionConfig, SshConnectionConfigResolver};
 use std::path::Path;
 use std::sync::Arc;
 
@@ -32,6 +32,8 @@ pub struct ConnectionConfig<'a> {
     pub jump_hosts_spec: Option<&'a str>,
     /// SSH keepalive / inactivity settings. `None` falls back to defaults.
     pub ssh_connection_config: Option<&'a SshConnectionConfig>,
+    /// Per-host connection settings resolver used by jump chains.
+    pub ssh_connection_config_resolver: Option<&'a SshConnectionConfigResolver>,
     /// Pre-collected SSH password shared with every per-node auth task.
     ///
     /// When `use_password` is `true`, this MUST be `Some(_)`; the dispatcher

--- a/src/ssh/client/connection.rs
+++ b/src/ssh/client/connection.rs
@@ -16,7 +16,9 @@ use super::core::SshClient;
 use crate::jump::{JumpHostChain, parse_jump_hosts};
 use crate::security::Password;
 use crate::ssh::known_hosts::StrictHostKeyChecking;
-use crate::ssh::tokio_client::{AuthMethod, Client, SshConnectionConfig};
+use crate::ssh::tokio_client::{
+    AuthMethod, Client, SshConnectionConfig, SshConnectionConfigResolver,
+};
 use anyhow::{Context, Result};
 use std::path::Path;
 use std::sync::Arc;
@@ -217,6 +219,7 @@ impl SshClient {
         use_password: bool,
         connect_timeout_seconds: Option<u64>,
         ssh_connection_config: Option<&SshConnectionConfig>,
+        ssh_connection_config_resolver: Option<&SshConnectionConfigResolver>,
         pre_collected_password: Option<Arc<Password>>,
     ) -> Result<Client> {
         // Create jump host chain with user-specified or default connect timeout
@@ -228,6 +231,9 @@ impl SshClient {
             .with_ssh_password(pre_collected_password);
         if let Some(cfg) = ssh_connection_config {
             chain = chain.with_ssh_connection_config(cfg.clone());
+        }
+        if let Some(resolver) = ssh_connection_config_resolver {
+            chain = chain.with_ssh_connection_config_resolver(resolver.clone());
         }
 
         // Connect through the chain
@@ -270,6 +276,7 @@ impl SshClient {
         use_password: bool,
         connect_timeout_seconds: Option<u64>,
         ssh_connection_config: Option<&SshConnectionConfig>,
+        ssh_connection_config_resolver: Option<&SshConnectionConfigResolver>,
         pre_collected_password: Option<Arc<Password>>,
     ) -> Result<Client> {
         if let Some(jump_spec) = jump_hosts_spec {
@@ -309,6 +316,7 @@ impl SshClient {
                     use_password,
                     connect_timeout_seconds,
                     ssh_connection_config,
+                    ssh_connection_config_resolver,
                     pre_collected_password,
                 )
                 .await

--- a/src/ssh/client/file_transfer.rs
+++ b/src/ssh/client/file_transfer.rs
@@ -15,7 +15,7 @@
 use super::core::SshClient;
 use crate::security::Password;
 use crate::ssh::known_hosts::StrictHostKeyChecking;
-use crate::ssh::tokio_client::{AddressFamily, Client, SshConnectionConfig};
+use crate::ssh::tokio_client::{Client, SshConnectionConfig, SshConnectionConfigResolver};
 use anyhow::{Context, Result};
 use std::path::Path;
 use std::sync::Arc;
@@ -333,7 +333,8 @@ impl SshClient {
         jump_hosts_spec: Option<&str>,
         connect_timeout_seconds: Option<u64>,
         pre_collected_password: Option<Arc<Password>>,
-        address_family: AddressFamily,
+        ssh_connection_config: &SshConnectionConfig,
+        ssh_connection_config_resolver: Option<&SshConnectionConfigResolver>,
     ) -> Result<()> {
         tracing::debug!(
             "Uploading file to {}:{} (jump hosts: {:?})",
@@ -351,7 +352,8 @@ impl SshClient {
                 jump_hosts_spec,
                 connect_timeout_seconds,
                 pre_collected_password,
-                address_family,
+                ssh_connection_config,
+                ssh_connection_config_resolver,
             )
             .await?;
 
@@ -413,7 +415,8 @@ impl SshClient {
         jump_hosts_spec: Option<&str>,
         connect_timeout_seconds: Option<u64>,
         pre_collected_password: Option<Arc<Password>>,
-        address_family: AddressFamily,
+        ssh_connection_config: &SshConnectionConfig,
+        ssh_connection_config_resolver: Option<&SshConnectionConfigResolver>,
     ) -> Result<()> {
         tracing::debug!(
             "Downloading file from {}:{} (jump hosts: {:?})",
@@ -431,7 +434,8 @@ impl SshClient {
                 jump_hosts_spec,
                 connect_timeout_seconds,
                 pre_collected_password,
-                address_family,
+                ssh_connection_config,
+                ssh_connection_config_resolver,
             )
             .await?;
 
@@ -489,7 +493,8 @@ impl SshClient {
         jump_hosts_spec: Option<&str>,
         connect_timeout_seconds: Option<u64>,
         pre_collected_password: Option<Arc<Password>>,
-        address_family: AddressFamily,
+        ssh_connection_config: &SshConnectionConfig,
+        ssh_connection_config_resolver: Option<&SshConnectionConfigResolver>,
     ) -> Result<()> {
         tracing::debug!(
             "Uploading directory to {}:{} (jump hosts: {:?})",
@@ -507,7 +512,8 @@ impl SshClient {
                 jump_hosts_spec,
                 connect_timeout_seconds,
                 pre_collected_password,
-                address_family,
+                ssh_connection_config,
+                ssh_connection_config_resolver,
             )
             .await?;
 
@@ -567,7 +573,8 @@ impl SshClient {
         jump_hosts_spec: Option<&str>,
         connect_timeout_seconds: Option<u64>,
         pre_collected_password: Option<Arc<Password>>,
-        address_family: AddressFamily,
+        ssh_connection_config: &SshConnectionConfig,
+        ssh_connection_config_resolver: Option<&SshConnectionConfigResolver>,
     ) -> Result<()> {
         tracing::debug!(
             "Downloading directory from {}:{} (jump hosts: {:?})",
@@ -585,7 +592,8 @@ impl SshClient {
                 jump_hosts_spec,
                 connect_timeout_seconds,
                 pre_collected_password,
-                address_family,
+                ssh_connection_config,
+                ssh_connection_config_resolver,
             )
             .await?;
 
@@ -702,7 +710,8 @@ impl SshClient {
         jump_hosts_spec: Option<&str>,
         connect_timeout_seconds: Option<u64>,
         pre_collected_password: Option<Arc<Password>>,
-        address_family: AddressFamily,
+        ssh_connection_config: &SshConnectionConfig,
+        ssh_connection_config_resolver: Option<&SshConnectionConfigResolver>,
     ) -> Result<Client> {
         // Determine authentication method
         // Note: use_keychain is set to false for file transfers to avoid prompts
@@ -719,12 +728,6 @@ impl SshClient {
 
         let strict_mode = strict_mode.unwrap_or(StrictHostKeyChecking::AcceptNew);
 
-        // SFTP transfers never carried a full `SshConnectionConfig`; they
-        // relied on `establish_connection` substituting the default. Building
-        // that default explicitly here lets the resolved address family ride
-        // along without changing any keepalive or compression behavior.
-        let connection_config = SshConnectionConfig::default().with_address_family(address_family);
-
         // Create client connection - either direct or through jump hosts.
         // Threading `pre_collected_password` here ensures jump-host auth
         // (when `--password` is combined with `-J`) consumes the dispatcher's
@@ -737,7 +740,8 @@ impl SshClient {
             use_agent,
             use_password,
             connect_timeout_seconds,
-            Some(&connection_config),
+            Some(ssh_connection_config),
+            ssh_connection_config_resolver,
             pre_collected_password,
         )
         .await

--- a/src/ssh/tokio_client/connection.rs
+++ b/src/ssh/tokio_client/connection.rs
@@ -25,6 +25,7 @@ use std::{fmt::Debug, io};
 
 use super::address_family::AddressFamily;
 use super::authentication::{AuthMethod, ServerCheckMethod};
+use crate::ssh::SshConfig;
 
 /// Default keepalive interval in seconds.
 ///
@@ -101,6 +102,129 @@ impl Default for SshConnectionConfig {
             compression: false,
             address_family: AddressFamily::Any,
         }
+    }
+}
+
+/// Resolves SSH connection settings for a concrete target host.
+///
+/// The dispatcher builds this once from the CLI flags, YAML defaults, and the
+/// parsed ssh_config. Per-node execution then calls
+/// [`resolve_for_host`](Self::resolve_for_host) at the last responsible moment
+/// so `Host <name>` blocks apply to the actual destination or jump hop instead
+/// of a once-per-dispatch fallback.
+#[derive(Debug, Clone, Default)]
+pub struct SshConnectionConfigResolver {
+    fixed_config: Option<SshConnectionConfig>,
+    ssh_config: Option<SshConfig>,
+    cli_keepalive_interval: Option<u64>,
+    cli_keepalive_max: Option<usize>,
+    yaml_keepalive_interval: Option<u64>,
+    yaml_keepalive_max: Option<usize>,
+    cli_address_family: Option<AddressFamily>,
+}
+
+impl SshConnectionConfigResolver {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn fixed(config: SshConnectionConfig) -> Self {
+        Self {
+            fixed_config: Some(config),
+            ..Self::default()
+        }
+    }
+
+    #[must_use]
+    pub fn with_ssh_config(mut self, ssh_config: Option<SshConfig>) -> Self {
+        self.ssh_config = ssh_config;
+        self
+    }
+
+    #[must_use]
+    pub fn with_cli_keepalive_interval(mut self, interval: Option<u64>) -> Self {
+        self.cli_keepalive_interval = interval;
+        self
+    }
+
+    #[must_use]
+    pub fn with_cli_keepalive_max(mut self, max: Option<usize>) -> Self {
+        self.cli_keepalive_max = max;
+        self
+    }
+
+    #[must_use]
+    pub fn with_yaml_keepalive_interval(mut self, interval: Option<u64>) -> Self {
+        self.yaml_keepalive_interval = interval;
+        self
+    }
+
+    #[must_use]
+    pub fn with_yaml_keepalive_max(mut self, max: Option<usize>) -> Self {
+        self.yaml_keepalive_max = max;
+        self
+    }
+
+    #[must_use]
+    pub fn with_cli_address_family(mut self, family: Option<AddressFamily>) -> Self {
+        if let (Some(config), Some(family)) = (self.fixed_config.as_mut(), family) {
+            config.address_family = family;
+            return self;
+        }
+        self.cli_address_family = family;
+        self
+    }
+
+    pub fn resolve_for_host(&self, hostname: &str) -> SshConnectionConfig {
+        if let Some(config) = &self.fixed_config {
+            return config.clone();
+        }
+
+        let keepalive_interval = self
+            .cli_keepalive_interval
+            .or_else(|| {
+                self.ssh_config
+                    .as_ref()
+                    .and_then(|config| config.get_int_option(Some(hostname), "serveraliveinterval"))
+                    .map(|v| v as u64)
+            })
+            .or(self.yaml_keepalive_interval)
+            .unwrap_or(DEFAULT_KEEPALIVE_INTERVAL);
+
+        let keepalive_max = self
+            .cli_keepalive_max
+            .or_else(|| {
+                self.ssh_config
+                    .as_ref()
+                    .and_then(|config| config.get_int_option(Some(hostname), "serveralivecountmax"))
+                    .map(|v| v as usize)
+            })
+            .or(self.yaml_keepalive_max)
+            .unwrap_or(DEFAULT_KEEPALIVE_MAX);
+
+        let compression = self
+            .ssh_config
+            .as_ref()
+            .and_then(|config| config.get_compression(hostname))
+            .unwrap_or(false);
+
+        let config_address_family = self
+            .ssh_config
+            .as_ref()
+            .and_then(|config| config.get_address_family(hostname));
+        let address_family = self.cli_address_family.unwrap_or_else(|| {
+            AddressFamily::resolve(false, false, config_address_family.as_deref())
+        });
+
+        SshConnectionConfig::new()
+            .with_keepalive_interval(if keepalive_interval == 0 {
+                None
+            } else {
+                Some(keepalive_interval)
+            })
+            .with_keepalive_max(keepalive_max)
+            .with_compression(compression)
+            .with_address_family(address_family)
     }
 }
 

--- a/src/ssh/tokio_client/connection_tests.rs
+++ b/src/ssh/tokio_client/connection_tests.rs
@@ -24,7 +24,8 @@
 
 use super::address_family::AddressFamily;
 use super::authentication::{AuthMethod, ServerCheckMethod};
-use super::connection::{Client, SshConnectionConfig};
+use super::connection::{Client, SshConnectionConfig, SshConnectionConfigResolver};
+use crate::ssh::SshConfig;
 
 #[test]
 fn test_default_compression_advertises_none_only() {
@@ -123,6 +124,75 @@ fn test_with_address_family_is_chainable_and_leaves_other_settings_alone() {
     assert_eq!(config.keepalive_interval, Some(15));
     assert_eq!(config.keepalive_max, 5);
     assert!(config.compression);
+}
+
+#[test]
+fn test_connection_config_resolver_applies_ssh_config_per_host() {
+    let ssh_config = SshConfig::parse(
+        r#"
+Host v4node
+    AddressFamily inet
+    Compression yes
+    ServerAliveInterval 11
+    ServerAliveCountMax 2
+
+Host v6node
+    AddressFamily inet6
+    Compression no
+    ServerAliveInterval 22
+    ServerAliveCountMax 4
+"#,
+    )
+    .expect("valid ssh_config");
+
+    let resolver = SshConnectionConfigResolver::new()
+        .with_ssh_config(Some(ssh_config))
+        .with_yaml_keepalive_interval(Some(30))
+        .with_yaml_keepalive_max(Some(3));
+
+    let v4 = resolver.resolve_for_host("v4node");
+    assert_eq!(v4.address_family, AddressFamily::V4);
+    assert!(v4.compression);
+    assert_eq!(v4.keepalive_interval, Some(11));
+    assert_eq!(v4.keepalive_max, 2);
+
+    let v6 = resolver.resolve_for_host("v6node");
+    assert_eq!(v6.address_family, AddressFamily::V6);
+    assert!(!v6.compression);
+    assert_eq!(v6.keepalive_interval, Some(22));
+    assert_eq!(v6.keepalive_max, 4);
+
+    let fallback = resolver.resolve_for_host("unconfigured");
+    assert_eq!(fallback.address_family, AddressFamily::Any);
+    assert!(!fallback.compression);
+    assert_eq!(fallback.keepalive_interval, Some(30));
+    assert_eq!(fallback.keepalive_max, 3);
+}
+
+#[test]
+fn test_connection_config_resolver_preserves_cli_precedence() {
+    let ssh_config = SshConfig::parse(
+        r#"
+Host target
+    AddressFamily inet6
+    ServerAliveInterval 11
+    ServerAliveCountMax 2
+"#,
+    )
+    .expect("valid ssh_config");
+
+    let config = SshConnectionConfigResolver::new()
+        .with_ssh_config(Some(ssh_config))
+        .with_cli_keepalive_interval(Some(7))
+        .with_cli_keepalive_max(Some(9))
+        .with_yaml_keepalive_interval(Some(30))
+        .with_yaml_keepalive_max(Some(3))
+        .with_cli_address_family(Some(AddressFamily::V4))
+        .resolve_for_host("target");
+
+    assert_eq!(config.address_family, AddressFamily::V4);
+    assert_eq!(config.keepalive_interval, Some(7));
+    assert_eq!(config.keepalive_max, 9);
 }
 
 /// The empty-after-filter path must fail with a specific error naming the host

--- a/src/ssh/tokio_client/mod.rs
+++ b/src/ssh/tokio_client/mod.rs
@@ -33,6 +33,7 @@ pub use authentication::{AuthKeyboardInteractive, AuthMethod, ServerCheckMethod}
 pub use channel_manager::{CommandExecutedResult, CommandOutput};
 pub use connection::{
     Client, ClientHandler, DEFAULT_KEEPALIVE_INTERVAL, DEFAULT_KEEPALIVE_MAX, SshConnectionConfig,
+    SshConnectionConfigResolver,
 };
 pub use error::Error;
 pub use to_socket_addrs_with_hostname::ToSocketAddrsWithHostname;


### PR DESCRIPTION
## Summary

Resolve SSH connection settings per target host instead of once per dispatch, covering AddressFamily, Compression, ServerAliveInterval, and ServerAliveCountMax for exec, ping, upload, and download.

## What changed

- Added SshConnectionConfigResolver to combine CLI overrides, YAML defaults, and ssh_config Host blocks, with fixed-config compatibility for existing callers.
- Resolved connection settings at the ParallelExecutor per-node seam and passed the resolver through SshClient and JumpHostChain so jump hops resolve against their own Host blocks.
- Updated SFTP transfer paths to carry the full resolved SshConnectionConfig instead of only AddressFamily.
- Added tests for per-node executor resolution, resolver CLI precedence, and jump-hop Host block resolution.

## Test plan

- [x] cargo fmt
- [x] cargo test --lib executor::parallel::tests::connection_config_for_node_resolves_each_node_host_block
- [x] cargo test --lib ssh::tokio_client::connection_tests::test_connection_config_resolver
- [x] cargo test --lib jump::chain::tests::test_chain_resolves_connection_config_per_jump_host
- [x] cargo check --lib --tests
- [x] cargo clippy --lib --tests -- -D warnings

Closes #249
