### PR TITLE
fix: repair merged host-port integration

### DIFF
--- a/src/ssh/tokio_client/to_socket_addrs_with_hostname.rs
+++ b/src/ssh/tokio_client/to_socket_addrs_with_hostname.rs
@@ -139,29 +139,7 @@ impl ToSocketAddrsWithHostname for &[SocketAddr] {
             .map(|addr| addr.ip().to_string())
             .unwrap_or_default()
     }
-}
 
-#[cfg(test)]
-mod tests {
-    use super::ToSocketAddrsWithHostname;
-    use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
-
-    #[test]
-    fn socket_addr_slice_hostname_uses_first_address_only() {
-        let addrs = [
-            SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 22),
-            SocketAddr::new(IpAddr::V6(Ipv6Addr::LOCALHOST), 22),
-        ];
-
-        assert_eq!(addrs.as_slice().hostname(), "127.0.0.1");
-    }
-
-    #[test]
-    fn empty_socket_addr_slice_hostname_is_empty() {
-        let addrs: [SocketAddr; 0] = [];
-
-        assert_eq!(addrs.as_slice().hostname(), "");
-    }
     fn host_port(&self) -> io::Result<(String, u16)> {
         self.first()
             .map(|addr| (addr.ip().to_string(), addr.port()))
@@ -200,6 +178,24 @@ fn parse_host_port(target: &str) -> io::Result<(String, u16)> {
 #[cfg(test)]
 mod tests {
     use super::{ToSocketAddrsWithHostname, parse_host_port};
+    use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
+
+    #[test]
+    fn socket_addr_slice_hostname_uses_first_address_only() {
+        let addrs = [
+            SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 22),
+            SocketAddr::new(IpAddr::V6(Ipv6Addr::LOCALHOST), 22),
+        ];
+
+        assert_eq!(addrs.as_slice().hostname(), "127.0.0.1");
+    }
+
+    #[test]
+    fn empty_socket_addr_slice_hostname_is_empty() {
+        let addrs: [SocketAddr; 0] = [];
+
+        assert_eq!(addrs.as_slice().hostname(), "");
+    }
 
     #[test]
     fn host_port_parses_domain_without_resolution() {


### PR DESCRIPTION
## Summary
- Restore `&[SocketAddr]::host_port` to the trait implementation after the PR #260 / PR #258 auto-merge placed it inside the test module.
- Merge the #243 first-address hostname tests and #257 host-port parsing tests into one valid `tests` module so both behavior checks remain compiled.

## Validation
- `cargo fmt --check`
- `CARGO_TARGET_DIR=/home/inureyes/Development/backend.ai/bssh/target cargo test --lib to_socket_addrs_with_hostname`
- `CARGO_TARGET_DIR=/home/inureyes/Development/backend.ai/bssh/target cargo check --lib --tests`
- `CARGO_TARGET_DIR=/home/inureyes/Development/backend.ai/bssh/target cargo clippy --lib --tests -- -D warnings`

Refs #243.
Refs #257.
