### PR TITLE
fix(security): honor configured known-hosts files

### DIFF
--- a/src/commands/exec.rs
+++ b/src/commands/exec.rs
@@ -167,7 +167,13 @@ async fn execute_command_with_forwarding(params: ExecuteCommandParams<'_>) -> Re
     // connection path (#239). The previous hand-rolled match sent accept-new
     // through strict default-known_hosts checking, which rejected unknown
     // hosts instead of recording them.
-    let server_check = crate::ssh::known_hosts::get_check_method(params.strict_mode);
+    let server_check = crate::ssh::known_hosts::get_check_method_for_target(
+        params.strict_mode,
+        &ssh_connection_config,
+        &node.host,
+        node.port,
+        &node.username,
+    );
 
     // Create SSH client. Going through `connect_with_ssh_config` rather than
     // `connect` gives this path the resolved keepalive, compression, and

--- a/src/commands/interactive/connection.rs
+++ b/src/commands/interactive/connection.rs
@@ -25,7 +25,7 @@ use zeroize::Zeroizing;
 use crate::jump::{JumpHostChain, parse_jump_hosts};
 use crate::node::Node;
 use crate::ssh::{
-    known_hosts::get_check_method,
+    known_hosts::get_check_method_for_target,
     tokio_client::{AuthMethod, Client, Error as SshError, ServerCheckMethod, SshConnectionConfig},
 };
 
@@ -213,7 +213,13 @@ impl InteractiveCommand {
         let auth_method = self.determine_auth_method(&node).await?;
 
         // Set up host key checking using the configured strict mode
-        let check_method = get_check_method(self.strict_mode);
+        let check_method = get_check_method_for_target(
+            self.strict_mode,
+            &self.ssh_connection_config,
+            &node.host,
+            node.port,
+            &node.username,
+        );
 
         // Connect with timeout
         let addr = (node.host.as_str(), node.port);
@@ -360,7 +366,13 @@ impl InteractiveCommand {
         let auth_method = self.determine_auth_method(&node).await?;
 
         // Set up host key checking using the configured strict mode
-        let check_method = get_check_method(self.strict_mode);
+        let check_method = get_check_method_for_target(
+            self.strict_mode,
+            &self.ssh_connection_config,
+            &node.host,
+            node.port,
+            &node.username,
+        );
 
         // Connect with timeout
         let addr = (node.host.as_str(), node.port);

--- a/src/jump/chain.rs
+++ b/src/jump/chain.rs
@@ -420,7 +420,13 @@ impl JumpHostChain {
             &self.auth_mutex,
         )
         .await?;
-        let check_method = crate::ssh::known_hosts::get_check_method(strict_mode);
+        let check_method = crate::ssh::known_hosts::get_check_method_for_target(
+            strict_mode,
+            &ssh_connection_config,
+            &jump_host.host,
+            jump_host.effective_port(),
+            &effective_user,
+        );
 
         let client = tokio::time::timeout(
             self.connect_timeout,

--- a/src/jump/chain/chain_connection.rs
+++ b/src/jump/chain/chain_connection.rs
@@ -39,9 +39,12 @@ pub(super) async fn connect_direct(
         .await
         .with_context(|| format!("Rate limited for host {host}"))?;
 
-    let check_method = strict_mode.map_or_else(
-        || crate::ssh::known_hosts::get_check_method(StrictHostKeyChecking::AcceptNew),
-        crate::ssh::known_hosts::get_check_method,
+    let check_method = crate::ssh::known_hosts::get_check_method_for_target(
+        strict_mode.unwrap_or(StrictHostKeyChecking::AcceptNew),
+        ssh_connection_config,
+        host,
+        port,
+        username,
     );
 
     let client = tokio::time::timeout(

--- a/src/jump/chain/tunnel.rs
+++ b/src/jump/chain/tunnel.rs
@@ -156,7 +156,13 @@ pub(super) async fn connect_through_tunnel(
     })?;
 
     // SECURITY: Always verify host keys for jump hosts to prevent MITM attacks
-    let check_method = crate::ssh::known_hosts::get_check_method(strict_mode);
+    let check_method = crate::ssh::known_hosts::get_check_method_for_target(
+        strict_mode,
+        ssh_connection_config,
+        &jump_host.host,
+        jump_host.effective_port(),
+        &jump_host.effective_user(),
+    );
 
     let handler = ClientHandler::new(jump_host.host.clone(), socket_addr, check_method);
 
@@ -262,7 +268,13 @@ pub(super) async fn connect_to_destination(
 
     // Create SSH client over the tunnel stream with keepalive settings
     let config = Arc::new(ssh_connection_config.to_russh_config());
-    let check_method = crate::ssh::known_hosts::get_check_method(strict_mode);
+    let check_method = crate::ssh::known_hosts::get_check_method_for_target(
+        strict_mode,
+        ssh_connection_config,
+        destination_host,
+        destination_port,
+        destination_user,
+    );
 
     // As in `connect_through_tunnel`, this address only supplies host key
     // verification context and display text for a connection that rides an

--- a/src/shared/auth_types.rs
+++ b/src/shared/auth_types.rs
@@ -295,6 +295,15 @@ pub enum ServerCheckMethod {
     /// and changed keys are rejected.
     AcceptNewKnownHostsFile(String),
 
+    /// Verify against several known_hosts files in declared lookup order.
+    KnownHostsFiles(Vec<String>),
+
+    /// Trust On First Use across several read stores, recording only to the
+    /// explicitly selected user store when one exists.
+    AcceptNewKnownHostsFiles {
+        files: Vec<String>,
+        write_path: Option<String>,
+    },
     /// Trust On First Use for the lifetime of this process only.
     AcceptNewInMemory,
 }
@@ -351,6 +360,13 @@ impl From<crate::ssh::tokio_client::ServerCheckMethod> for ServerCheckMethod {
             crate::ssh::tokio_client::ServerCheckMethod::KnownHostsFile(path) => {
                 Self::KnownHostsFile(path)
             }
+            crate::ssh::tokio_client::ServerCheckMethod::KnownHostsFiles(paths) => {
+                Self::KnownHostsFiles(paths)
+            }
+            crate::ssh::tokio_client::ServerCheckMethod::AcceptNewKnownHostsFiles {
+                files,
+                write_path,
+            } => Self::AcceptNewKnownHostsFiles { files, write_path },
             crate::ssh::tokio_client::ServerCheckMethod::AcceptNewKnownHostsFile(path) => {
                 Self::AcceptNewKnownHostsFile(path)
             }
@@ -370,6 +386,10 @@ impl From<ServerCheckMethod> for crate::ssh::tokio_client::ServerCheckMethod {
             ServerCheckMethod::DefaultKnownHostsFile => Self::DefaultKnownHostsFile,
             ServerCheckMethod::KnownHostsFile(path) => Self::KnownHostsFile(path),
             ServerCheckMethod::AcceptNewKnownHostsFile(path) => Self::AcceptNewKnownHostsFile(path),
+            ServerCheckMethod::KnownHostsFiles(paths) => Self::KnownHostsFiles(paths),
+            ServerCheckMethod::AcceptNewKnownHostsFiles { files, write_path } => {
+                Self::AcceptNewKnownHostsFiles { files, write_path }
+            }
             ServerCheckMethod::AcceptNewInMemory => Self::AcceptNewInMemory,
         }
     }
@@ -452,5 +472,24 @@ mod tests {
         let in_memory: ServerCheckMethod =
             crate::ssh::tokio_client::ServerCheckMethod::AcceptNewInMemory.into();
         assert_eq!(in_memory, ServerCheckMethod::AcceptNewInMemory);
+    }
+
+    #[test]
+    fn test_multi_file_server_check_methods_round_trip() {
+        for shared in [
+            ServerCheckMethod::KnownHostsFiles(vec!["user".into(), "global".into()]),
+            ServerCheckMethod::AcceptNewKnownHostsFiles {
+                files: vec!["user".into(), "global".into()],
+                write_path: Some("user".into()),
+            },
+            ServerCheckMethod::AcceptNewKnownHostsFiles {
+                files: vec!["global".into()],
+                write_path: None,
+            },
+        ] {
+            let client: crate::ssh::tokio_client::ServerCheckMethod = shared.clone().into();
+            let round_trip: ServerCheckMethod = client.into();
+            assert_eq!(round_trip, shared);
+        }
     }
 }

--- a/src/ssh/client/connection.rs
+++ b/src/ssh/client/connection.rs
@@ -150,7 +150,6 @@ impl SshClient {
         let start_time = std::time::Instant::now();
 
         let addr = (self.host.as_str(), self.port);
-        let check_method = crate::ssh::known_hosts::get_check_method(strict_mode);
 
         let connect_timeout =
             Duration::from_secs(connect_timeout_seconds.unwrap_or(SSH_CONNECT_TIMEOUT_SECS));
@@ -163,6 +162,13 @@ impl SshClient {
                 &default_conn_cfg
             }
         };
+        let check_method = crate::ssh::known_hosts::get_check_method_for_target(
+            strict_mode,
+            conn_cfg,
+            &self.host,
+            self.port,
+            &self.username,
+        );
 
         let result = match tokio::time::timeout(
             connect_timeout,

--- a/src/ssh/known_hosts.rs
+++ b/src/ssh/known_hosts.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use super::tokio_client::ServerCheckMethod;
+use super::tokio_client::{ServerCheckMethod, SshConnectionConfig};
 use std::path::PathBuf;
 use std::str::FromStr;
 
@@ -80,6 +80,149 @@ pub fn get_check_method(strict_mode: StrictHostKeyChecking) -> ServerCheckMethod
             }
         },
     }
+}
+
+/// Select host-key verification from the effective ssh_config for a target.
+///
+/// OpenSSH accepts multiple user and global files. bssh preserves their
+/// declared order, reads user files before global files, and records a new
+/// key only into the first usable user file. The default file is used only
+/// when neither directive was configured.
+pub fn get_check_method_for_target(
+    strict_mode: StrictHostKeyChecking,
+    connection_config: &SshConnectionConfig,
+    hostname: &str,
+    port: u16,
+    remote_username: &str,
+) -> ServerCheckMethod {
+    if matches!(strict_mode, StrictHostKeyChecking::No) {
+        return ServerCheckMethod::NoCheck;
+    }
+
+    let user_configured = connection_config.user_known_hosts_files.is_some();
+    let global_configured = connection_config.global_known_hosts_files.is_some();
+    if !user_configured && !global_configured {
+        return get_check_method(strict_mode);
+    }
+
+    let user_files = expand_known_hosts_files(
+        connection_config.user_known_hosts_files.as_deref(),
+        hostname,
+        port,
+        remote_username,
+    );
+    let global_files = expand_known_hosts_files(
+        connection_config.global_known_hosts_files.as_deref(),
+        hostname,
+        port,
+        remote_username,
+    );
+    let write_path = user_files.first().cloned();
+    let files = user_files.into_iter().chain(global_files).collect();
+
+    match strict_mode {
+        StrictHostKeyChecking::Yes => ServerCheckMethod::KnownHostsFiles(files),
+        StrictHostKeyChecking::AcceptNew => {
+            ServerCheckMethod::AcceptNewKnownHostsFiles { files, write_path }
+        }
+        StrictHostKeyChecking::No => ServerCheckMethod::NoCheck,
+    }
+}
+
+fn expand_known_hosts_files(
+    templates: Option<&[String]>,
+    hostname: &str,
+    port: u16,
+    remote_username: &str,
+) -> Vec<String> {
+    templates
+        .into_iter()
+        .flatten()
+        .filter_map(|template| expand_known_hosts_path(template, hostname, port, remote_username))
+        .collect()
+}
+
+fn expand_known_hosts_path(
+    template: &str,
+    hostname: &str,
+    port: u16,
+    remote_username: &str,
+) -> Option<String> {
+    if template.eq_ignore_ascii_case("none") || template == "/dev/null" {
+        return None;
+    }
+
+    let home = dirs::home_dir().map(|path| path.to_string_lossy().into_owned());
+    let local_username = std::env::var("USER")
+        .or_else(|_| std::env::var("USERNAME"))
+        .or_else(|_| std::env::var("LOGNAME"))
+        .unwrap_or_else(|_| whoami::username().unwrap_or_else(|_| "user".to_string()));
+    let port = port.to_string();
+    let mut expanded = String::with_capacity(template.len());
+    let mut chars = template.chars();
+
+    while let Some(ch) = chars.next() {
+        if ch != '%' {
+            expanded.push(ch);
+            continue;
+        }
+        let Some(token) = chars.next() else {
+            tracing::warn!("Ignoring known_hosts path with a trailing '%' token: {template}");
+            return None;
+        };
+        match token {
+            '%' => expanded.push('%'),
+            'd' => {
+                let Some(home) = home.as_deref() else {
+                    tracing::warn!(
+                        "Ignoring known_hosts path requiring %d because no home directory is available: {template}"
+                    );
+                    return None;
+                };
+                expanded.push_str(home);
+            }
+            'h' => expanded.push_str(hostname),
+            'p' => expanded.push_str(&port),
+            'r' => expanded.push_str(remote_username),
+            'u' => expanded.push_str(&local_username),
+            other => {
+                tracing::warn!(
+                    "Ignoring known_hosts path with unsupported %{other} token: {template}"
+                );
+                return None;
+            }
+        }
+    }
+
+    if expanded == "~" {
+        let Some(home) = home else {
+            tracing::warn!(
+                "Ignoring known_hosts path requiring tilde expansion because no home directory is available: {template}"
+            );
+            return None;
+        };
+        return Some(home);
+    }
+    if let Some(suffix) = expanded.strip_prefix("~/") {
+        let Some(home) = home else {
+            tracing::warn!(
+                "Ignoring known_hosts path requiring tilde expansion because no home directory is available: {template}"
+            );
+            return None;
+        };
+        return Some(
+            PathBuf::from(home)
+                .join(suffix)
+                .to_string_lossy()
+                .into_owned(),
+        );
+    }
+
+    if expanded.eq_ignore_ascii_case("none") || expanded == "/dev/null" {
+        return None;
+    }
+
+    Some(expanded)
 }
 
 /// Mode for host key checking
@@ -207,5 +350,109 @@ mod tests {
             ServerCheckMethod::DefaultKnownHostsFile => {}
             other => panic!("strict mode must keep verification enabled, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn configured_known_hosts_files_preserve_order_and_expand_tokens() {
+        let config = SshConnectionConfig::new().with_known_hosts_files(
+            Some(vec![
+                "/tmp/user-first".to_string(),
+                "none".to_string(),
+                "/dev/null".to_string(),
+                "/tmp/%h-%p-%r-%u".to_string(),
+            ]),
+            Some(vec!["/tmp/global".to_string()]),
+        );
+        let local_username = std::env::var("USER")
+            .or_else(|_| std::env::var("USERNAME"))
+            .or_else(|_| std::env::var("LOGNAME"))
+            .unwrap_or_else(|_| whoami::username().unwrap_or_else(|_| "user".to_string()));
+
+        let method = get_check_method_for_target(
+            StrictHostKeyChecking::Yes,
+            &config,
+            "node.example.com",
+            2222,
+            "remote",
+        );
+        assert_eq!(
+            method,
+            ServerCheckMethod::KnownHostsFiles(vec![
+                "/tmp/user-first".to_string(),
+                format!("/tmp/node.example.com-2222-remote-{local_username}"),
+                "/tmp/global".to_string(),
+            ])
+        );
+    }
+
+    #[test]
+    fn accept_new_records_only_to_first_expanded_user_file() {
+        let config = SshConnectionConfig::new().with_known_hosts_files(
+            Some(vec!["/tmp/%h-first".to_string(), "/tmp/second".to_string()]),
+            Some(vec!["/tmp/global".to_string()]),
+        );
+
+        let method = get_check_method_for_target(
+            StrictHostKeyChecking::AcceptNew,
+            &config,
+            "node",
+            22,
+            "remote",
+        );
+        assert_eq!(
+            method,
+            ServerCheckMethod::AcceptNewKnownHostsFiles {
+                files: vec![
+                    "/tmp/node-first".to_string(),
+                    "/tmp/second".to_string(),
+                    "/tmp/global".to_string(),
+                ],
+                write_path: Some("/tmp/node-first".to_string()),
+            }
+        );
+    }
+
+    #[test]
+    fn configured_empty_stores_do_not_fall_back_to_default() {
+        let config = SshConnectionConfig::new().with_known_hosts_files(
+            Some(vec!["none".to_string(), "/dev/null".to_string()]),
+            None,
+        );
+
+        let method =
+            get_check_method_for_target(StrictHostKeyChecking::Yes, &config, "node", 22, "remote");
+        assert_eq!(method, ServerCheckMethod::KnownHostsFiles(Vec::new()));
+    }
+
+    #[test]
+    fn resolver_preserves_multiple_known_hosts_paths_and_empty_sentinels() {
+        let ssh_config = crate::ssh::SshConfig::parse(
+            "Host target\n  UserKnownHostsFile ~/.ssh/one /dev/null none\n  GlobalKnownHostsFile %d/global %h-%p-%r-%u\n",
+        )
+        .unwrap();
+        let host = crate::ssh::tokio_client::SshConnectionConfigResolver::new()
+            .with_ssh_config(Some(ssh_config))
+            .resolve_for_host("target");
+        assert_eq!(
+            host.user_known_hosts_files,
+            Some(vec!["~/.ssh/one".into(), "/dev/null".into(), "none".into()])
+        );
+        assert_eq!(
+            host.global_known_hosts_files,
+            Some(vec!["%d/global".into(), "%h-%p-%r-%u".into()])
+        );
+    }
+
+    #[test]
+    fn expands_home_directory_tokens_and_tilde() {
+        let home = dirs::home_dir().expect("test environment must have a home directory");
+        assert_eq!(
+            expand_known_hosts_path("%d/.ssh/custom", "node", 22, "remote"),
+            Some(home.join(".ssh/custom").to_string_lossy().into_owned())
+        );
+        assert_eq!(
+            expand_known_hosts_path("~/.ssh/other", "node", 22, "remote"),
+            Some(home.join(".ssh/other").to_string_lossy().into_owned())
+        );
     }
 }

--- a/src/ssh/ssh_config/parser/options/security.rs
+++ b/src/ssh/ssh_config/parser/options/security.rs
@@ -18,7 +18,6 @@
 //! verification, known hosts files, and cryptographic algorithms.
 
 use crate::ssh::ssh_config::parser::helpers::parse_yes_no;
-use crate::ssh::ssh_config::security::secure_validate_path;
 use crate::ssh::ssh_config::types::SshHostConfig;
 use anyhow::{Context, Result};
 
@@ -46,21 +45,13 @@ pub(super) fn parse_security_option(
             if args.is_empty() {
                 anyhow::bail!("UserKnownHostsFile requires a value at line {line_number}");
             }
-            let path =
-                secure_validate_path(&args[0], "known_hosts", line_number).with_context(|| {
-                    format!("Invalid UserKnownHostsFile path at line {line_number}")
-                })?;
-            host.user_known_hosts_file = Some(path);
+            host.user_known_hosts_file = Some(args.to_vec());
         }
         "globalknownhostsfile" => {
             if args.is_empty() {
                 anyhow::bail!("GlobalKnownHostsFile requires a value at line {line_number}");
             }
-            let path =
-                secure_validate_path(&args[0], "known_hosts", line_number).with_context(|| {
-                    format!("Invalid GlobalKnownHostsFile path at line {line_number}")
-                })?;
-            host.global_known_hosts_file = Some(path);
+            host.global_known_hosts_file = Some(args.to_vec());
         }
         "hostkeyalgorithms" => {
             if args.is_empty() {

--- a/src/ssh/ssh_config/types.rs
+++ b/src/ssh/ssh_config/types.rs
@@ -45,8 +45,13 @@ pub struct SshHostConfig {
     /// client implementation as bssh doesn't currently support proxy connections.
     pub proxy_use_fdpass: Option<bool>,
     pub strict_host_key_checking: Option<String>,
-    pub user_known_hosts_file: Option<PathBuf>,
-    pub global_known_hosts_file: Option<PathBuf>,
+    /// Raw `UserKnownHostsFile` values in OpenSSH lookup order.
+    ///
+    /// Expansion is intentionally deferred until connection time because the
+    /// supported `%h`, `%p`, and `%r` tokens depend on the concrete target.
+    pub user_known_hosts_file: Option<Vec<String>>,
+    /// Raw `GlobalKnownHostsFile` values in OpenSSH lookup order.
+    pub global_known_hosts_file: Option<Vec<String>>,
     pub forward_agent: Option<bool>,
     pub forward_x11: Option<bool>,
     pub server_alive_interval: Option<u32>,

--- a/src/ssh/tokio_client/authentication.rs
+++ b/src/ssh/tokio_client/authentication.rs
@@ -196,6 +196,14 @@ pub enum ServerCheckMethod {
     DefaultKnownHostsFile,
     /// Use a specific known_hosts file path
     KnownHostsFile(String),
+    /// Verify against several known_hosts files in declared lookup order.
+    KnownHostsFiles(Vec<String>),
+    /// Trust On First Use across several read stores, recording only to the
+    /// first explicitly configured user store when one exists.
+    AcceptNewKnownHostsFiles {
+        files: Vec<String>,
+        write_path: Option<String>,
+    },
     /// Trust On First Use against a specific known_hosts file path:
     /// matching keys are accepted, unknown hosts are recorded and accepted,
     /// changed keys are rejected (OpenSSH `StrictHostKeyChecking=accept-new`)

--- a/src/ssh/tokio_client/connection.rs
+++ b/src/ssh/tokio_client/connection.rs
@@ -92,6 +92,15 @@ pub struct SshConnectionConfig {
     /// applied in [`Client::connect_with_ssh_config`]; see `ARCHITECTURE.md`
     /// ("Address Family Preference") for the scope of that constraint.
     pub address_family: AddressFamily,
+
+    /// Raw `UserKnownHostsFile` values selected for this host.
+    ///
+    /// They stay unexpanded until the connection target supplies `%h`, `%p`,
+    /// and `%r` values to host-key verification.
+    pub user_known_hosts_files: Option<Vec<String>>,
+
+    /// Raw `GlobalKnownHostsFile` values selected for this host.
+    pub global_known_hosts_files: Option<Vec<String>>,
 }
 
 impl Default for SshConnectionConfig {
@@ -101,6 +110,8 @@ impl Default for SshConnectionConfig {
             keepalive_max: DEFAULT_KEEPALIVE_MAX,
             compression: false,
             address_family: AddressFamily::Any,
+            user_known_hosts_files: None,
+            global_known_hosts_files: None,
         }
     }
 }
@@ -216,6 +227,17 @@ impl SshConnectionConfigResolver {
             AddressFamily::resolve(false, false, config_address_family.as_deref())
         });
 
+        let host_config = self
+            .ssh_config
+            .as_ref()
+            .map(|config| config.find_host_config(hostname));
+        let user_known_hosts_files = host_config
+            .as_ref()
+            .and_then(|config| config.user_known_hosts_file.clone());
+        let global_known_hosts_files = host_config
+            .as_ref()
+            .and_then(|config| config.global_known_hosts_file.clone());
+
         SshConnectionConfig::new()
             .with_keepalive_interval(if keepalive_interval == 0 {
                 None
@@ -225,6 +247,7 @@ impl SshConnectionConfigResolver {
             .with_keepalive_max(keepalive_max)
             .with_compression(compression)
             .with_address_family(address_family)
+            .with_known_hosts_files(user_known_hosts_files, global_known_hosts_files)
     }
 }
 
@@ -252,6 +275,18 @@ impl SshConnectionConfig {
     /// Create a new configuration with default values.
     pub fn new() -> Self {
         Self::default()
+    }
+
+    /// Attach the raw known-hosts path lists selected from ssh_config.
+    #[must_use]
+    pub fn with_known_hosts_files(
+        mut self,
+        user_files: Option<Vec<String>>,
+        global_files: Option<Vec<String>>,
+    ) -> Self {
+        self.user_known_hosts_files = user_files;
+        self.global_known_hosts_files = global_files;
+        self
     }
 
     /// Set the keepalive interval in seconds.
@@ -756,6 +791,14 @@ impl Handler for ClientHandler {
                     known_hosts_path,
                 )
             }
+            ServerCheckMethod::KnownHostsFiles(known_hosts_paths) => {
+                super::host_verification::verify_known_hosts_files(
+                    &self.hostname,
+                    self.host.port(),
+                    server_public_key,
+                    known_hosts_paths,
+                )
+            }
             ServerCheckMethod::DefaultKnownHostsFile => {
                 // Resolve the default path here rather than letting russh
                 // resolve it internally, so the check and the changed-key
@@ -784,6 +827,16 @@ impl Handler for ClientHandler {
                     self.host.port(),
                     server_public_key,
                     known_hosts_path,
+                )
+                .await
+            }
+            ServerCheckMethod::AcceptNewKnownHostsFiles { files, write_path } => {
+                super::host_verification::verify_accept_new_files(
+                    &self.hostname,
+                    self.host.port(),
+                    server_public_key,
+                    files,
+                    write_path.as_deref(),
                 )
                 .await
             }

--- a/src/ssh/tokio_client/host_verification.rs
+++ b/src/ssh/tokio_client/host_verification.rs
@@ -831,6 +831,134 @@ pub(super) fn verify_known_hosts_file(
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum KnownHostsFilesLookup {
+    Match,
+    Conflict { path: String, line: usize },
+    Unknown,
+}
+
+fn lookup_known_host_files(
+    hostname: &str,
+    port: u16,
+    server_public_key: &PublicKey,
+    known_hosts_paths: &[String],
+) -> Result<KnownHostsFilesLookup, super::Error> {
+    for path in known_hosts_paths {
+        probe_known_hosts_path(path)?;
+        check_marker_lines(hostname, port, server_public_key, path)?;
+    }
+
+    let mut conflict = None;
+    for path in known_hosts_paths {
+        match lookup_known_host(hostname, port, server_public_key, path) {
+            Ok(KnownHostLookup::Match) => return Ok(KnownHostsFilesLookup::Match),
+            Ok(KnownHostLookup::Conflict { line }) => {
+                conflict.get_or_insert_with(|| KnownHostsFilesLookup::Conflict {
+                    path: path.clone(),
+                    line,
+                });
+            }
+            Ok(KnownHostLookup::Unknown) => {}
+            Err(error) => {
+                return Err(map_known_hosts_error(
+                    hostname,
+                    port,
+                    server_public_key,
+                    path,
+                    error,
+                ));
+            }
+        }
+    }
+
+    Ok(conflict.unwrap_or(KnownHostsFilesLookup::Unknown))
+}
+
+/// Verify a server key against every configured user/global known-hosts file.
+pub(super) fn verify_known_hosts_files(
+    hostname: &str,
+    port: u16,
+    server_public_key: &PublicKey,
+    known_hosts_paths: &[String],
+) -> Result<bool, super::Error> {
+    let hostname = hostname.to_ascii_lowercase();
+    let hostname = hostname.as_str();
+    ensure_recordable_hostname(hostname)?;
+
+    match lookup_known_host_files(hostname, port, server_public_key, known_hosts_paths)? {
+        KnownHostsFilesLookup::Match => Ok(true),
+        KnownHostsFilesLookup::Unknown => Ok(false),
+        KnownHostsFilesLookup::Conflict { path, line } => Err(map_known_hosts_error(
+            hostname,
+            port,
+            server_public_key,
+            &path,
+            russh::keys::Error::KeyChanged { line },
+        )),
+    }
+}
+
+/// Apply accept-new semantics across every configured read store and record a
+/// genuinely unknown key only into the explicitly selected user write store.
+pub(super) async fn verify_accept_new_files(
+    hostname: &str,
+    port: u16,
+    server_public_key: &PublicKey,
+    known_hosts_paths: &[String],
+    write_path: Option<&str>,
+) -> Result<bool, super::Error> {
+    let hostname = hostname.to_ascii_lowercase();
+    let hostname = hostname.as_str();
+    ensure_recordable_hostname(hostname)?;
+    let trust_scope = (!known_hosts_paths.is_empty()).then(|| known_hosts_paths.join("\0"));
+
+    match lookup_known_host_files(hostname, port, server_public_key, known_hosts_paths)? {
+        KnownHostsFilesLookup::Match => {
+            verify_process_pin(hostname, port, trust_scope.as_deref(), server_public_key).await?;
+            return Ok(true);
+        }
+        KnownHostsFilesLookup::Conflict { path, line } => {
+            return Err(map_known_hosts_error(
+                hostname,
+                port,
+                server_public_key,
+                &path,
+                russh::keys::Error::KeyChanged { line },
+            ));
+        }
+        KnownHostsFilesLookup::Unknown => {}
+    }
+
+    let _guard = KNOWN_HOSTS_LOCK.lock().await;
+    let _file_lock = match write_path {
+        Some(path) => Some(acquire_known_hosts_file_lock(path)?),
+        None => None,
+    };
+
+    match lookup_known_host_files(hostname, port, server_public_key, known_hosts_paths)? {
+        KnownHostsFilesLookup::Match => {
+            verify_process_pin(hostname, port, trust_scope.as_deref(), server_public_key).await?;
+            Ok(true)
+        }
+        KnownHostsFilesLookup::Conflict { path, line } => Err(map_known_hosts_error(
+            hostname,
+            port,
+            server_public_key,
+            &path,
+            russh::keys::Error::KeyChanged { line },
+        )),
+        KnownHostsFilesLookup::Unknown => {
+            verify_process_pin(hostname, port, trust_scope.as_deref(), server_public_key).await?;
+            if let Some(path) = write_path {
+                record_host_key(hostname, port, server_public_key, path);
+            }
+            remember_process_pin(hostname, port, trust_scope.as_deref(), server_public_key).await;
+            Ok(true)
+        }
+    }
+}
+
 /// Convert a known_hosts check failure into the crate error type.
 ///
 /// A [`russh::keys::Error::KeyChanged`] becomes the dedicated
@@ -2245,7 +2373,12 @@ mod tests {
 
         for check in [
             ServerCheckMethod::KnownHostsFile(path_str.clone()),
-            ServerCheckMethod::AcceptNewKnownHostsFile(path_str),
+            ServerCheckMethod::KnownHostsFiles(vec![path_str.clone()]),
+            ServerCheckMethod::AcceptNewKnownHostsFile(path_str.clone()),
+            ServerCheckMethod::AcceptNewKnownHostsFiles {
+                files: vec![path_str.clone()],
+                write_path: Some(path_str),
+            },
             ServerCheckMethod::AcceptNewInMemory,
             ServerCheckMethod::PublicKey(
                 subject.public_key().to_openssh().unwrap()[..]
@@ -2297,5 +2430,150 @@ mod tests {
                 .is_empty(),
             "the client config must not advertise certificate host key algorithms"
         );
+    }
+
+    #[tokio::test]
+    async fn test_known_hosts_files_distinguishes_matching_and_empty_user_store() {
+        let (_matching_dir, _matching_path, matching) = temp_known_hosts();
+        let (_empty_dir, _empty_path, empty) = temp_known_hosts();
+        let expected = generate_key();
+        record_host_key("explicit.example.com", 22, expected.public_key(), &matching);
+
+        let mut matching_handler = ClientHandler::new(
+            "explicit.example.com".into(),
+            "127.0.0.1:22".parse().unwrap(),
+            ServerCheckMethod::KnownHostsFiles(vec![matching]),
+        );
+        assert!(matches!(
+            matching_handler
+                .check_server_key(&host_key(expected.public_key()))
+                .await,
+            Ok(true)
+        ));
+
+        let mut empty_handler = ClientHandler::new(
+            "explicit.example.com".into(),
+            "127.0.0.1:22".parse().unwrap(),
+            ServerCheckMethod::KnownHostsFiles(vec![empty]),
+        );
+        assert!(matches!(
+            empty_handler
+                .check_server_key(&host_key(expected.public_key()))
+                .await,
+            Ok(false)
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_known_hosts_files_accepts_match_after_earlier_conflict() {
+        let (_first_dir, _first_path, first) = temp_known_hosts();
+        let (_second_dir, _second_path, second) = temp_known_hosts();
+        let expected = generate_key();
+        let conflicting = generate_key();
+        record_host_key("multi.example.com", 22, conflicting.public_key(), &first);
+        record_host_key("multi.example.com", 22, expected.public_key(), &second);
+
+        let mut handler = ClientHandler::new(
+            "multi.example.com".into(),
+            "127.0.0.1:22".parse().unwrap(),
+            ServerCheckMethod::KnownHostsFiles(vec![first, second]),
+        );
+        assert!(matches!(
+            handler
+                .check_server_key(&host_key(expected.public_key()))
+                .await,
+            Ok(true)
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_known_hosts_files_with_no_stores_fails_closed_as_unknown() {
+        let key = generate_key();
+        let mut handler = handler_for(ServerCheckMethod::KnownHostsFiles(Vec::new()));
+        assert!(matches!(
+            handler.check_server_key(&host_key(key.public_key())).await,
+            Ok(false)
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_accept_new_files_records_only_explicit_user_write_path() {
+        let (_user_dir, user_path, user) = temp_known_hosts();
+        let (_global_dir, global_path, global) = temp_known_hosts();
+        let (_second_user_dir, second_user_path, second_user) = temp_known_hosts();
+        let key = generate_key();
+        let mut handler = handler_for(ServerCheckMethod::AcceptNewKnownHostsFiles {
+            files: vec![user.clone(), second_user, global],
+            write_path: Some(user),
+        });
+
+        assert!(matches!(
+            handler.check_server_key(&host_key(key.public_key())).await,
+            Ok(true)
+        ));
+        assert_eq!(entry_lines(&user_path).len(), 1);
+        assert!(
+            !second_user_path.exists(),
+            "only the first user store may receive a learned key"
+        );
+        assert!(!global_path.exists(), "global store must remain read-only");
+    }
+
+    #[tokio::test]
+    async fn test_accept_new_files_uses_global_match_without_writing_user_file() {
+        let (_user_dir, user_path, user) = temp_known_hosts();
+        let (_global_dir, _global_path, global) = temp_known_hosts();
+        let key = generate_key();
+        record_host_key("global-match.example.com", 22, key.public_key(), &global);
+        let mut handler = ClientHandler::new(
+            "global-match.example.com".into(),
+            "127.0.0.1:22".parse().unwrap(),
+            ServerCheckMethod::AcceptNewKnownHostsFiles {
+                files: vec![user.clone(), global],
+                write_path: Some(user),
+            },
+        );
+
+        assert!(matches!(
+            handler.check_server_key(&host_key(key.public_key())).await,
+            Ok(true)
+        ));
+        assert!(
+            !user_path.exists(),
+            "a later matching read store must prevent first-use recording"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_accept_new_files_without_write_path_keeps_process_pin() {
+        let original = generate_key();
+        let changed = generate_key();
+        let method = ServerCheckMethod::AcceptNewKnownHostsFiles {
+            files: Vec::new(),
+            write_path: None,
+        };
+        let mut first = ClientHandler::new(
+            "memory-only-multifile.example.com".into(),
+            "127.0.0.1:22".parse().unwrap(),
+            method.clone(),
+        );
+        assert!(matches!(
+            first
+                .check_server_key(&host_key(original.public_key()))
+                .await,
+            Ok(true)
+        ));
+
+        let mut second = ClientHandler::new(
+            "memory-only-multifile.example.com".into(),
+            "127.0.0.1:22".parse().unwrap(),
+            method,
+        );
+        assert!(matches!(
+            second
+                .check_server_key(&host_key(changed.public_key()))
+                .await,
+            Err(Error::HostKeyChanged { .. })
+        ));
     }
 }


### PR DESCRIPTION
## Summary

Honor the effective `UserKnownHostsFile` and `GlobalKnownHostsFile` settings for every SSH connection path instead of silently falling back to the ambient default trust store.

## Changes

- Preserve multiple configured user and global paths and expand `~`, `%d`, `%h`, `%p`, `%r`, `%u`, and `%%` at connection time.
- Treat `none` and `/dev/null` as explicitly empty stores, using `~/.ssh/known_hosts` only when neither directive is configured.
- Verify all configured stores while allowing a later matching key to override an earlier conflicting entry and retaining fail-closed revoked, malformed, and unreadable-file handling.
- Record `accept-new` keys only in the first configured user store and retain the existing in-process and cross-process serialization behavior.
- Wire the resolved verification method through direct, interactive, forwarding, and jump-host connection paths.

## Test plan

- `cargo test --lib known_hosts`
- `cargo test --lib test_accept_new_files`
- `cargo test --lib test_host_certificate_is_rejected_by_verifying_modes`
- `cargo test --lib test_multi_file_server_check_methods_round_trip`
- `cargo check --lib --tests`
- `cargo clippy --lib --tests -- -D warnings`
- `cargo fmt --all -- --check`

Closes #278
