### PR TITLE
fix: preserve single-host output bytes (#283)

### DIFF
--- a/src/app/cache.rs
+++ b/src/app/cache.rs
@@ -14,8 +14,8 @@
 
 //! Cache statistics and management functionality
 
+use bssh::ui::Colorize;
 use bssh::{diagnosticln as eprintln, ssh::GLOBAL_CACHE};
-use owo_colors::OwoColorize;
 
 /// Handle cache statistics command
 pub async fn handle_cache_stats(detailed: bool, clear: bool, maintain: bool) {

--- a/src/app/dispatcher.rs
+++ b/src/app/dispatcher.rs
@@ -643,6 +643,7 @@ async fn handle_exec_command(
             output_dir: cli.output_dir.as_deref(),
             stream: cli.stream,
             no_prefix: cli.no_prefix,
+            byte_transparent: cli.is_ssh_mode(),
             timeout,
             connect_timeout: Some(cli.connect_timeout),
             jump_hosts: jump_hosts.as_deref(),

--- a/src/cli/bssh.rs
+++ b/src/cli/bssh.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::ui::ColorMode;
 use anyhow::{Context, Result};
 use clap::{Parser, Subcommand};
 use std::path::PathBuf;
@@ -19,7 +20,7 @@ use std::path::PathBuf;
 #[derive(Parser, Debug)]
 #[command(
     name = "bssh",
-    version,
+    disable_version_flag = true,
     before_help = "\n\nBroadcast SSH - Parallel command execution across cluster nodes",
     about = "Broadcast SSH - SSH-compatible parallel command execution tool",
     long_about = "bssh is a high-performance SSH client with parallel execution capabilities.\nIt can be used as a drop-in replacement for SSH (single host) or as a powerful cluster management tool (multiple hosts).\n\nThe tool provides secure file transfer using SFTP and supports SSH keys, SSH agent, and password authentication.\nIt automatically detects Backend.AI multi-node session environments.\n\nOutput Modes:\n- TUI Mode (default): Interactive terminal UI with real-time monitoring (auto-enabled in terminals)\n- Stream Mode (--stream): Real-time output with [node] prefixes\n- File Mode (--output-dir): Save per-node output to timestamped files\n- Normal Mode: Traditional output after all nodes complete\n\nSSH Configuration Support:\n- Reads standard SSH config files (defaulting to ~/.ssh/config)\n- Supports Host patterns, HostName, User, Port, IdentityFile, StrictHostKeyChecking\n- ProxyJump, and many other SSH configuration directives\n- CLI arguments override SSH config values following SSH precedence rules",
@@ -145,6 +146,17 @@ pub struct Cli {
         help = "Stream output in real-time with [node] prefixes\nEach line of output is prefixed with the node hostname and displayed as it arrives.\nUseful for monitoring long-running commands across multiple nodes.\nAutomatically disabled when output is piped or in CI environments."
     )]
     pub stream: bool,
+
+    #[arg(
+        long,
+        value_enum,
+        default_value_t = ColorMode::Auto,
+        help = "Control ANSI styling: auto, always, or never"
+    )]
+    pub color: ColorMode,
+
+    #[arg(short = 'V', long = "version", help = "Print version to stderr")]
+    pub version: bool,
 
     #[arg(
         short = 'N',

