### PR TITLE
feat(cli): implement -E log file

### DIFF
--- a/docs/openssh-regress.md
+++ b/docs/openssh-regress.md
@@ -30,7 +30,9 @@ An upstream `SKIPPED:` result is reported as `skip` and excluded from the eligib
 
 The score is `pass / (pass + fail)`. CI compares both the pass count and the environment-valid result count with platform-specific floors in `baseline.json`, uploads the generated JSON table even on failure, and fails when either count drops below its floor. Durations are milliseconds, and `first_failure_line` is the first diagnostic line selected from the captured combined harness output; per-test logs are streamed under `target/openssh-regress/logs/` and capped at 16 MiB each.
 
-Before #277 adds `-E`, the honest pass floor is zero. A nonzero eligible-result floor still rejects a collapsed all-environmental run; #277 raises the pass floor after the suite becomes runnable. Focused `--test` runs report verdicts without enforcing full-suite floors.
+At PR head `13c35ce`, after #277 made the suite runnable, Linux measured 25 pass, 42 fail, five environmental, and six upstream skips for 67 eligible results. macOS measured 26 pass, 39 fail, seven environmental, and six upstream skips for 65 eligible results. Both platforms keep a conservative 23-pass floor, preserving the epic's measured pass floor while leaving observed slack.
+
+The eligible floors are 67 on Linux and 65 on macOS. This recalibrates the denominator from the 78 runnable manifest rows: six upstream skips are now reached and excluded, followed by the existing platform environmental allowances of five on Linux and seven on macOS (`78 - 6 - 5 = 67`; `78 - 6 - 7 = 65`). A nonzero eligible-result floor still rejects a collapsed all-environmental run. Focused `--test` runs report verdicts without enforcing full-suite floors.
 
 ## Candidate inventory
 

--- a/src/app/cache.rs
+++ b/src/app/cache.rs
@@ -14,7 +14,7 @@
 
 //! Cache statistics and management functionality
 
-use bssh::ssh::GLOBAL_CACHE;
+use bssh::{diagnosticln as eprintln, ssh::GLOBAL_CACHE};
 use owo_colors::OwoColorize;
 
 /// Handle cache statistics command

--- a/src/app/dispatcher.rs
+++ b/src/app/dispatcher.rs
@@ -26,6 +26,7 @@ use bssh::{
         upload::{FileTransferParams, upload_file},
     },
     config::InteractiveMode,
+    diagnosticln as eprintln,
     pty::PtyConfig,
     security::{Password, get_password, get_sudo_password},
     ssh::tokio_client::{AddressFamily, SshConnectionConfigResolver},

