### PR TITLE
fix: run the Homebrew formula job automatically on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,23 @@
 name: Release
 
 on:
+  # Both ways of cutting a release are supported, and both end with the Homebrew
+  # tap bumped automatically:
+  #
+  #   prereleased - the release is published as a pre-release. `build` uploads
+  #     every asset, `publish-release` then flips the release to official, and
+  #     `update-homebrew` bumps the tap.
+  #   released - the release is published directly as official (or an existing
+  #     pre-release is flipped by hand). `publish-release` is skipped because
+  #     there is nothing to convert, so `update-homebrew` keys off `build`.
+  #
+  # Before `released` was listed here, a release published directly as official
+  # started no run at all: no binaries, no assets, no formula bump. Listing it
+  # cannot loop back on us either, because `publish-release` performs its flip
+  # with the default GITHUB_TOKEN and events raised by GITHUB_TOKEN do not start
+  # new workflow runs.
   release:
-    types: [prereleased]
+    types: [prereleased, released]
   workflow_dispatch:
     inputs:
       update_homebrew:
@@ -263,14 +278,38 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   # ============================================================================
-  # Update Homebrew formula (after publish converts pre-release to official)
+  # Update Homebrew formula (after every release asset has been uploaded)
   # ============================================================================
+  #
+  # `build` is listed in `needs` explicitly rather than relied on transitively
+  # through `publish-release`. The called workflow downloads the published
+  # assets and hashes them, so it must never start before all five build legs
+  # have finished uploading, and that guarantee has to hold on the path where
+  # `publish-release` does not run at all. `publish-release` stays in `needs` so
+  # the pre-release path is still ordered behind the flip to official.
+  #
+  # `!cancelled()` is required: `publish-release` is legitimately skipped when
+  # the release was published as official already, and under the implicit
+  # `success()` a job whose dependency was skipped is skipped too. A bare
+  # `always()` would be the wrong way to lift that, since it would also fire
+  # after a failed build and push a formula whose sha256 values point at assets
+  # that were never uploaded, so the build result is asserted explicitly instead
+  # of leaning on job ordering.
+  #
+  # On a manual `workflow_dispatch` of this workflow the formula is updated only
+  # when the `update_homebrew` input asks for it, so rebuilding a tag by hand
+  # does not push a tap commit as a side effect.
   update-homebrew:
     name: Update Homebrew formula
-    needs: [publish-release]
+    needs: [build, publish-release]
+    if: >-
+      !cancelled()
+      && needs.build.result == 'success'
+      && (needs.publish-release.result == 'success' || needs.publish-release.result == 'skipped')
+      && (github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && github.event.inputs.update_homebrew == 'true'))
     uses: ./.github/workflows/update_homebrew_formula.yml
     with:
-      release_tag: ${{ github.event.release.tag_name }}
+      release_tag: ${{ github.event.release.tag_name || github.event.inputs.release_tag }}
     secrets: inherit
 
   # ============================================================================

--- a/.github/workflows/update_homebrew_formula.yml
+++ b/.github/workflows/update_homebrew_formula.yml
@@ -23,7 +23,20 @@ jobs:
     runs-on: macos-latest
     environment: packaging
 
-    if: github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_call'
+    # No job-level `if` here, on purpose. This job used to carry
+    #
+    #     if: github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_call'
+    #
+    # which is unsatisfiable on the `uses:` path. Inside a called workflow
+    # `github.event_name` reports the *caller's* originating event, which is
+    # `release` during a release run, and never `workflow_call`. So the job was
+    # skipped in 0s on every release (v2.4.1 job 91700817094, v2.4.2 job
+    # 94746343757) and the tap had to be bumped afterwards by hand.
+    #
+    # The `on:` block above already declares the only two ways this workflow can
+    # start, so an event gate here can only exclude legitimate runs. Whether the
+    # formula should be updated at all is the caller's decision; see the
+    # `update-homebrew` job in release.yml.
 
     steps:
       - name: Checkout this repository


### PR DESCRIPTION
## Summary

The Homebrew tap formula never updated as part of a release, so every release since the job was wired up needed a manual `workflow_dispatch` afterwards. This removes the unsatisfiable event gate that skipped the job, and closes the second gap where a release published directly as official produced no run at all.

## The defect

`update_homebrew_formula.yml` gated its only job on:

```yaml
if: github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_call'
```

Inside a workflow invoked through `uses:`, `github.event_name` reports the caller's originating event, which is `release` during a release run, and never `workflow_call`. Both sides are false on the `uses:` path, so the job was skipped in 0s on v2.4.1 (job 91700817094) and v2.4.2 (job 94746343757). Since that workflow declares only `workflow_dispatch` and `workflow_call` triggers, no other event can start it and the condition could only ever exclude legitimate runs, so it is removed rather than rewritten. Whether the formula should be updated is now the caller's decision.

## The direct-official release path: option 1, supported