--- a/src/cli/pdsh.rs
+++ b/src/cli/pdsh.rs
@@ -307,6 +307,8 @@ impl PdshCli {
             jump_hosts: None,
             port: None,
             stream: false,
+            color: crate::ui::ColorMode::Auto,
+            version: false,
             output_dir: None,
             log_file: None,
             verbose: 0,

--- a/src/commands/download.rs
+++ b/src/commands/download.rs
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::ui::Colorize;
 use anyhow::{Context, Result};
-use owo_colors::OwoColorize;
 use std::path::Path;
 use tokio::fs;
 

--- a/src/commands/exec.rs
+++ b/src/commands/exec.rs
@@ -16,7 +16,6 @@ use anyhow::Result;
 use std::path::Path;
 use std::sync::Arc;
 
-use crate::diagnosticln as eprintln;
 use crate::executor::{ExitCodeStrategy, OutputMode, ParallelExecutor, RankDetector};
 use crate::forwarding::ForwardingType;
 use crate::node::Node;
@@ -45,6 +44,7 @@ pub struct ExecuteCommandParams<'a> {
     pub output_dir: Option<&'a Path>,
     pub stream: bool,
     pub no_prefix: bool,
+    pub byte_transparent: bool,
     pub timeout: Option<u64>,
     pub connect_timeout: Option<u64>,
     pub jump_hosts: Option<&'a str>,
@@ -60,11 +60,12 @@ pub struct ExecuteCommandParams<'a> {
 }
 
 pub async fn execute_command(params: ExecuteCommandParams<'_>) -> Result<()> {
-    // Display command header
-    println!(
-        "{}",
-        OutputFormatter::format_command_header(params.command, params.nodes.len())
-    );
+    if !params.byte_transparent {
+        println!(
+            "{}",
+            OutputFormatter::format_command_header(params.command, params.nodes.len())
+        );
+    }
 
     // Handle port forwarding if specified
     if let Some(ref forwards) = params.port_forwards
@@ -85,14 +86,19 @@ async fn execute_command_with_forwarding(params: ExecuteCommandParams<'_>) -> Re
     // Note: This is a simplified implementation for SSH compatibility
     // For full multi-node forwarding, we would need to handle forwarding per node
 
-    println!("Setting up port forwarding...");
+    let byte_transparent = params.byte_transparent;
+    if !byte_transparent {
+        println!("Setting up port forwarding...");
+    }
 
     let forwards = params.port_forwards.as_ref().unwrap();
     let node = &params.nodes[0]; // Use first node for SSH compatibility mode
 
     // Display forwarding information
-    for forward in forwards {
-        println!("  {forward}");
+    if !byte_transparent {
+        for forward in forwards {
+            println!("  {forward}");
+        }
     }
 
     // Create forwarding manager. The resolved address family narrows which
@@ -184,10 +190,12 @@ async fn execute_command_with_forwarding(params: ExecuteCommandParams<'_>) -> Re
         .await?,
     );
 
-    println!(
-        "SSH connection established to {}@{}",
-        node.username, node.host
-    );
+    if !byte_transparent {
+        println!(
+            "SSH connection established to {}@{}",
+            node.username, node.host
+        );
+    }
 
     // Start port forwarding
     let mut forwarding_ids = Vec::new();
@@ -203,7 +211,9 @@ async fn execute_command_with_forwarding(params: ExecuteCommandParams<'_>) -> Re
             .await?;
     }
 
-    println!("Port forwarding active. Executing command...");
+    if !byte_transparent {
+        println!("Port forwarding active. Executing command...");
+    }
 
     // Execute the actual command
     let result = execute_command_without_forwarding(ExecuteCommandParams {
@@ -214,10 +224,12 @@ async fn execute_command_with_forwarding(params: ExecuteCommandParams<'_>) -> Re
     .await;
 
     // Cleanup: stop forwarding
-    println!("Stopping port forwarding...");
+    if !byte_transparent {
+        println!("Stopping port forwarding...");
+    }
     for id in forwarding_ids {
         if let Err(e) = manager.stop_forwarding(id).await {
-            eprintln!("Warning: Failed to stop forwarding {id}: {e}");
+            crate::diagnosticln!("Warning: Failed to stop forwarding {id}: {e}");
         }
     }
 
@@ -255,12 +267,15 @@ async fn execute_command_without_forwarding(params: ExecuteCommandParams<'_>) ->
     #[cfg(target_os = "macos")]
     let executor = executor.with_keychain(params.use_keychain);
 
-    // Determine output mode
-    let output_mode = OutputMode::from_args_with_no_prefix(
-        params.stream,
-        params.output_dir.map(|p| p.to_path_buf()),
-        params.no_prefix,
-    );
+    let output_mode = if params.byte_transparent && params.output_dir.is_none() {
+        OutputMode::raw_stream()
+    } else {
+        OutputMode::from_args_with_no_prefix(
+            params.stream,
+            params.output_dir.map(|p| p.to_path_buf()),
+            params.no_prefix,
+        )
+    };
 
     // Execute with appropriate mode
     let results = if output_mode.is_normal() {
@@ -283,20 +298,21 @@ async fn execute_command_without_forwarding(params: ExecuteCommandParams<'_>) ->
     }
 
     // Print results (skip if already printed in stream mode)
-    if !params.stream {
+    if output_mode.is_normal() {
         for result in &results {
             result.print_output(params.verbose);
         }
     }
 
-    // Print summary
     let success_count = results.iter().filter(|r| r.is_success()).count();
     let failed_count = results.len() - success_count;
 
-    println!(
-        "{}",
-        OutputFormatter::format_summary(results.len(), success_count, failed_count)
-    );
+    if !params.byte_transparent {
+        println!(
+            "{}",
+            OutputFormatter::format_summary(results.len(), success_count, failed_count)
+        );
+    }
 
     // Determine exit code strategy from CLI flags
     let strategy = if params.require_all_success {

--- a/src/commands/interactive/execution.rs
+++ b/src/commands/interactive/execution.rs
@@ -14,8 +14,8 @@
 
 //! Main execution logic for interactive sessions
 
+use crate::ui::Colorize;
 use anyhow::Result;
-use owo_colors::OwoColorize;
 use std::sync::Arc;
 
 use crate::commands::error_format::format_connection_error;
@@ -65,7 +65,7 @@ impl InteractiveCommand {
                 Err(e) => {
                     eprintln!(
                         "✗ Failed to connect to {}: {}",
-                        node.to_string().red(),
+                        node.to_string().red_stderr(),
                         format_connection_error(&e)
                     );
                 }
@@ -138,7 +138,7 @@ impl InteractiveCommand {
                 Err(e) => {
                     eprintln!(
                         "✗ Failed to connect to {}: {}",
-                        node.to_string().red(),
+                        node.to_string().red_stderr(),
                         format_connection_error(&e)
                     );
                 }

--- a/src/commands/interactive/multiplex.rs
+++ b/src/commands/interactive/multiplex.rs
@@ -14,9 +14,9 @@
 
 //! Multi-node multiplexed interactive session handling
 
+use crate::ui::Colorize;
 use anyhow::Result;
 use chrono;
-use owo_colors::OwoColorize;
 use rustyline::DefaultEditor;
 use rustyline::config::Configurer;
 use rustyline::error::ReadlineError;
@@ -213,7 +213,7 @@ impl InteractiveCommand {
                             if let Err(e) = session.send_command(&command_to_execute).await {
                                 eprintln!(
                                     "Failed to send command to {}: {}",
-                                    session.node.to_string().red(),
+                                    session.node.to_string().red_stderr(),
                                     e
                                 );
                                 session.is_connected = false;

--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use owo_colors::OwoColorize;
+use crate::ui::Colorize;
 
 use crate::config::{Config, NodeConfig};
 

--- a/src/commands/ping.rs
+++ b/src/commands/ping.rs
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::ui::Colorize;
 use anyhow::Result;
-use owo_colors::OwoColorize;
 use std::path::Path;
 use std::sync::Arc;
 

--- a/src/commands/upload.rs
+++ b/src/commands/upload.rs
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::ui::Colorize;
 use anyhow::{Context, Result};
-use owo_colors::OwoColorize;
 use std::path::Path;
 use std::sync::Arc;
 

--- a/src/executor/execution_strategy.rs
+++ b/src/executor/execution_strategy.rs
@@ -14,9 +14,9 @@
 
 //! Execution strategies and task management for parallel operations.
 
+use crate::ui::Colorize;
 use anyhow::Result;
 use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
-use owo_colors::OwoColorize;
 use std::path::Path;
 use std::sync::Arc;
 use tokio::sync::Semaphore;

--- a/src/executor/output_mode.rs
+++ b/src/executor/output_mode.rs
@@ -39,6 +39,10 @@ pub enum OutputMode {
     /// The bool indicates whether to disable the prefix (no_prefix option).
     Stream { no_prefix: bool },
 
+    /// Byte-transparent streaming for a single SSH-compatible destination.
+    /// Chunks are written unchanged without prefixes or newline synthesis.
+    RawStream,
+
     /// File mode - save per-node output to separate files
     ///
     /// Each node's output is saved to a separate file in the specified
@@ -123,6 +127,11 @@ impl OutputMode {
         }
     }
 
+    /// Create byte-transparent streaming mode for SSH compatibility.
+    pub fn raw_stream() -> Self {
+        OutputMode::RawStream
+    }
+
     /// Check if this is normal mode
     pub fn is_normal(&self) -> bool {
         matches!(self, OutputMode::Normal)
@@ -130,7 +139,7 @@ impl OutputMode {
 
     /// Check if this is stream mode
     pub fn is_stream(&self) -> bool {
-        matches!(self, OutputMode::Stream { .. })
+        matches!(self, OutputMode::Stream { .. } | OutputMode::RawStream)
     }
 
     /// Check if this is file mode
@@ -156,8 +165,14 @@ impl OutputMode {
         match self {
             OutputMode::Stream { no_prefix } => *no_prefix,
             OutputMode::File { no_prefix, .. } => *no_prefix,
+            OutputMode::RawStream => true,
             _ => false,
         }
+    }
+
+    /// Check whether stream chunks must be emitted byte-for-byte.
+    pub fn is_raw_stream(&self) -> bool {
+        matches!(self, OutputMode::RawStream)
     }
 }
 

--- a/src/executor/output_sync.rs
+++ b/src/executor/output_sync.rs
@@ -141,6 +141,30 @@ impl NodeOutputWriter {
         Ok(())
     }
 
+    /// Write a stdout chunk without decoding, prefixing, or adding a newline.
+    pub fn write_stdout_bytes(&self, bytes: &[u8]) -> io::Result<()> {
+        if bytes.is_empty() {
+            return Ok(());
+        }
+        let mut stdout = STDOUT_MUTEX
+            .lock()
+            .map_err(|_| io::Error::other("stdout lock is poisoned"))?;
+        stdout.write_all(bytes)?;
+        stdout.flush()
+    }
+
+    /// Write a stderr chunk without decoding, prefixing, or adding a newline.
+    pub fn write_stderr_bytes(&self, bytes: &[u8]) -> io::Result<()> {
+        if bytes.is_empty() {
+            return Ok(());
+        }
+        let mut stderr = STDERR_MUTEX
+            .lock()
+            .map_err(|_| io::Error::other("stderr lock is poisoned"))?;
+        stderr.write_all(bytes)?;
+        stderr.flush()
+    }
+
     /// Write a single stdout line with optional node prefix
     pub fn write_stdout(&self, line: &str) -> io::Result<()> {
         synchronized_println(&self.format_line(line))
@@ -241,5 +265,70 @@ mod tests {
         let contents = std::fs::read_to_string(&log).expect("failed to read diagnostic log");
         assert!(contents.contains("bssh-owned diagnostic"));
         assert!(!contents.contains("remote command stderr"));
+    }
+    #[test]
+    fn raw_output_helper() {
+        if std::env::var_os("BSSH_RAW_OUTPUT_TEST_HELPER").is_none() {
+            return;
+        }
+
+        let writer = NodeOutputWriter::new_with_no_prefix("example", true);
+        writer
+            .write_stdout_bytes(b"stdout\0\xff-no-newline")
+            .expect("helper should write raw stdout");
+        writer
+            .write_stderr_bytes(b"stderr\0\xfe-no-newline")
+            .expect("helper should write raw stderr");
+    }
+
+    #[test]
+    fn raw_output_preserves_bytes_and_streams() {
+        let output = Command::new(std::env::current_exe().expect("test executable should exist"))
+            .args([
+                "--exact",
+                "executor::output_sync::tests::raw_output_helper",
+                "--nocapture",
+            ])
+            .env("BSSH_RAW_OUTPUT_TEST_HELPER", "1")
+            .output()
+            .expect("failed to run raw output helper");
+
+        assert!(output.status.success(), "raw output helper should pass");
+        let expected_stdout = b"stdout\0\xff-no-newline";
+        let expected_stderr = b"stderr\0\xfe-no-newline";
+        let stdout_start = output
+            .stdout
+            .windows(expected_stdout.len())
+            .position(|window| window == expected_stdout)
+            .expect("exact raw stdout payload should be present");
+        let stderr_start = output
+            .stderr
+            .windows(expected_stderr.len())
+            .position(|window| window == expected_stderr)
+            .expect("exact raw stderr payload should be present");
+        assert_eq!(
+            &output.stdout[stdout_start..stdout_start + expected_stdout.len()],
+            expected_stdout
+        );
+        assert_eq!(
+            &output.stderr[stderr_start..stderr_start + expected_stderr.len()],
+            expected_stderr
+        );
+        assert_eq!(
+            output
+                .stdout
+                .windows(expected_stdout.len())
+                .filter(|window| *window == expected_stdout)
+                .count(),
+            1
+        );
+        assert_eq!(
+            output
+                .stderr
+                .windows(expected_stderr.len())
+                .filter(|window| *window == expected_stderr)
+                .count(),
+            1
+        );
     }
 }

--- a/src/executor/parallel.rs
+++ b/src/executor/parallel.rs
@@ -1310,13 +1310,14 @@ impl ParallelExecutor {
 
         // Execute based on mode and ensure cleanup
         let no_prefix = output_mode.is_no_prefix();
+        let raw_stream = output_mode.is_raw_stream();
 
         if output_mode.is_tui() {
             // TUI mode: interactive terminal UI
             self.handle_tui_mode(&mut manager, handles, command).await
         } else if output_mode.is_stream() {
             // Stream mode: output in real-time with optional [node] prefixes
-            self.handle_stream_mode(&mut manager, handles, no_prefix)
+            self.handle_stream_mode(&mut manager, handles, no_prefix, raw_stream)
                 .await
         } else if let Some(output_dir) = output_mode.output_dir() {
             // File mode: save to per-node files
@@ -1334,6 +1335,7 @@ impl ParallelExecutor {
         manager: &mut super::stream_manager::MultiNodeStreamManager,
         handles: Vec<tokio::task::JoinHandle<(Node, Result<u32>)>>,
         no_prefix: bool,
+        raw_stream: bool,
     ) -> Result<Vec<ExecutionResult>> {
         use super::output_sync::NodeOutputWriter;
         use std::time::Duration;
@@ -1422,19 +1424,27 @@ impl ParallelExecutor {
                 let stderr = stream.take_stderr();
 
                 if !stdout.is_empty() {
-                    // Use lossy conversion to handle non-UTF8 data gracefully
-                    let text = String::from_utf8_lossy(&stdout);
                     let writer = NodeOutputWriter::new_with_no_prefix(&stream.node.host, no_prefix);
-                    if let Err(e) = writer.write_stdout_lines(&text) {
+                    let result = if raw_stream {
+                        writer.write_stdout_bytes(&stdout)
+                    } else {
+                        let text = String::from_utf8_lossy(&stdout);
+                        writer.write_stdout_lines(&text)
+                    };
+                    if let Err(e) = result {
                         tracing::error!("Failed to write stdout for {}: {}", stream.node.host, e);
                     }
                 }
 
                 if !stderr.is_empty() {
-                    // Use lossy conversion to handle non-UTF8 data gracefully
-                    let text = String::from_utf8_lossy(&stderr);
                     let writer = NodeOutputWriter::new_with_no_prefix(&stream.node.host, no_prefix);
-                    if let Err(e) = writer.write_stderr_lines(&text) {
+                    let result = if raw_stream {
+                        writer.write_stderr_bytes(&stderr)
+                    } else {
+                        let text = String::from_utf8_lossy(&stderr);
+                        writer.write_stderr_lines(&text)
+                    };
+                    if let Err(e) = result {
                         tracing::error!("Failed to write stderr for {}: {}", stream.node.host, e);
                     }
                 }
@@ -1469,6 +1479,29 @@ impl ParallelExecutor {
             tokio::time::sleep(Duration::from_millis(10)).await;
         }
 
+        // Drain chunks that arrived with the final channel-close notification.
+        manager.poll_all();
+        for stream in manager.streams_mut() {
+            let stdout = stream.take_stdout();
+            let stderr = stream.take_stderr();
+            let writer = NodeOutputWriter::new_with_no_prefix(&stream.node.host, no_prefix);
+            if !stdout.is_empty() {
+                let result = if raw_stream {
+                    writer.write_stdout_bytes(&stdout)
+                } else {
+                    writer.write_stdout_lines(&String::from_utf8_lossy(&stdout))
+                };
+                result?;
+            }
+            if !stderr.is_empty() {
+                let result = if raw_stream {
+                    writer.write_stderr_bytes(&stderr)
+                } else {
+                    writer.write_stderr_lines(&String::from_utf8_lossy(&stderr))
+                };
+                result?;
+            }
+        }
         // Collect final results from all streams
         for stream in manager.streams() {
             use crate::ssh::client::CommandResult;

--- a/src/executor/result_types.rs
+++ b/src/executor/result_types.rs
@@ -14,8 +14,8 @@
 
 //! Result types for parallel execution operations.
 
+use crate::ui::Colorize;
 use anyhow::Result;
-use owo_colors::OwoColorize;
 use std::path::PathBuf;
 
 use crate::node::Node;

--- a/src/main.rs
+++ b/src/main.rs
@@ -122,6 +122,7 @@ async fn run_pdsh_mode(args: &[String]) -> Result<()> {
 
     // Convert to bssh CLI
     let mut cli = pdsh_cli.to_bssh_cli();
+    bssh::ui::configure_color(cli.color);
 
     // Check if we have hosts
     if cli.hosts.is_none() {
@@ -254,6 +255,12 @@ async fn run_bssh_mode(args: &[String]) -> Result<()> {
     }
 
     let mut cli = Cli::parse();
+    bssh::ui::configure_color(cli.color);
+
+    if cli.version {
+        eprintln!("bssh_{}", env!("CARGO_PKG_VERSION"));
+        return Ok(());
+    }
 
     if let Some(path) = &cli.log_file {
         bssh::utils::diagnostics::set_log_file(path)?;

--- a/src/ssh/ssh_config/parser/options/authentication.rs
+++ b/src/ssh/ssh_config/parser/options/authentication.rs
@@ -98,7 +98,7 @@ pub(super) fn parse_authentication_option(
                 host.identity_agent = Some(value.to_string());
             }
         }
-        "pubkeyacceptedalgorithms" => {
+        "pubkeyacceptedalgorithms" | "pubkeyacceptedkeytypes" => {
             if args.is_empty() {
                 anyhow::bail!("PubkeyAcceptedAlgorithms requires a value at line {line_number}");
             }
@@ -201,7 +201,7 @@ pub(super) fn parse_authentication_option(
             }
             host.password_authentication = Some(parse_yes_no(&args[0], line_number)?);
         }
-        "kbdinteractiveauthentication" => {
+        "kbdinteractiveauthentication" | "challengeresponseauthentication" => {
             if args.is_empty() {
                 anyhow::bail!(
                     "KbdInteractiveAuthentication requires a value at line {line_number}"
@@ -231,7 +231,7 @@ pub(super) fn parse_authentication_option(
             }
             host.hostbased_authentication = Some(parse_yes_no(&args[0], line_number)?);
         }
-        "hostbasedacceptedalgorithms" => {
+        "hostbasedacceptedalgorithms" | "hostbasedkeytypes" => {
             if args.is_empty() {
                 anyhow::bail!("HostbasedAcceptedAlgorithms requires a value at line {line_number}");
             }

--- a/src/ssh/ssh_config/parser/options/mod.rs
+++ b/src/ssh/ssh_config/parser/options/mod.rs
@@ -51,14 +51,17 @@ pub fn parse_option(
         | "addkeystoagent"
         | "identityagent"
         | "pubkeyacceptedalgorithms"
+        | "pubkeyacceptedkeytypes"
         | "certificatefile"
         | "pubkeyauthentication"
         | "passwordauthentication"
         | "kbdinteractiveauthentication"
+        | "challengeresponseauthentication"
         | "gssapiauthentication"
         | "preferredauthentications"
         | "hostbasedauthentication"
         | "hostbasedacceptedalgorithms"
+        | "hostbasedkeytypes"
         | "numberofpasswordprompts"
         | "enablesshkeysign"
         | "usekeychain" => {
@@ -142,13 +145,17 @@ pub fn parse_option(
         | "sessiontype"
         | "stdinnull" => command::parse_command_option(host, keyword, args, line_number),
 
+        "cipher"
+        | "fallbacktorsh"
+        | "globalknownhostsfile2"
+        | "rhostsauthentication"
+        | "userknownhostsfile2"
+        | "useroaming"
+        | "usersh"
+        | "useprivilegedport" => Ok(()),
+
         _ => {
-            // Unknown option - log a warning but continue
-            tracing::warn!(
-                "Unknown SSH config option '{}' at line {}",
-                keyword,
-                line_number
-            );
+            crate::diagnosticln!("Unknown SSH config option '{keyword}' at line {line_number}");
             Ok(())
         }
     }

--- a/src/ui/basic.rs
+++ b/src/ui/basic.rs
@@ -14,7 +14,7 @@
 
 use crate::executor::ExecutionResult;
 use crate::node::Node;
-use owo_colors::OwoColorize;
+use crate::ui::Colorize;
 use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 
 pub enum NodeStatus {

--- a/src/ui/color.rs
+++ b/src/ui/color.rs
@@ -1,0 +1,191 @@
+// Copyright 2025 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Process-wide color policy with independent stdout and stderr detection.
+
+use std::ffi::OsStr;
+use std::fmt;
+use std::io::IsTerminal;
+use std::sync::atomic::{AtomicU8, Ordering};
+
+use clap::ValueEnum;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum, Default)]
+pub enum ColorMode {
+    #[default]
+    Auto,
+    Always,
+    Never,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OutputStream {
+    Stdout,
+    Stderr,
+}
+
+static COLOR_MODE: AtomicU8 = AtomicU8::new(ColorMode::Auto as u8);
+
+pub fn configure_color(mode: ColorMode) {
+    COLOR_MODE.store(mode as u8, Ordering::Relaxed);
+}
+
+fn configured_mode() -> ColorMode {
+    match COLOR_MODE.load(Ordering::Relaxed) {
+        value if value == ColorMode::Always as u8 => ColorMode::Always,
+        value if value == ColorMode::Never as u8 => ColorMode::Never,
+        _ => ColorMode::Auto,
+    }
+}
+
+fn auto_color_enabled(is_terminal: bool, no_color: Option<&OsStr>, term: Option<&OsStr>) -> bool {
+    is_terminal
+        && !no_color.is_some_and(|value| !value.is_empty())
+        && !term.is_some_and(|value| value.eq_ignore_ascii_case(OsStr::new("dumb")))
+}
+
+fn color_enabled_for(
+    mode: ColorMode,
+    is_terminal: bool,
+    no_color: Option<&OsStr>,
+    term: Option<&OsStr>,
+) -> bool {
+    match mode {
+        ColorMode::Auto => auto_color_enabled(is_terminal, no_color, term),
+        ColorMode::Always => true,
+        ColorMode::Never => false,
+    }
+}
+
+pub fn colors_enabled(stream: OutputStream) -> bool {
+    let is_terminal = match stream {
+        OutputStream::Stdout => std::io::stdout().is_terminal(),
+        OutputStream::Stderr => std::io::stderr().is_terminal(),
+    };
+    color_enabled_for(
+        configured_mode(),
+        is_terminal,
+        std::env::var_os("NO_COLOR").as_deref(),
+        std::env::var_os("TERM").as_deref(),
+    )
+}
+
+pub trait Colorize: fmt::Display {
+    fn styled_for(&self, ansi_code: &'static str, stream: OutputStream) -> StyledText {
+        StyledText {
+            text: self.to_string(),
+            ansi_code,
+            stream,
+        }
+    }
+    fn styled(&self, ansi_code: &'static str) -> StyledText {
+        self.styled_for(ansi_code, OutputStream::Stdout)
+    }
+    fn red(&self) -> StyledText {
+        self.styled("31")
+    }
+    fn red_stderr(&self) -> StyledText {
+        self.styled_for("31", OutputStream::Stderr)
+    }
+    fn green(&self) -> StyledText {
+        self.styled("32")
+    }
+    fn yellow(&self) -> StyledText {
+        self.styled("33")
+    }
+    fn blue(&self) -> StyledText {
+        self.styled("34")
+    }
+    fn cyan(&self) -> StyledText {
+        self.styled("36")
+    }
+    fn bright_blue(&self) -> StyledText {
+        self.styled("94")
+    }
+    fn bold(&self) -> StyledText {
+        self.styled("1")
+    }
+    fn dimmed(&self) -> StyledText {
+        self.styled("2")
+    }
+}
+
+impl<T: fmt::Display> Colorize for T {}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StyledText {
+    text: String,
+    ansi_code: &'static str,
+    stream: OutputStream,
+}
+
+impl fmt::Display for StyledText {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if colors_enabled(self.stream) {
+            write!(formatter, "\x1b[{}m{}\x1b[0m", self.ansi_code, self.text)
+        } else {
+            formatter.write_str(&self.text)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn auto_requires_a_terminal() {
+        assert!(!color_enabled_for(ColorMode::Auto, false, None, None));
+        assert!(color_enabled_for(ColorMode::Auto, true, None, None));
+    }
+
+    #[test]
+    fn auto_honors_non_empty_no_color_and_dumb_term() {
+        assert!(!color_enabled_for(
+            ColorMode::Auto,
+            true,
+            Some(OsStr::new("1")),
+            None
+        ));
+        assert!(color_enabled_for(
+            ColorMode::Auto,
+            true,
+            Some(OsStr::new("")),
+            None
+        ));
+        assert!(!color_enabled_for(
+            ColorMode::Auto,
+            true,
+            None,
+            Some(OsStr::new("dumb"))
+        ));
+    }
+
+    #[test]
+    fn explicit_modes_override_environment_and_terminal_detection() {
+        assert!(color_enabled_for(
+            ColorMode::Always,
+            false,
+            Some(OsStr::new("1")),
+            Some(OsStr::new("dumb")),
+        ));
+        assert!(!color_enabled_for(ColorMode::Never, true, None, None));
+    }
+
+    #[test]
+    fn styled_text_tracks_its_destination_stream() {
+        assert_eq!("stdout".red().stream, OutputStream::Stdout);
+        assert_eq!("stderr".red_stderr().stream, OutputStream::Stderr);
+    }
+}

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -19,7 +19,9 @@
 //! - `tui`: Interactive terminal UI with ratatui for real-time monitoring
 
 pub mod basic;
+mod color;
 pub mod tui;
 
 // Re-export basic UI components for backward compatibility
 pub use basic::*;
+pub use color::{ColorMode, Colorize, OutputStream, colors_enabled, configure_color};

--- a/src/utils/logging.rs
+++ b/src/utils/logging.rs
@@ -14,6 +14,7 @@
 
 use crate::ui::tui::log_buffer::LogBuffer;
 use crate::ui::tui::log_layer::TuiLogLayer;
+use crate::ui::{OutputStream, colors_enabled};
 use crate::utils::diagnostics::{self, DiagnosticMakeWriter};
 use std::io::IsTerminal;
 use std::sync::{Arc, Mutex, OnceLock};
@@ -88,6 +89,7 @@ pub fn init_logging(verbosity: u8) -> Arc<Mutex<LogBuffer>> {
         tracing_subscriber::fmt()
             .with_env_filter(filter)
             .with_target(true)
+            .with_ansi(colors_enabled(OutputStream::Stderr))
             .init();
     }
 
@@ -103,6 +105,7 @@ pub fn init_logging_console_only(verbosity: u8) {
     tracing_subscriber::fmt()
         .with_env_filter(filter)
         .with_target(true)
+        .with_ansi(colors_enabled(OutputStream::Stderr))
         .init();
 }
 

--- a/src/utils/output.rs
+++ b/src/utils/output.rs
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::ui::Colorize;
 use anyhow::{Context, Result};
-use owo_colors::OwoColorize;
 use std::path::Path;
 use tokio::fs;
 use tokio::io::AsyncWriteExt;

--- a/tests/ssh_compat_output_test.rs
+++ b/tests/ssh_compat_output_test.rs
@@ -1,0 +1,111 @@
+// Copyright 2025 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+use std::fs;
+use std::process::Command;
+
+use tempfile::tempdir;
+
+fn bssh() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_bssh"))
+}
+
+fn contains_ansi(bytes: &[u8]) -> bool {
+    bytes.contains(&0x1b)
+}
+
+#[test]
+fn version_matches_openssh_stream_contract() {
+    let output = bssh().arg("-V").output().expect("bssh should run");
+
+    assert!(output.status.success());
+    assert!(output.stdout.is_empty());
+    assert_eq!(
+        output.stderr,
+        format!("bssh_{}\n", env!("CARGO_PKG_VERSION")).as_bytes()
+    );
+}
+
+#[test]
+fn explicit_and_environment_color_controls_apply_to_stdout() {
+    let never = bssh()
+        .args(["--color=never", "cache-stats"])
+        .output()
+        .expect("bssh --color=never should run");
+    assert!(never.status.success());
+    assert!(!contains_ansi(&never.stdout));
+
+    let always = bssh()
+        .args(["--color=always", "cache-stats"])
+        .output()
+        .expect("bssh --color=always should run");
+    assert!(always.status.success());
+    assert!(contains_ansi(&always.stdout));
+
+    let no_color = bssh()
+        .args(["cache-stats"])
+        .env("NO_COLOR", "1")
+        .output()
+        .expect("bssh with NO_COLOR should run");
+    assert!(no_color.status.success());
+    assert!(!contains_ansi(&no_color.stdout));
+
+    let dumb = bssh()
+        .args(["cache-stats"])
+        .env("TERM", "dumb")
+        .output()
+        .expect("bssh with TERM=dumb should run");
+    assert!(dumb.status.success());
+    assert!(!contains_ansi(&dumb.stdout));
+}
+
+#[test]
+fn deprecated_alias_is_silent_and_unknown_keyword_uses_log_file() {
+    let directory = tempdir().expect("temporary directory should be created");
+    let config = directory.path().join("ssh_config");
+    let log = directory.path().join("bssh.log");
+    fs::write(
+        &config,
+        "Host *\n    ChallengeResponseAuthentication no\n    DefinitelyUnknownOption yes\n",
+    )
+    .expect("ssh config should be written");
+
+    let output = bssh()
+        .args([
+            "-E",
+            log.to_str().expect("UTF-8 log path"),
+            "-F",
+            config.to_str().expect("UTF-8 config path"),
+            "--connect-timeout=1",
+            "--strict-host-key-checking=no",
+            "127.0.0.1:1",
+            "true",
+        ])
+        .output()
+        .expect("bssh should parse the ssh config");
+
+    assert!(!output.status.success());
+    assert!(!String::from_utf8_lossy(&output.stderr).contains("ChallengeResponseAuthentication"));
+
+    let diagnostics = fs::read_to_string(log).expect("diagnostic log should exist");
+    assert!(!diagnostics.contains("ChallengeResponseAuthentication"));
+    let unknown = diagnostics
+        .lines()
+        .find(|line| line.contains("definitelyunknownoption"))
+        .unwrap_or_else(|| {
+            panic!(
+                "unknown keyword diagnostic should be routed to -E; log: {diagnostics:?}; stderr: {:?}",
+                String::from_utf8_lossy(&output.stderr)
+            )
+        });
+    assert_eq!(
+        unknown,
+        "Unknown SSH config option 'definitelyunknownoption' at line 4"
+    );
+    assert!(!unknown.contains("bssh::"));
+}


### PR DESCRIPTION
## Summary

Make single-destination SSH execution byte-transparent while preserving bssh's decorated multi-host behavior.

## Changes

- Route a single SSH destination through raw stdout and stderr writers with no UTF-8 conversion, prefix, synthesized newline, execution banner, forwarding status, or summary, and drain chunks delivered with final channel closure.
- Decide styling independently for stdout and stderr, honor `--color=auto|always|never`, `NO_COLOR`, and `TERM=dumb`, and retain explicit styling for multi-host output.
- Emit `bssh_VERSION` from `-V` only on stderr, accept pinned OpenSSH aliases silently, and route genuine unknown ssh_config diagnostics through the existing `-E`-aware plain diagnostic path.

## Validation

- `cargo check --locked --bin bssh --tests`
- `cargo clippy --locked --bin bssh --tests -- -D warnings`
- `cargo test --locked --test ssh_compat_output_test` (3 passed)
- `cargo test --locked --test log_file_test` (4 passed)
- `cargo test --locked --lib executor::output_sync::tests` (7 passed, including exact non-UTF-8/NUL/no-newline stdout and stderr payload slices, lengths, and single occurrence)
- `cargo test --locked --lib ui::color::tests` (4 passed)
- `cargo test --locked --lib executor::output_mode::tests` (4 passed)
- `cargo test --locked --lib ssh::ssh_config::parser` (113 passed)

## OpenSSH regression notes

The four requested OpenSSH regress cases were executed against V_10_3_P1 with `TEST_SSH_UNSAFE_PERMISSIONS=1`. They currently stop in sibling compatibility dependencies before exercising the raw writer, while the independent subprocess tests above complete this PR's output contract.

- `stderr-after-eof`: first candidate command was `bssh -F .../ssh_proxy otherhost exec sh -c 'exec > /dev/null; sleep 2; cat ... 1>&2'`; parsing reported the ProxyCommand line as unknown and the carrier failed with an I/O error, which is tracked by #280.
- `stderr-data`: the first non-`-n` command used the same `-F .../ssh_proxy otherhost` route and failed at the #280 ProxyCommand gap; the later `-n` variants exited 2 because that SSH flag is tracked by #285.
- `transfer`: first candidate command was `bssh -n -q -F .../ssh_proxy somehost cat ...` and failed with `unexpected argument '-n'`, tracked by #285; later non-`-n` variants reached the #280 ProxyCommand gap.
- `yes-head`: first candidate command was `bssh -F .../ssh_proxy thishost sh -c 'while true; do echo yes; done | head -2000'`; the #280 ProxyCommand gap caused an I/O error and zero lines instead of 2000.

Closes #283