--- a/src/app/initialization.rs
+++ b/src/app/initialization.rs
@@ -137,6 +137,9 @@ pub fn looks_like_host_specification(s: &str) -> bool {
 pub async fn initialize_app(cli: &mut Cli, args: &[String]) -> Result<AppContext> {
     // Initialize logging
     init_logging(cli.verbose);
+    if let Some(path) = &cli.log_file {
+        tracing::debug!(path = %path.display(), "Appending bssh diagnostics to log file");
+    }
 
     // Early Backend.AI environment detection
     // Auto-set cluster if Backend.AI environment is detected and no explicit cluster/hosts specified

--- a/src/app/query.rs
+++ b/src/app/query.rs
@@ -14,6 +14,8 @@
 
 //! SSH query options handler (-Q option)
 
+use bssh::diagnosticln as eprintln;
+
 /// Handle SSH query options (-Q)
 pub fn handle_query(query: &str) {
     match query {

--- a/src/cli/bssh.rs
+++ b/src/cli/bssh.rs
@@ -160,6 +160,13 @@ pub struct Cli {
     pub output_dir: Option<PathBuf>,
 
     #[arg(
+        short = 'E',
+        value_name = "log_file",
+        help = "Append bssh diagnostics and debug logs to the specified file (SSH-compatible)"
+    )]
+    pub log_file: Option<PathBuf>,
+
+    #[arg(
         short = 'v',
         long,
         action = clap::ArgAction::Count,

--- a/src/cli/pdsh.rs
+++ b/src/cli/pdsh.rs
@@ -308,6 +308,7 @@ impl PdshCli {
             port: None,
             stream: false,
             output_dir: None,
+            log_file: None,
             verbose: 0,
             strict_host_key_checking: "accept-new".to_string(),
             require_all_success: false,

--- a/src/commands/exec.rs
+++ b/src/commands/exec.rs
@@ -16,6 +16,7 @@ use anyhow::Result;
 use std::path::Path;
 use std::sync::Arc;
 
+use crate::diagnosticln as eprintln;
 use crate::executor::{ExitCodeStrategy, OutputMode, ParallelExecutor, RankDetector};
 use crate::forwarding::ForwardingType;
 use crate::node::Node;

--- a/src/commands/interactive/execution.rs
+++ b/src/commands/interactive/execution.rs
@@ -19,6 +19,7 @@ use owo_colors::OwoColorize;
 use std::sync::Arc;
 
 use crate::commands::error_format::format_connection_error;
+use crate::diagnosticln as eprintln;
 use crate::pty::PtyManager;
 
 use super::super::interactive_signal::{

--- a/src/commands/interactive/multiplex.rs
+++ b/src/commands/interactive/multiplex.rs
@@ -22,6 +22,8 @@ use rustyline::config::Configurer;
 use rustyline::error::ReadlineError;
 use tokio::time::Duration;
 
+use crate::diagnosticln as eprintln;
+
 use super::super::interactive_signal::is_interrupted;
 use super::types::{
     InteractiveCommand, NODES_TO_SHOW_IN_COMPACT, NodeSession, SSH_OUTPUT_POLL_INTERVAL_MS,

--- a/src/commands/interactive/single_node.rs
+++ b/src/commands/interactive/single_node.rs
@@ -25,6 +25,8 @@ use tokio::sync::Mutex;
 use tokio::sync::mpsc;
 use tokio::time::Duration;
 
+use crate::diagnosticln as eprintln;
+
 use super::super::interactive_signal::is_interrupted;
 use super::types::{InteractiveCommand, NodeSession, SSH_OUTPUT_POLL_INTERVAL_MS};
 

--- a/src/commands/interactive_signal.rs
+++ b/src/commands/interactive_signal.rs
@@ -20,6 +20,8 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use tokio::signal;
 use tracing::{debug, info};
 
+use crate::diagnosticln as eprintln;
+
 /// Global flag for interrupt signal
 static INTERRUPTED: AtomicBool = AtomicBool::new(false);
 

--- a/src/executor/mod.rs
+++ b/src/executor/mod.rs
@@ -29,6 +29,7 @@ pub mod rank_detector;
 pub use connection_manager::download_dir_from_node;
 pub use exit_strategy::ExitCodeStrategy;
 pub use output_mode::{OutputMode, is_tty, should_use_colors};
+pub use output_sync::NodeOutputWriter;
 pub use parallel::ParallelExecutor;
 pub use rank_detector::RankDetector;
 pub use result_types::{DownloadResult, ExecutionResult, UploadResult};

--- a/src/executor/mod.rs
+++ b/src/executor/mod.rs
@@ -29,7 +29,6 @@ pub mod rank_detector;
 pub use connection_manager::download_dir_from_node;
 pub use exit_strategy::ExitCodeStrategy;
 pub use output_mode::{OutputMode, is_tty, should_use_colors};
-pub use output_sync::NodeOutputWriter;
 pub use parallel::ParallelExecutor;
 pub use rank_detector::RankDetector;
 pub use result_types::{DownloadResult, ExecutionResult, UploadResult};

--- a/src/executor/output_sync.rs
+++ b/src/executor/output_sync.rs
@@ -155,6 +155,11 @@ impl NodeOutputWriter {
 
 #[cfg(test)]
 mod tests {
+    use std::path::PathBuf;
+    use std::process::Command;
+
+    use tempfile::tempdir;
+
     use super::*;
 
     #[test]
@@ -192,5 +197,49 @@ mod tests {
         let lines = ["line1", "line2"];
         let _ = synchronized_print_lines(lines.iter().copied());
         let _ = synchronized_eprint_lines(lines.iter().copied());
+    }
+
+    #[test]
+    fn remote_stderr_helper() {
+        if std::env::var_os("BSSH_LOG_FILE_TEST_HELPER").is_none() {
+            return;
+        }
+
+        let log = PathBuf::from(
+            std::env::var_os("BSSH_LOG_FILE_TEST_PATH").expect("helper log path should be set"),
+        );
+        crate::utils::diagnostics::set_log_file(&log).expect("helper should open diagnostic log");
+        crate::diagnosticln!("bssh-owned diagnostic");
+        NodeOutputWriter::new_with_no_prefix("example", true)
+            .write_stderr_lines("remote command stderr")
+            .expect("helper should write remote stderr");
+    }
+
+    #[test]
+    fn remote_command_stderr_stays_on_fd_2() {
+        let directory = tempdir().expect("failed to create temporary directory");
+        let log = directory.path().join("bssh.log");
+        let output = Command::new(std::env::current_exe().expect("test executable should exist"))
+            .args([
+                "--exact",
+                "executor::output_sync::tests::remote_stderr_helper",
+                "--nocapture",
+            ])
+            .env("BSSH_LOG_FILE_TEST_HELPER", "1")
+            .env("BSSH_LOG_FILE_TEST_PATH", &log)
+            .output()
+            .expect("failed to run remote stderr helper");
+
+        assert!(output.status.success(), "remote stderr helper should pass");
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(
+            stderr.contains("remote command stderr"),
+            "stderr was: {stderr}"
+        );
+        assert!(!stderr.contains("bssh-owned diagnostic"));
+
+        let contents = std::fs::read_to_string(&log).expect("failed to read diagnostic log");
+        assert!(contents.contains("bssh-owned diagnostic"));
+        assert!(!contents.contains("remote command stderr"));
     }
 }

--- a/src/executor/parallel.rs
+++ b/src/executor/parallel.rs
@@ -21,6 +21,7 @@ use std::path::Path;
 use std::sync::Arc;
 use tokio::sync::Semaphore;
 
+use crate::diagnosticln as eprintln;
 use crate::node::Node;
 use crate::security::{Password, SudoPassword};
 use crate::ssh::SshConfig;

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::process::ExitCode;
+
 use anyhow::Result;
 use bssh::cli::{
     Cli, Commands, PdshCli, has_pdsh_compat_flag, is_pdsh_compat_mode, remove_pdsh_compat_flag,
@@ -38,7 +40,17 @@ use app::{
 /// 2. pdsh compatibility mode (via symlink, env var, or --pdsh-compat flag)
 /// 3. SSH compatibility mode (single host)
 #[tokio::main]
-async fn main() -> Result<()> {
+async fn main() -> ExitCode {
+    match run().await {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(error) => {
+            bssh::diagnosticln!("Error: {error:?}");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+async fn run() -> Result<()> {
     let args: Vec<String> = std::env::args().collect();
 
     // Check for pdsh compatibility mode
@@ -82,7 +94,7 @@ fn map_hard_failure(command: &Option<Commands>, error: anyhow::Error) -> anyhow:
     if matches!(command, Some(Commands::Ping)) {
         // Match the format anyhow's `Termination` impl uses, since this path
         // replaces it.
-        eprintln!("Error: {error:?}");
+        bssh::diagnosticln!("Error: {error:?}");
         std::process::exit(PING_SSH_LEVEL_FAILURE);
     }
 
@@ -113,15 +125,15 @@ async fn run_pdsh_mode(args: &[String]) -> Result<()> {
 
     // Check if we have hosts
     if cli.hosts.is_none() {
-        eprintln!("Error: No hosts specified. Use -w to specify target hosts.");
-        eprintln!("Usage: pdsh -w hosts command");
+        bssh::diagnosticln!("Error: No hosts specified. Use -w to specify target hosts.");
+        bssh::diagnosticln!("Usage: pdsh -w hosts command");
         std::process::exit(1);
     }
 
     // Check if we have a command (unless in query mode)
     if cli.command_args.is_empty() {
-        eprintln!("Error: No command specified.");
-        eprintln!("Usage: pdsh -w hosts command");
+        bssh::diagnosticln!("Error: No command specified.");
+        bssh::diagnosticln!("Usage: pdsh -w hosts command");
         std::process::exit(1);
     }
 
@@ -224,8 +236,8 @@ async fn handle_pdsh_query_mode(pdsh_cli: &PdshCli) -> Result<()> {
             }
         }
     } else {
-        eprintln!("Error: No hosts specified for query mode.");
-        eprintln!("Usage: pdsh -w hosts -q");
+        bssh::diagnosticln!("Error: No hosts specified for query mode.");
+        bssh::diagnosticln!("Usage: pdsh -w hosts -q");
         std::process::exit(1);
     }
 
@@ -242,6 +254,10 @@ async fn run_bssh_mode(args: &[String]) -> Result<()> {
     }
 
     let mut cli = Cli::parse();
+
+    if let Some(path) = &cli.log_file {
+        bssh::utils::diagnostics::set_log_file(path)?;
+    }
 
     // Handle SSH query option (-Q)
     if let Some(ref query) = cli.query {

--- a/src/pty/mod.rs
+++ b/src/pty/mod.rs
@@ -27,6 +27,8 @@ use terminal_size::{Height, Width, terminal_size};
 use tokio::sync::{mpsc, watch};
 use tokio::time::Duration;
 
+use crate::diagnosticln as eprintln;
+
 pub mod session;
 pub mod terminal;
 mod terminal_protocol;

--- a/src/pty/session/session_manager.rs
+++ b/src/pty/session/session_manager.rs
@@ -322,7 +322,9 @@ impl PtySession {
                             if let Err(e) = self.channel.data(data.as_slice()).await {
                                 tracing::error!("Failed to send data to SSH channel: {e}");
                                 // Connection likely dead - terminate gracefully
-                                eprintln!("\r\n[bssh] Connection lost: failed to send data to remote host\r");
+                                crate::diagnosticln!(
+                                    "\r\n[bssh] Connection lost: failed to send data to remote host\r"
+                                );
                                 should_terminate = true;
                             }
                         }

--- a/src/pty/terminal.rs
+++ b/src/pty/terminal.rs
@@ -26,6 +26,8 @@ use crossterm::{
     terminal::{disable_raw_mode, enable_raw_mode},
 };
 
+use crate::diagnosticln as eprintln;
+
 use super::terminal_protocol::{ProtocolState, capture_protocol_state, write_terminal_cleanup};
 use super::terminal_screen::ScreenModeTracker;
 

--- a/src/security/password.rs
+++ b/src/security/password.rs
@@ -37,6 +37,8 @@ use anyhow::Result;
 use secrecy::{ExposeSecret, SecretString};
 use std::fmt;
 
+use crate::diagnosticln as eprintln;
+
 /// A secure wrapper for SSH authentication passwords.
 ///
 /// Automatically clears its contents from memory when dropped. Designed to be

--- a/src/security/sudo.rs
+++ b/src/security/sudo.rs
@@ -223,7 +223,7 @@ pub fn get_sudo_password(warn_env: bool) -> Result<SudoPassword> {
     match get_sudo_password_from_env()? {
         Some(password) => {
             if warn_env {
-                eprintln!(
+                crate::diagnosticln!(
                     "Warning: Using sudo password from BSSH_SUDO_PASSWORD environment variable. \
                      This is not recommended for security reasons."
                 );

--- a/src/ssh/known_hosts.rs
+++ b/src/ssh/known_hosts.rs
@@ -16,6 +16,8 @@ use super::tokio_client::ServerCheckMethod;
 use std::path::PathBuf;
 use std::str::FromStr;
 
+use crate::diagnosticln as eprintln;
+
 /// Get the default known_hosts file path
 pub fn get_default_known_hosts_path() -> Option<PathBuf> {
     dirs::home_dir().map(|home| home.join(".ssh").join("known_hosts"))

--- a/src/ssh/tokio_client/host_verification.rs
+++ b/src/ssh/tokio_client/host_verification.rs
@@ -36,6 +36,8 @@
 //! host list, so a line like `@revoked node1 ssh-ed25519 <key>` never matches
 //! `node1` and is otherwise invisible to [`lookup_known_host`].
 
+use crate::diagnosticln as eprintln;
+
 use russh::keys::{Algorithm, HashAlg, PublicKey};
 #[cfg(test)]
 use std::sync::Mutex as StdMutex;

--- a/src/utils/diagnostics.rs
+++ b/src/utils/diagnostics.rs
@@ -1,0 +1,134 @@
+// Copyright 2025 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Routing for bssh-owned diagnostics.
+//!
+//! This deliberately does not replace file descriptor 2. Remote command
+//! stderr is written through `executor::output_sync` and must remain visible
+//! to the caller even when `ssh -E` compatibility logging is enabled.
+
+use std::fmt;
+use std::fs::{File, OpenOptions};
+use std::io::{self, Write};
+#[cfg(unix)]
+use std::os::unix::fs::OpenOptionsExt;
+use std::path::Path;
+use std::sync::Mutex;
+
+use anyhow::{Context, Result};
+use tracing_subscriber::fmt::MakeWriter;
+
+static LOG_FILE: Mutex<Option<File>> = Mutex::new(None);
+
+/// Open `path` as the destination for subsequent bssh diagnostics.
+///
+/// OpenSSH's `-E` option appends to an existing file. Opening is completed
+/// before tracing or application initialization so failures are reported on
+/// stderr and terminate the process instead of silently falling back.
+pub fn set_log_file(path: &Path) -> Result<()> {
+    let mut options = OpenOptions::new();
+    options.create(true).append(true);
+    #[cfg(unix)]
+    options.mode(0o600);
+
+    let file = options
+        .open(path)
+        .with_context(|| format!("Cannot open log file {}", path.display()))?;
+
+    let mut destination = LOG_FILE
+        .lock()
+        .map_err(|_| anyhow::anyhow!("diagnostic log lock is poisoned"))?;
+    *destination = Some(file);
+    Ok(())
+}
+
+/// Return whether diagnostics currently target an explicitly selected file.
+pub fn has_log_file() -> bool {
+    LOG_FILE
+        .lock()
+        .map(|destination| destination.is_some())
+        .unwrap_or(false)
+}
+
+fn write(bytes: &[u8]) -> io::Result<()> {
+    let mut destination = LOG_FILE
+        .lock()
+        .map_err(|_| io::Error::other("diagnostic log lock is poisoned"))?;
+    if let Some(file) = destination.as_mut() {
+        file.write_all(bytes)?;
+        file.flush()
+    } else {
+        let mut stderr = io::stderr().lock();
+        stderr.write_all(bytes)?;
+        stderr.flush()
+    }
+}
+
+/// Write one human-facing diagnostic line to the configured destination.
+pub fn write_line(arguments: fmt::Arguments<'_>) {
+    let mut line = String::new();
+    if fmt::write(&mut line, arguments).is_ok() {
+        line.push('\n');
+        let _ = write(line.as_bytes());
+    }
+}
+
+/// A tracing writer that emits each formatted event as one diagnostic write.
+#[derive(Debug, Default)]
+pub struct DiagnosticWriter {
+    buffer: Vec<u8>,
+}
+
+impl Write for DiagnosticWriter {
+    fn write(&mut self, bytes: &[u8]) -> io::Result<usize> {
+        self.buffer.extend_from_slice(bytes);
+        Ok(bytes.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        if self.buffer.is_empty() {
+            return Ok(());
+        }
+        let result = write(&self.buffer);
+        if result.is_ok() {
+            self.buffer.clear();
+        }
+        result
+    }
+}
+
+impl Drop for DiagnosticWriter {
+    fn drop(&mut self) {
+        let _ = self.flush();
+    }
+}
+
+/// Factory used by `tracing_subscriber` for diagnostic events.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct DiagnosticMakeWriter;
+
+impl<'a> MakeWriter<'a> for DiagnosticMakeWriter {
+    type Writer = DiagnosticWriter;
+
+    fn make_writer(&'a self) -> Self::Writer {
+        DiagnosticWriter::default()
+    }
+}
+
+#[macro_export]
+macro_rules! diagnosticln {
+    ($($argument:tt)*) => {
+        $crate::utils::diagnostics::write_line(format_args!($($argument)*))
+    };
+}

--- a/src/utils/logging.rs
+++ b/src/utils/logging.rs
@@ -14,6 +14,7 @@
 
 use crate::ui::tui::log_buffer::LogBuffer;
 use crate::ui::tui::log_layer::TuiLogLayer;
+use crate::utils::diagnostics::{self, DiagnosticMakeWriter};
 use std::io::IsTerminal;
 use std::sync::{Arc, Mutex, OnceLock};
 use tracing_subscriber::{EnvFilter, prelude::*};
@@ -67,7 +68,14 @@ pub fn init_logging(verbosity: u8) -> Arc<Mutex<LogBuffer>> {
 
     let filter = create_env_filter(verbosity);
 
-    if is_tui_likely() {
+    if diagnostics::has_log_file() {
+        tracing_subscriber::fmt()
+            .with_env_filter(filter)
+            .with_target(true)
+            .with_ansi(false)
+            .with_writer(DiagnosticMakeWriter)
+            .init();
+    } else if is_tui_likely() {
         // TUI mode: use TuiLogLayer to capture logs in buffer
         let tui_layer = TuiLogLayer::new(Arc::clone(&log_buffer));
 

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 pub mod buffer_pool;
+pub mod diagnostics;
 pub mod fs;
 pub mod logging;
 pub mod output;

--- a/tests/log_file_test.rs
+++ b/tests/log_file_test.rs
@@ -1,0 +1,173 @@
+// Copyright 2025 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+use bssh::cli::Cli;
+use bssh::executor::NodeOutputWriter;
+use clap::Parser;
+use tempfile::tempdir;
+
+fn run_bssh(arguments: &[&str]) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_bssh"))
+        .env_remove("RUST_LOG")
+        .env_remove("BSSH_PDSH_COMPAT")
+        .args(arguments)
+        .output()
+        .expect("failed to run bssh")
+}
+
+fn as_str(path: &Path) -> &str {
+    path.to_str().expect("temporary path should be UTF-8")
+}
+
+#[test]
+fn parses_separated_and_attached_log_file_options() {
+    let separated = Cli::try_parse_from(["bssh", "-E", "/tmp/bssh.log", "example.com"])
+        .expect("separated -E should parse");
+    let attached = Cli::try_parse_from(["bssh", "-E/tmp/bssh.log", "example.com"])
+        .expect("attached -Epath should parse");
+
+    let expected = Some(PathBuf::from("/tmp/bssh.log"));
+    assert_eq!(separated.log_file, expected);
+    assert_eq!(attached.log_file, expected);
+}
+
+#[test]
+fn human_diagnostics_are_routed_and_repeated_runs_append() {
+    let directory = tempdir().expect("failed to create temporary directory");
+    let log = directory.path().join("bssh.log");
+
+    for _ in 0..2 {
+        let output = run_bssh(&["-E", as_str(&log), "-Q", "not-a-query"]);
+        assert!(!output.status.success(), "an unknown query should fail");
+        assert!(
+            output.stderr.is_empty(),
+            "bssh diagnostic leaked to stderr: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    let contents = std::fs::read_to_string(&log).expect("failed to read diagnostic log");
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+
+        let mode = std::fs::metadata(&log)
+            .expect("failed to inspect diagnostic log")
+            .permissions()
+            .mode()
+            & 0o777;
+        assert_eq!(mode, 0o600, "new diagnostic logs must be private");
+    }
+    assert_eq!(
+        contents
+            .matches("Unknown query option: not-a-query")
+            .count(),
+        2
+    );
+    assert_eq!(
+        contents
+            .matches("Use 'bssh -Q help' to see available options")
+            .count(),
+        2
+    );
+}
+
+#[test]
+fn remote_stderr_helper() {
+    if std::env::var_os("BSSH_LOG_FILE_TEST_HELPER").is_none() {
+        return;
+    }
+
+    let log = PathBuf::from(
+        std::env::var_os("BSSH_LOG_FILE_TEST_PATH").expect("helper log path should be set"),
+    );
+    bssh::utils::diagnostics::set_log_file(&log).expect("helper should open diagnostic log");
+    bssh::diagnosticln!("bssh-owned diagnostic");
+    NodeOutputWriter::new_with_no_prefix("example", true)
+        .write_stderr_lines("remote command stderr")
+        .expect("helper should write remote stderr");
+}
+
+#[test]
+fn remote_command_stderr_stays_on_fd_2() {
+    let directory = tempdir().expect("failed to create temporary directory");
+    let log = directory.path().join("bssh.log");
+    let output = Command::new(std::env::current_exe().expect("test executable should exist"))
+        .args(["--exact", "remote_stderr_helper", "--nocapture"])
+        .env("BSSH_LOG_FILE_TEST_HELPER", "1")
+        .env("BSSH_LOG_FILE_TEST_PATH", &log)
+        .output()
+        .expect("failed to run remote stderr helper");
+
+    assert!(output.status.success(), "remote stderr helper should pass");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("remote command stderr"),
+        "stderr was: {stderr}"
+    );
+    assert!(!stderr.contains("bssh-owned diagnostic"));
+
+    let contents = std::fs::read_to_string(&log).expect("failed to read diagnostic log");
+    assert!(contents.contains("bssh-owned diagnostic"));
+    assert!(!contents.contains("remote command stderr"));
+}
+
+#[test]
+fn tracing_and_top_level_errors_use_the_log_file() {
+    let directory = tempdir().expect("failed to create temporary directory");
+    let log = directory.path().join("bssh.log");
+    let missing_config = directory.path().join("missing.yaml");
+
+    let output = run_bssh(&[
+        "-vv",
+        "-E",
+        as_str(&log),
+        "--config",
+        as_str(&missing_config),
+        "-H",
+        "example.invalid",
+        "true",
+    ]);
+
+    assert!(!output.status.success(), "missing config must fail");
+    assert!(
+        output.stderr.is_empty(),
+        "bssh diagnostic leaked to stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let contents = std::fs::read_to_string(&log).expect("failed to read diagnostic log");
+    assert!(contents.contains("Appending bssh diagnostics to log file"));
+    assert!(contents.contains("Config file not found"));
+    assert!(contents.contains(as_str(&missing_config)));
+}
+
+#[test]
+fn log_open_failure_is_actionable_and_exits_nonzero() {
+    let directory = tempdir().expect("failed to create temporary directory");
+    let output = run_bssh(&["-E", as_str(directory.path()), "-Q", "help"]);
+
+    assert!(!output.status.success(), "a directory cannot be a log file");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("Cannot open log file"),
+        "stderr was: {stderr}"
+    );
+    assert!(
+        stderr.contains(as_str(directory.path())),
+        "stderr did not name the failed path: {stderr}"
+    );
+}

--- a/tests/log_file_test.rs
+++ b/tests/log_file_test.rs
@@ -16,7 +16,6 @@ use std::path::{Path, PathBuf};
 use std::process::{Command, Output};
 
 use bssh::cli::Cli;
-use bssh::executor::NodeOutputWriter;
 use clap::Parser;
 use tempfile::tempdir;
 
@@ -84,46 +83,6 @@ fn human_diagnostics_are_routed_and_repeated_runs_append() {
             .count(),
         2
     );
-}
-
-#[test]
-fn remote_stderr_helper() {
-    if std::env::var_os("BSSH_LOG_FILE_TEST_HELPER").is_none() {
-        return;
-    }
-
-    let log = PathBuf::from(
-        std::env::var_os("BSSH_LOG_FILE_TEST_PATH").expect("helper log path should be set"),
-    );
-    bssh::utils::diagnostics::set_log_file(&log).expect("helper should open diagnostic log");
-    bssh::diagnosticln!("bssh-owned diagnostic");
-    NodeOutputWriter::new_with_no_prefix("example", true)
-        .write_stderr_lines("remote command stderr")
-        .expect("helper should write remote stderr");
-}
-
-#[test]
-fn remote_command_stderr_stays_on_fd_2() {
-    let directory = tempdir().expect("failed to create temporary directory");
-    let log = directory.path().join("bssh.log");
-    let output = Command::new(std::env::current_exe().expect("test executable should exist"))
-        .args(["--exact", "remote_stderr_helper", "--nocapture"])
-        .env("BSSH_LOG_FILE_TEST_HELPER", "1")
-        .env("BSSH_LOG_FILE_TEST_PATH", &log)
-        .output()
-        .expect("failed to run remote stderr helper");
-
-    assert!(output.status.success(), "remote stderr helper should pass");
-    let stderr = String::from_utf8_lossy(&output.stderr);
-    assert!(
-        stderr.contains("remote command stderr"),
-        "stderr was: {stderr}"
-    );
-    assert!(!stderr.contains("bssh-owned diagnostic"));
-
-    let contents = std::fs::read_to_string(&log).expect("failed to read diagnostic log");
-    assert!(contents.contains("bssh-owned diagnostic"));
-    assert!(!contents.contains("remote command stderr"));
 }
 
 #[test]

--- a/tests/openssh-regress/baseline.json
+++ b/tests/openssh-regress/baseline.json
@@ -1,11 +1,11 @@
 {
   "minimum_eligible": {
-    "linux": 73,
-    "macos": 71
+    "linux": 67,
+    "macos": 65
   },
   "minimum_pass": {
-    "linux": 0,
-    "macos": 0
+    "linux": 23,
+    "macos": 23
   },
   "openssh_tag": "V_10_3_P1",
   "schema_version": 1


### PR DESCRIPTION
## Summary

- accept both `-E log_file` and attached `-Elog_file` syntax
- append bssh diagnostics and tracing to a private log file while leaving remote command stderr on fd 2
- route human-facing warnings and terminal errors through the selected diagnostic sink
- fail with an actionable stderr message when the log cannot be opened
- enforce evidence-backed nonzero OpenSSH compatibility floors

## Testing

- `cargo test --locked --test log_file_test` (4 passed)
- `cargo test --locked executor::output_sync::tests::remote_command_stderr_stays_on_fd_2` (1 passed)
- `cargo test --locked --test ping_exit_code_test` (8 passed)
- `cargo test --locked --test pdsh_compat_test` (35 passed)
- `cargo check --locked --bin bssh`
- `cargo clippy --locked --bin bssh -- -D warnings`
- `cargo fmt --all -- --check`
- OpenSSH harness self-tests (13 passed) and manifest validation (78 runnable, 11 permanent skips, 26 excluded)
- first complete Linux run: 25 passed of 67 eligible; conservative pass floor 23
- first complete macOS run: 26 passed of 65 eligible; conservative pass floor 23
- focused OpenSSH regress: `addrmatch` passed; `stderr-data` reached its test body and exposed a later existing I/O compatibility failure while the reference client passed

## Review fixes

- route the remaining PTY connection-loss diagnostic through `-E`
- keep the remote-stderr contract test inside the private executor module
- recalibrate eligible floors for six newly reached upstream skips while preserving platform environmental allowances

Closes #277