### PR TITLE
update: upgrade test dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2313,9 +2313,9 @@ dependencies = [
 
 [[package]]
 name = "mockall"
-version = "0.14.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f58d964098a5f9c6b63d0798e5372fd04708193510a7af313c22e9f29b7b620b"
+checksum = "1a6ceddfe3ce334925e96bf420fdb2dcee5bed6c632a168ece622676dadeaf8a"
 dependencies = [
  "cfg-if",
  "downcast",
@@ -2327,9 +2327,9 @@ dependencies = [
 
 [[package]]
 name = "mockall_derive"
-version = "0.14.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca41ce716dda6a9be188b385aa78ee5260fc25cd3802cb2a8afdc6afbe6b6dbf"
+checksum = "9cfe16fbe8a314aeec0b861ac24e60b1e123e97634bab045475b9d6a18416fd8"
 dependencies = [
  "cfg-if",
  "proc-macro2",
@@ -3890,9 +3890,9 @@ dependencies = [
 
 [[package]]
 name = "serial_test"
-version = "3.5.0"
+version = "4.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "699f4197115b8a7e7ff19c9a315a4bd6fffec26cc4626ef45ecaea389e081c6d"
+checksum = "a6df5ed973ad8d834e09f824f9e9f449af6b9a3745f78dec7cc752770bd3bf11"
 dependencies = [
  "futures-executor",
  "futures-util",
@@ -3904,13 +3904,13 @@ dependencies = [
 
 [[package]]
 name = "serial_test_derive"
-version = "3.5.0"
+version = "4.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94e153fc76e1c6a068703d6d29c508a0b15c061c4b7e43da59cc097bc342673c"
+checksum = "a22144e767da4ddd8416dbf383700542ffd8a5dc493dfecedfe1fe3ad03c98ae"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.4",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,6 +73,11 @@ shell-words = "1.1.1"
 libc = "0.2"
 ipnetwork = "0.21"
 bcrypt = "0.19"
+# `argon2` 0.5 uses `crypto-common` 0.1.7, which deliberately pins
+# `generic-array` to 0.14.7 to avoid the 0.14.9 deprecation-only release.
+# Revisit this transitive hold when the stable RustCrypto stack migrates to
+# hybrid-array:
+# https://github.com/RustCrypto/traits/issues/2036
 argon2 = { version = "0.5", features = ["std"] }
 rand = "0.10"
 # Pinned to match russh's ssh-key (0.63.x uses =0.7.0-rc.11) so the workspace
@@ -94,10 +99,10 @@ security-framework = "3.7.0"
 tempfile = "3.27.0"
 mockito = "1.7.2"
 tokio-test = "0.4"
-serial_test = "3.4"
+serial_test = "4.0.1"
 insta = "1.47"
 criterion = { version = "0.8", features = ["html_reports"] }
-mockall = "0.14"
+mockall = "0.15.0"
 
 [[bench]]
 name = "large_output_benchmark"


### PR DESCRIPTION
## Summary

- Upgrade mockall from 0.14.0 to 0.15.0 and serial_test from 3.5.0 to 4.0.1, including their derive crates.
- Document why crypto-common 0.1.7 intentionally keeps the transitive generic-array dependency at 0.14.7 instead of forcing the deprecation-only 0.14.9 release.
- Keep the stable Argon2 authentication stack rather than introducing a release candidate or local dependency override solely to change the transitive version.

## Validation

- `rustup run 1.96 cargo check --workspace --all-targets --locked`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace --lib --bins --tests -- --skip test_localhost_multiple_file_upload --skip test_parallel_execution_with_multiple_nodes --skip test_download_with_unique_filenames`

## Risk

- Runtime dependencies and application code are unchanged.
- The three excluded localhost integration cases remain blocked by the pre-existing local `~/.ssh/known_hosts` key conflict.
