### PR TITLE
feat(release): notarize with an API key, and promote on dispatch

### DIFF
--- a/.github/actions/macos-sign-notarize-binary/action.yml
+++ b/.github/actions/macos-sign-notarize-binary/action.yml
@@ -25,14 +25,18 @@ inputs:
       ignores them.
     required: false
     default: ""
-  apple-id:
-    description: "Apple ID used for notarization (the APPLE_ID secret)."
+  api-key-id:
+    description: "App Store Connect API key id (the AC_API_KEY_ID secret)."
     required: false
-  apple-team-id:
-    description: "Apple Developer team identifier (the APPLE_TEAM_ID secret)."
+  api-issuer-id:
+    description: >-
+      App Store Connect API issuer id, UUID form (the AC_API_ISSUER_ID secret).
+      Required for a Team key; notarytool rejects it for an Individual key.
     required: false
-  apple-password:
-    description: "App-specific password for notarization (the APPLE_PASSWORD secret)."
+  api-private-key:
+    description: >-
+      The App Store Connect .p8 private key (the AC_API_PRIVATE_KEY_P8 secret),
+      base64-encoded. A raw .p8 pasted verbatim is also accepted.
     required: false
 
 outputs:
@@ -169,9 +173,9 @@ runs:
     - name: Notarize ${{ inputs.zip-name }}
       shell: bash
       env:
-        APPLE_ID: ${{ inputs.apple-id }}
-        APPLE_TEAM_ID: ${{ inputs.apple-team-id }}
-        APPLE_PASSWORD: ${{ inputs.apple-password }}
+        AC_API_KEY_ID: ${{ inputs.api-key-id }}
+        AC_API_ISSUER_ID: ${{ inputs.api-issuer-id }}
+        AC_API_PRIVATE_KEY_P8: ${{ inputs.api-private-key }}
         ZIP_PATH: ${{ steps.package.outputs.zip-path }}
         BINARY_PATH: ${{ inputs.binary-path }}
       run: |
@@ -188,9 +192,47 @@ runs:
         # download. Signing and notarization are one decision: SIGNING_READY
         # above is the only place a run is allowed to degrade to an unsigned
         # artifact.
-        if [ -z "$APPLE_ID" ] || [ -z "$APPLE_TEAM_ID" ] || [ -z "$APPLE_PASSWORD" ]; then
-          echo "::error::$(basename "$ZIP_PATH") was signed with the Developer ID identity but the Apple notarization credentials (APPLE_ID, APPLE_TEAM_ID, APPLE_PASSWORD) are missing, so it cannot be notarized"
+        #
+        # Authentication is an App Store Connect API key, not an Apple ID with
+        # an app-specific password. The name misleads: notarization is for
+        # distribution *outside* the App Store, App Store submissions are not
+        # notarized by the developer at all, and `notarytool` documents the key
+        # as a first-class credential next to `--apple-id`. What the key buys is
+        # ownership. An app-specific password belongs to one person's Apple ID,
+        # so it dies when they leave the team, rotate their password, or reset
+        # 2FA; an API key is issued and revoked by the organisation.
+        if [ -z "$AC_API_KEY_ID" ] || [ -z "$AC_API_PRIVATE_KEY_P8" ]; then
+          echo "::error::$(basename "$ZIP_PATH") was signed with the Developer ID identity but the App Store Connect API credentials (AC_API_KEY_ID, AC_API_PRIVATE_KEY_P8) are missing, so it cannot be notarized"
           exit 1
+        fi
+
+        KEY_FILE="$RUNNER_TEMP/AuthKey.p8"
+        # Wipe the key on every exit path, not only the success one.
+        cleanup() { rm -f "$KEY_FILE"; }
+        trap cleanup EXIT
+
+        # The secret holds the .p8 base64-encoded. A raw .p8 pasted verbatim is
+        # tolerated too, and CR is stripped so a CRLF-mangled paste still
+        # parses. Writing the secret out without decoding makes notarytool fail
+        # with the opaque "Error: invalidAsn1".
+        if grep -q 'BEGIN PRIVATE KEY' <<<"$AC_API_PRIVATE_KEY_P8"; then
+          printf '%s\n' "$AC_API_PRIVATE_KEY_P8" | tr -d '\r' > "$KEY_FILE"
+        else
+          printf '%s' "$AC_API_PRIVATE_KEY_P8" | tr -d '[:space:]' | base64 --decode > "$KEY_FILE"
+        fi
+        chmod 600 "$KEY_FILE"
+
+        # Say so here rather than letting notarytool report "invalidAsn1" much
+        # later, which names neither the secret nor the encoding.
+        if command -v openssl >/dev/null 2>&1 && ! openssl pkey -in "$KEY_FILE" -noout 2>/dev/null; then
+          echo "::warning::AC_API_PRIVATE_KEY_P8 did not parse as a PKCS#8 private key after decoding; notarization will likely fail. Re-store it as base64 of the .p8 file (base64 -i AuthKey_XXXX.p8 | pbcopy)."
+        fi
+
+        # `--issuer` belongs to a Team key and must be omitted for an
+        # Individual key, which notarytool rejects it for.
+        ISSUER_ARGS=()
+        if [ -n "$AC_API_ISSUER_ID" ]; then
+          ISSUER_ARGS=(--issuer "$AC_API_ISSUER_ID")
         fi
 
         echo "=== Submitting $(basename "$ZIP_PATH") for notarization ==="