The issue asked for a choice between supporting a release published directly as official and documenting it as unsupported. This PR supports it.

Worth recording, because it changes what the fix has to be: `release.yml` listened only for `types: [prereleased]`, so a release published directly as official did not merely skip `publish-release` and therefore `update-homebrew`. It started **no run at all**: no binaries, no assets, no formula bump. Relaxing `needs`/`if` alone would have supported nothing on that path, because no job was running to relax. So `released` is now listed alongside `prereleased`, and `update-homebrew` gates on job results instead of on `publish-release` having run.

Adding `released` cannot loop back on us: `publish-release` performs its flip with the default `GITHUB_TOKEN`, and events raised by `GITHUB_TOKEN` do not start new workflow runs. A human flipping a pre-release to official by hand does start a fresh run, which rebuilds, re-uploads with `--clobber`, and re-bumps the tap consistently.

## What changed

- `.github/workflows/update_homebrew_formula.yml`: removed the job-level `if`, replacing it with a comment recording why an event gate cannot work here.
- `.github/workflows/release.yml`: added `released` to the `release` trigger types.
- `.github/workflows/release.yml`: `update-homebrew` now declares `needs: [build, publish-release]` with an explicit result-based condition (below).
- `.github/workflows/release.yml`: the tag passed to the called workflow is now `${{ github.event.release.tag_name || github.event.inputs.release_tag }}`, mirroring the existing upload step, so the manual dispatch path passes its own tag.
- The `update_homebrew` `workflow_dispatch` input, declared since the file was written but never referenced anywhere, is now what decides whether a manual rebuild also pushes a tap commit.

`publish-release` is unchanged: `needs: [build]`, `if: github.event_name == 'release' && github.event.release.prerelease`. On the `released` event `prerelease` is false, so it correctly skips, having nothing to convert.

`update-homebrew` is now:

```yaml
needs: [build, publish-release]
if: >-
  !cancelled()
  && needs.build.result == 'success'
  && (needs.publish-release.result == 'success' || needs.publish-release.result == 'skipped')
  && (github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && github.event.inputs.update_homebrew == 'true'))
```

## Why the checksum ordering guarantee still holds

The called workflow downloads the published release assets and hashes them, so it must never start before all five build legs have uploaded. That guarantee previously came transitively through `publish-release`, which no longer runs on every supported path, so `build` is now named in `needs` directly and its result is asserted. `publish-release` stays in `needs` so the pre-release path remains ordered behind the flip to official.

`!cancelled()` is required because a job whose dependency was skipped is itself skipped under the implicit `success()`, and `publish-release` is legitimately skipped on the direct-official path. A bare `always()` would have been the wrong way to lift that: it would also fire after a failed build and push a formula whose sha256 values point at assets that were never uploaded. Asserting `needs.build.result == 'success'` is what rules that out, rather than any implicit ordering.

## Path trace

| Path | build | publish-release | update-homebrew |
|---|---|---|---|
| Pre-release publish (`prereleased`) | success | success | **runs** |
| Direct-official publish (`released`) | success | skipped | **runs** |
| Build failure | failure | skipped | skipped |
| `publish-release` failure | success | failure | skipped |
| Run cancelled | cancelled | cancelled | skipped |
| Manual dispatch, `update_homebrew=false` | success | skipped | skipped |
| Manual dispatch, `update_homebrew=true` | success | skipped | **runs** |

## Test plan

- [x] Both workflow files parse: `python3 -c 'import yaml; yaml.safe_load(open(".github/workflows/release.yml")); yaml.safe_load(open(".github/workflows/update_homebrew_formula.yml"))'`
- [x] The folded `if` collapses to a single-line expression with no embedded newlines (verified by printing the parsed scalar).
- [x] Job graph traced across all seven paths in the table above, modelling the implicit `success()` and skip propagation.
- [x] Manual `workflow_dispatch` of `update_homebrew_formula.yml` with an explicit `release_tag` is untouched and still the recovery path: the trigger block is unchanged and the tag plumbing at `INPUT_TAG="${{ github.event.inputs.release_tag || inputs.release_tag }}"` already handles both the dispatch and call inputs.

## Not verified yet, by construction

Two of the issue's acceptance criteria are only observable by cutting a real release, and are deliberately left unticked rather than claimed:

- **AC1**, cutting a release updates the tap with no manual dispatch.
- **AC5**, verified on a real release rather than by reading the YAML.

What to watch on the next release: the run should show `build` (five legs) then `publish-release` on the pre-release path, then `update-homebrew` as a nested reusable-workflow run rather than a 0s skip. Success looks like a `bump: bssh, bssh-server, and bssh-keygen to vX.Y.Z` commit appearing in `lablup/homebrew-tap` from that run, with no separate manual dispatch run, and the tap commit timestamp falling inside the release run's window instead of after it. If `update-homebrew` still reports skipped, check its condition against the actual `needs.*.result` values in the run's job list.

Closes #266