@@ -199,9 +241,9 @@ runs:
         # installer packages, not a bare Mach-O or a zip. The ticket stays on
         # Apple's servers and Gatekeeper looks it up online.
         SUBMISSION_OUTPUT=$(xcrun notarytool submit "$ZIP_PATH" \
-          --apple-id "$APPLE_ID" \
-          --team-id "$APPLE_TEAM_ID" \
-          --password "$APPLE_PASSWORD" \
+          --key "$KEY_FILE" \
+          --key-id "$AC_API_KEY_ID" \
+          "${ISSUER_ARGS[@]}" \
           --wait --timeout 30m 2>&1) || true
 
         echo "$SUBMISSION_OUTPUT"
@@ -217,9 +259,9 @@ runs:
           if [ -n "$SUBMISSION_ID" ]; then
             echo "Fetching detailed notarization log..."
             xcrun notarytool log "$SUBMISSION_ID" \
-              --apple-id "$APPLE_ID" \
-              --team-id "$APPLE_TEAM_ID" \
-              --password "$APPLE_PASSWORD" || true
+              --key "$KEY_FILE" \
+              --key-id "$AC_API_KEY_ID" \
+              "${ISSUER_ARGS[@]}" || true
           fi
           exit 1
         fi
@@ -229,11 +271,10 @@ runs:
         # Informational only. A freshly issued ticket takes time to propagate,
         # so this must not gate the job; the hard gates are the codesign
         # assertions and the Accepted status above.
-        # `set -uo pipefail` above does not turn -e back off: composite
-        # `shell: bash` already started this as `bash -eo pipefail`. Guard the
-        # whole block, or an unzip failure here would fail the job after
-        # notarization was already accepted, and the zip would never be
-        # uploaded.
+        #
+        # `spctl -t exec` assesses app bundles, so a bare Mach-O draws "does not
+        # seem to be an app" even when it is correctly signed and notarized.
+        # That is why this is a report, not a check.
         VERIFY_DIR="$(mktemp -d "$RUNNER_TEMP/macos-spctl.XXXXXX")"
         if unzip -q -o "$ZIP_PATH" -d "$VERIFY_DIR"; then
           spctl -a -vv -t exec "$VERIFY_DIR/$(basename "$BINARY_PATH")" || true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -162,9 +162,9 @@ jobs:
           identifier: ${{ vars.BUNDLE_ID || secrets.BUNDLE_ID }}
           extra-files: |
             docs/man/bssh.1
-          apple-id: ${{ secrets.APPLE_ID }}
-          apple-team-id: ${{ secrets.APPLE_TEAM_ID }}
-          apple-password: ${{ secrets.APPLE_PASSWORD }}
+          api-key-id: ${{ secrets.AC_API_KEY_ID }}
+          api-issuer-id: ${{ secrets.AC_API_ISSUER_ID }}
+          api-private-key: ${{ secrets.AC_API_PRIVATE_KEY_P8 }}
 
       - name: Sign, package, and notarize bssh-server (macOS)
         if: runner.os == 'macOS'
@@ -175,9 +175,9 @@ jobs:
           identifier: ${{ vars.BUNDLE_ID || secrets.BUNDLE_ID }}-server
           extra-files: |
             docs/man/bssh-server.8
-          apple-id: ${{ secrets.APPLE_ID }}
-          apple-team-id: ${{ secrets.APPLE_TEAM_ID }}
-          apple-password: ${{ secrets.APPLE_PASSWORD }}
+          api-key-id: ${{ secrets.AC_API_KEY_ID }}
+          api-issuer-id: ${{ secrets.AC_API_ISSUER_ID }}
+          api-private-key: ${{ secrets.AC_API_PRIVATE_KEY_P8 }}
 
       - name: Sign, package, and notarize bssh-keygen (macOS)
         if: runner.os == 'macOS'
@@ -188,9 +188,9 @@ jobs:
           identifier: ${{ vars.BUNDLE_ID || secrets.BUNDLE_ID }}-keygen
           extra-files: |
             docs/man/bssh-keygen.1
-          apple-id: ${{ secrets.APPLE_ID }}
-          apple-team-id: ${{ secrets.APPLE_TEAM_ID }}
-          apple-password: ${{ secrets.APPLE_PASSWORD }}
+          api-key-id: ${{ secrets.AC_API_KEY_ID }}
+          api-issuer-id: ${{ secrets.AC_API_ISSUER_ID }}
+          api-private-key: ${{ secrets.AC_API_PRIVATE_KEY_P8 }}
 
       - name: Package Linux binaries (tar.gz)
         if: runner.os == 'Linux'
@@ -261,7 +261,13 @@ jobs:
   publish-release:
     name: Publish pre-release as official
     needs: [build]
-    if: github.event_name == 'release' && github.event.release.prerelease
+    # A dispatch has to be able to finish a release too, not only build one.
+    # Rebuilding a tag by hand previously stopped at "artifacts uploaded", so a
+    # release rescued that way stayed a pre-release, and the Homebrew formula
+    # job resolves through `releases/latest`, which never returns one.
+    if: >-
+      (github.event_name == 'release' && github.event.release.prerelease) ||
+      (github.event_name == 'workflow_dispatch' && github.event.inputs.release_tag != '')
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -271,11 +277,38 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Convert pre-release to official release
-        run: |
-          TAG="${{ github.event.release.tag_name }}"
-          gh release edit "$TAG" --prerelease=false
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.event.release.tag_name || github.event.inputs.release_tag }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "$TAG" ]; then
+            echo "::error::no release tag to promote"
+            exit 1
+          fi
+
+          # Read the state into a variable rather than testing the command
+          # substitution inline. A failing `gh` there yields an empty string,
+          # `set -e` does not fire inside a test, and empty is not "true", so
+          # the guard would conclude "already promoted" and exit 0 having done
+          # nothing while reporting success.
+          IS_PRERELEASE="$(gh release view "$TAG" --json isPrerelease -q .isPrerelease)"
+          if [ -z "$IS_PRERELEASE" ]; then
+            echo "::error::could not read the release state for $TAG; refusing to guess whether it needs promoting"
+            exit 1
+          fi
+
+          # Idempotent: re-running a dispatch against an already-promoted tag
+          # is a normal thing to do while recovering, and must not fail.
+          if [ "$IS_PRERELEASE" != "true" ]; then
+            echo "$TAG is already a full release; nothing to promote"
+            exit 0
+          fi
+
+          # `--latest` is explicit rather than left to GitHub's own ordering,
+          # so the tag Homebrew resolves is the one this run promoted.
+          gh release edit "$TAG" --prerelease=false --latest
 
   # ============================================================================
   # Update Homebrew formula (after every release asset has been uploaded)


### PR DESCRIPTION
## Notarization moves off the Apple ID

`notarytool` authenticated with `--apple-id` and an app-specific password. That credential belongs to one person's Apple ID: it stops working when they leave the team, rotate their password, or reset 2FA, and the release stops with it. An App Store Connect API key is issued and revoked by the organisation instead.

The name misleads, so worth stating plainly: the key is not App Store only. Notarization exists for distribution *outside* the App Store, App Store submissions are not notarized by the developer at all, and `notarytool` documents `--key/--key-id/--issuer` as a first-class credential alongside `--apple-id`.

`--issuer` is passed only when set, since it is required for a Team key and rejected for an Individual one. The .p8 is accepted base64-encoded or raw, and a key that does not parse as PKCS#8 is reported at that point rather than surfacing later as notarytool's opaque "invalidAsn1".

No new secrets. `AC_API_KEY_ID`, `AC_API_ISSUER_ID`, and `AC_API_PRIVATE_KEY_P8` are already on the `packaging` environment; nothing referenced them. `APPLE_ID`, `APPLE_TEAM_ID`, and `APPLE_PASSWORD` become unreferenced and can be removed once a release has gone out on this path.

## A dispatched release can now stop being a pre-release

`publish-release` ran only for `release` events, so rebuilding a tag by hand ended at "artifacts uploaded" and the release stayed a pre-release forever. That also stalls the Homebrew formula job, which resolves through `releases/latest`, and a pre-release is exactly what that endpoint omits.

It now also runs for a dispatch naming a `release_tag`, and exits cleanly when the tag is already promoted, since re-running a dispatch is a normal thing to do while recovering.

The state is read into a variable first rather than testing the command substitution inline. A failing `gh` yields an empty string, `set -e` does not fire inside a test, and empty is not "true", so the guard would conclude "already promoted" and exit 0 having done nothing while reporting success. Unreadable state is now a hard error. `--latest` is explicit so the tag Homebrew resolves is the one this run promoted.

## Verification

`actionlint` is clean on release.yml, both composite action steps pass `bash -n`, and no reference to the Apple ID credentials remains outside one explanatory comment. The notarization path itself is only observable on a real release, so the next one is the proof.
