### PR TITLE
fix(ssh): honor HostKeyAlias for host verification

### DIFF
--- a/src/app/dispatcher.rs
+++ b/src/app/dispatcher.rs
@@ -61,6 +61,7 @@ fn build_ssh_connection_config_resolver(
         .with_yaml_keepalive_interval(ctx.config.get_server_alive_interval(cluster_name))
         .with_yaml_keepalive_max(ctx.config.get_server_alive_count_max(cluster_name))
         .with_cli_address_family(AddressFamily::from_flags(cli.ipv4, cli.ipv6))
+        .with_cli_host_key_alias(cli.get_ssh_option("HostKeyAlias"))
 }
 
 /// Decide whether `-S` (sudo-password) is meaningful for the given dispatch path.

--- a/src/cli/bssh.rs
+++ b/src/cli/bssh.rs
@@ -590,6 +590,17 @@ impl Cli {
         options
     }
 
+    /// Return the first `-o Key=Value` option matching `key`, case-insensitively.
+    /// OpenSSH keeps the first obtained value for repeated configuration keys.
+    pub fn get_ssh_option(&self, key: &str) -> Option<String> {
+        self.ssh_options.iter().find_map(|option| {
+            let (candidate, value) = option.split_once('=')?;
+            candidate
+                .eq_ignore_ascii_case(key)
+                .then(|| value.to_string())
+        })
+    }
+
     /// Parse port forwarding specifications into ForwardingType instances
     ///
     /// Returns a Result containing a vector of all parsed forwarding specifications
@@ -641,5 +652,27 @@ impl Cli {
     /// Get count of total port forwarding specifications
     pub fn port_forward_count(&self) -> usize {
         self.local_forwards.len() + self.remote_forwards.len() + self.dynamic_forwards.len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ssh_option_lookup_is_case_insensitive_and_first_value_wins() {
+        let cli = Cli::try_parse_from([
+            "bssh",
+            "-o",
+            "hostkeyalias=first.example.com",
+            "-o",
+            "HostKeyAlias=final.example.com",
+            "target",
+        ])
+        .unwrap();
+        assert_eq!(
+            cli.get_ssh_option("HostKeyAlias").as_deref(),
+            Some("first.example.com")
+        );
     }
 }

--- a/src/shared/auth_types.rs
+++ b/src/shared/auth_types.rs
@@ -306,6 +306,12 @@ pub enum ServerCheckMethod {
     },
     /// Trust On First Use for the lifetime of this process only.
     AcceptNewInMemory,
+    /// Use `alias` as the unbracketed known-hosts identity for the wrapped
+    /// verification method.
+    HostKeyAlias {
+        alias: String,
+        method: Box<ServerCheckMethod>,
+    },
 }
 
 impl ServerCheckMethod {
@@ -373,6 +379,12 @@ impl From<crate::ssh::tokio_client::ServerCheckMethod> for ServerCheckMethod {
             crate::ssh::tokio_client::ServerCheckMethod::AcceptNewInMemory => {
                 Self::AcceptNewInMemory
             }
+            crate::ssh::tokio_client::ServerCheckMethod::HostKeyAlias { alias, method } => {
+                Self::HostKeyAlias {
+                    alias,
+                    method: Box::new((*method).into()),
+                }
+            }
         }
     }
 }
@@ -391,6 +403,10 @@ impl From<ServerCheckMethod> for crate::ssh::tokio_client::ServerCheckMethod {
                 Self::AcceptNewKnownHostsFiles { files, write_path }
             }
             ServerCheckMethod::AcceptNewInMemory => Self::AcceptNewInMemory,
+            ServerCheckMethod::HostKeyAlias { alias, method } => Self::HostKeyAlias {
+                alias,
+                method: Box::new((*method).into()),
+            },
         }
     }
 }
@@ -491,5 +507,16 @@ mod tests {
             let round_trip: ServerCheckMethod = client.into();
             assert_eq!(round_trip, shared);
         }
+    }
+
+    #[test]
+    fn test_host_key_alias_server_check_method_round_trip() {
+        let shared = ServerCheckMethod::HostKeyAlias {
+            alias: "trust.example.com".into(),
+            method: Box::new(ServerCheckMethod::KnownHostsFiles(vec!["user".into()])),
+        };
+        let client: crate::ssh::tokio_client::ServerCheckMethod = shared.clone().into();
+        let round_trip: ServerCheckMethod = client.into();
+        assert_eq!(round_trip, shared);
     }
 }

--- a/src/ssh/known_hosts.rs
+++ b/src/ssh/known_hosts.rs
@@ -101,10 +101,27 @@ pub fn get_check_method_for_target(
 
     let user_configured = connection_config.user_known_hosts_files.is_some();
     let global_configured = connection_config.global_known_hosts_files.is_some();
-    if !user_configured && !global_configured {
-        return get_check_method(strict_mode);
-    }
+    let method = if !user_configured && !global_configured {
+        get_check_method(strict_mode)
+    } else {
+        configured_check_method(
+            strict_mode,
+            connection_config,
+            hostname,
+            port,
+            remote_username,
+        )
+    };
+    wrap_host_key_alias(method, connection_config.host_key_alias.as_deref())
+}
 
+fn configured_check_method(
+    strict_mode: StrictHostKeyChecking,
+    connection_config: &SshConnectionConfig,
+    hostname: &str,
+    port: u16,
+    remote_username: &str,
+) -> ServerCheckMethod {
     let user_files = expand_known_hosts_files(
         connection_config.user_known_hosts_files.as_deref(),
         hostname,
@@ -126,6 +143,16 @@ pub fn get_check_method_for_target(
             ServerCheckMethod::AcceptNewKnownHostsFiles { files, write_path }
         }
         StrictHostKeyChecking::No => ServerCheckMethod::NoCheck,
+    }
+}
+
+fn wrap_host_key_alias(method: ServerCheckMethod, alias: Option<&str>) -> ServerCheckMethod {
+    match alias {
+        Some(alias) => ServerCheckMethod::HostKeyAlias {
+            alias: alias.to_string(),
+            method: Box::new(method),
+        },
+        None => method,
     }
 }
 
@@ -427,7 +454,7 @@ mod tests {
     #[test]
     fn resolver_preserves_multiple_known_hosts_paths_and_empty_sentinels() {
         let ssh_config = crate::ssh::SshConfig::parse(
-            "Host target\n  UserKnownHostsFile ~/.ssh/one /dev/null none\n  GlobalKnownHostsFile %d/global %h-%p-%r-%u\n",
+            "Host target\n  HostKeyAlias config-alias.example.com\n  UserKnownHostsFile ~/.ssh/one /dev/null none\n  GlobalKnownHostsFile %d/global %h-%p-%r-%u\n",
         )
         .unwrap();
         let host = crate::ssh::tokio_client::SshConnectionConfigResolver::new()
@@ -440,6 +467,42 @@ mod tests {
         assert_eq!(
             host.global_known_hosts_files,
             Some(vec!["%d/global".into(), "%h-%p-%r-%u".into()])
+        );
+        assert_eq!(
+            host.host_key_alias.as_deref(),
+            Some("config-alias.example.com")
+        );
+    }
+
+    #[test]
+    fn cli_host_key_alias_overrides_effective_host_config() {
+        let ssh_config = crate::ssh::SshConfig::parse(
+            "Host target\n  HostKeyAlias config-alias.example.com\n  UserKnownHostsFile /tmp/known_hosts\n",
+        )
+        .unwrap();
+        let config = crate::ssh::tokio_client::SshConnectionConfigResolver::new()
+            .with_ssh_config(Some(ssh_config))
+            .with_cli_host_key_alias(Some("cli-alias.example.com".into()))
+            .resolve_for_host("target");
+
+        assert_eq!(
+            config.host_key_alias.as_deref(),
+            Some("cli-alias.example.com")
+        );
+        assert_eq!(
+            get_check_method_for_target(
+                StrictHostKeyChecking::Yes,
+                &config,
+                "target",
+                4242,
+                "user"
+            ),
+            ServerCheckMethod::HostKeyAlias {
+                alias: "cli-alias.example.com".into(),
+                method: Box::new(ServerCheckMethod::KnownHostsFiles(vec![
+                    "/tmp/known_hosts".into()
+                ])),
+            }
         );
     }
 

--- a/src/ssh/tokio_client/authentication.rs
+++ b/src/ssh/tokio_client/authentication.rs
@@ -215,6 +215,13 @@ pub enum ServerCheckMethod {
     /// becoming unconditional `NoCheck`: the first key seen for a host:port is
     /// accepted, and a different key later in the same run is rejected.
     AcceptNewInMemory,
+    /// Use `alias` as the known-hosts identity for the wrapped verification
+    /// method. The alias has logical port 22 so it remains unbracketed even
+    /// when the network connection uses a non-default port.
+    HostKeyAlias {
+        alias: String,
+        method: Box<ServerCheckMethod>,
+    },
 }
 
 impl ServerCheckMethod {

--- a/src/ssh/tokio_client/connection.rs
+++ b/src/ssh/tokio_client/connection.rs
@@ -101,6 +101,9 @@ pub struct SshConnectionConfig {
 
     /// Raw `GlobalKnownHostsFile` values selected for this host.
     pub global_known_hosts_files: Option<Vec<String>>,
+
+    /// Explicit known-hosts identity selected by `HostKeyAlias`.
+    pub host_key_alias: Option<String>,
 }
 
 impl Default for SshConnectionConfig {
@@ -112,6 +115,7 @@ impl Default for SshConnectionConfig {
             address_family: AddressFamily::Any,
             user_known_hosts_files: None,
             global_known_hosts_files: None,
+            host_key_alias: None,
         }
     }
 }
@@ -132,6 +136,7 @@ pub struct SshConnectionConfigResolver {
     yaml_keepalive_interval: Option<u64>,
     yaml_keepalive_max: Option<usize>,
     cli_address_family: Option<AddressFamily>,
+    cli_host_key_alias: Option<String>,
 }
 
 impl SshConnectionConfigResolver {
@@ -186,6 +191,16 @@ impl SshConnectionConfigResolver {
         self
     }
 
+    #[must_use]
+    pub fn with_cli_host_key_alias(mut self, alias: Option<String>) -> Self {
+        if let (Some(config), Some(alias)) = (self.fixed_config.as_mut(), alias.as_ref()) {
+            config.host_key_alias = Some(alias.clone());
+            return self;
+        }
+        self.cli_host_key_alias = alias;
+        self
+    }
+
     pub fn resolve_for_host(&self, hostname: &str) -> SshConnectionConfig {
         if let Some(config) = &self.fixed_config {
             return config.clone();
@@ -237,6 +252,11 @@ impl SshConnectionConfigResolver {
         let global_known_hosts_files = host_config
             .as_ref()
             .and_then(|config| config.global_known_hosts_file.clone());
+        let host_key_alias = self.cli_host_key_alias.clone().or_else(|| {
+            host_config
+                .as_ref()
+                .and_then(|config| config.host_key_alias.clone())
+        });
 
         SshConnectionConfig::new()
             .with_keepalive_interval(if keepalive_interval == 0 {
@@ -248,6 +268,7 @@ impl SshConnectionConfigResolver {
             .with_compression(compression)
             .with_address_family(address_family)
             .with_known_hosts_files(user_known_hosts_files, global_known_hosts_files)
+            .with_host_key_alias(host_key_alias)
     }
 }
 
@@ -286,6 +307,13 @@ impl SshConnectionConfig {
     ) -> Self {
         self.user_known_hosts_files = user_files;
         self.global_known_hosts_files = global_files;
+        self
+    }
+
+    /// Set the explicit identity used for known-hosts lookup and recording.
+    #[must_use]
+    pub fn with_host_key_alias(mut self, alias: Option<String>) -> Self {
+        self.host_key_alias = alias;
         self
     }
 
@@ -743,6 +771,21 @@ impl Handler for ClientHandler {
         &mut self,
         server_key: &russh::keys::PublicKeyOrCertificate,
     ) -> Result<bool, Self::Error> {
+        let mut server_check = &self.server_check;
+        let mut host_key_alias = None;
+        while let ServerCheckMethod::HostKeyAlias { alias, method } = server_check {
+            if host_key_alias.is_none() {
+                host_key_alias = Some(alias.as_str());
+            }
+            server_check = method;
+        }
+        let hostname = host_key_alias.unwrap_or(&self.hostname);
+        let port = if host_key_alias.is_some() {
+            22
+        } else {
+            self.host.port()
+        };
+
         // russh 0.63 widened this callback to also deliver OpenSSH *host
         // certificates*. bssh never advertises certificate host key algorithms
         // (both `Preferred` overrides only touch compression, and
@@ -755,21 +798,21 @@ impl Handler for ClientHandler {
         let server_public_key = match server_key {
             russh::keys::PublicKeyOrCertificate::PublicKey { key, .. } => key,
             russh::keys::PublicKeyOrCertificate::Certificate(cert) => {
-                if matches!(self.server_check, ServerCheckMethod::NoCheck) {
+                if matches!(server_check, ServerCheckMethod::NoCheck) {
                     return Ok(true);
                 }
                 tracing::error!(
                     "Host '{}' presented an OpenSSH host certificate (key ID '{}'); \
                      bssh cannot verify certificate signatures, so the host is rejected. \
                      Configure the server to offer a plain host key.",
-                    self.hostname,
+                    hostname,
                     cert.key_id()
                 );
                 return Err(super::Error::ServerCheckFailed);
             }
         };
 
-        match &self.server_check {
+        match server_check {
             ServerCheckMethod::NoCheck => Ok(true),
             ServerCheckMethod::PublicKey(key) => {
                 let pk = russh::keys::parse_public_key_base64(key)
@@ -785,16 +828,16 @@ impl Handler for ClientHandler {
             }
             ServerCheckMethod::KnownHostsFile(known_hosts_path) => {
                 super::host_verification::verify_known_hosts_file(
-                    &self.hostname,
-                    self.host.port(),
+                    hostname,
+                    port,
                     server_public_key,
                     known_hosts_path,
                 )
             }
             ServerCheckMethod::KnownHostsFiles(known_hosts_paths) => {
                 super::host_verification::verify_known_hosts_files(
-                    &self.hostname,
-                    self.host.port(),
+                    hostname,
+                    port,
                     server_public_key,
                     known_hosts_paths,
                 )
@@ -810,21 +853,21 @@ impl Handler for ClientHandler {
                 else {
                     tracing::error!(
                         "Cannot determine the known_hosts path; rejecting host key for '{}'",
-                        self.hostname
+                        hostname
                     );
                     return Err(super::Error::ServerCheckFailed);
                 };
                 super::host_verification::verify_known_hosts_file(
-                    &self.hostname,
-                    self.host.port(),
+                    hostname,
+                    port,
                     server_public_key,
                     &known_hosts_path.to_string_lossy(),
                 )
             }
             ServerCheckMethod::AcceptNewKnownHostsFile(known_hosts_path) => {
                 super::host_verification::verify_accept_new(
-                    &self.hostname,
-                    self.host.port(),
+                    hostname,
+                    port,
                     server_public_key,
                     known_hosts_path,
                 )
@@ -832,8 +875,8 @@ impl Handler for ClientHandler {
             }
             ServerCheckMethod::AcceptNewKnownHostsFiles { files, write_path } => {
                 super::host_verification::verify_accept_new_files(
-                    &self.hostname,
-                    self.host.port(),
+                    hostname,
+                    port,
                     server_public_key,
                     files,
                     write_path.as_deref(),
@@ -842,12 +885,13 @@ impl Handler for ClientHandler {
             }
             ServerCheckMethod::AcceptNewInMemory => {
                 super::host_verification::verify_accept_new_in_memory(
-                    &self.hostname,
-                    self.host.port(),
+                    hostname,
+                    port,
                     server_public_key,
                 )
                 .await
             }
+            ServerCheckMethod::HostKeyAlias { .. } => unreachable!("aliases are unwrapped above"),
         }
     }
 }

--- a/src/ssh/tokio_client/host_verification.rs
+++ b/src/ssh/tokio_client/host_verification.rs
@@ -2379,6 +2379,10 @@ mod tests {
                 files: vec![path_str.clone()],
                 write_path: Some(path_str),
             },
+            ServerCheckMethod::HostKeyAlias {
+                alias: "alias.example.com".into(),
+                method: Box::new(ServerCheckMethod::KnownHostsFiles(Vec::new())),
+            },
             ServerCheckMethod::AcceptNewInMemory,
             ServerCheckMethod::PublicKey(
                 subject.public_key().to_openssh().unwrap()[..]
@@ -2430,6 +2434,112 @@ mod tests {
                 .is_empty(),
             "the client config must not advertise certificate host key algorithms"
         );
+    }
+
+    #[tokio::test]
+    async fn test_host_key_alias_changes_lookup_identity_at_non_default_port() {
+        let (_alias_dir, _alias_path, alias_store) = temp_known_hosts();
+        let (_target_dir, _target_path, target_store) = temp_known_hosts();
+        let key = generate_key();
+        record_host_key(
+            "trust-alias.example.com",
+            22,
+            key.public_key(),
+            &alias_store,
+        );
+        record_host_key(
+            "connection-target.example.com",
+            4242,
+            key.public_key(),
+            &target_store,
+        );
+
+        let mut alias_handler = ClientHandler::new(
+            "connection-target.example.com".into(),
+            "127.0.0.1:4242".parse().unwrap(),
+            ServerCheckMethod::HostKeyAlias {
+                alias: "trust-alias.example.com".into(),
+                method: Box::new(ServerCheckMethod::KnownHostsFiles(vec![
+                    alias_store.clone(),
+                ])),
+            },
+        );
+        assert!(matches!(
+            alias_handler
+                .check_server_key(&host_key(key.public_key()))
+                .await,
+            Ok(true)
+        ));
+
+        let mut target_against_alias_store = ClientHandler::new(
+            "connection-target.example.com".into(),
+            "127.0.0.1:4242".parse().unwrap(),
+            ServerCheckMethod::KnownHostsFiles(vec![alias_store]),
+        );
+        assert!(matches!(
+            target_against_alias_store
+                .check_server_key(&host_key(key.public_key()))
+                .await,
+            Ok(false)
+        ));
+
+        let mut target_handler = ClientHandler::new(
+            "connection-target.example.com".into(),
+            "127.0.0.1:4242".parse().unwrap(),
+            ServerCheckMethod::KnownHostsFiles(vec![target_store.clone()]),
+        );
+        assert!(matches!(
+            target_handler
+                .check_server_key(&host_key(key.public_key()))
+                .await,
+            Ok(true)
+        ));
+
+        let mut alias_against_target_store = ClientHandler::new(
+            "connection-target.example.com".into(),
+            "127.0.0.1:4242".parse().unwrap(),
+            ServerCheckMethod::HostKeyAlias {
+                alias: "trust-alias.example.com".into(),
+                method: Box::new(ServerCheckMethod::KnownHostsFiles(vec![target_store])),
+            },
+        );
+        assert!(matches!(
+            alias_against_target_store
+                .check_server_key(&host_key(key.public_key()))
+                .await,
+            Ok(false)
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_host_key_alias_accept_new_records_unbracketed_alias() {
+        let (_dir, path, path_str) = temp_known_hosts();
+        let key = generate_key();
+        let mut handler = ClientHandler::new(
+            "connection-target.example.com".into(),
+            "127.0.0.1:4242".parse().unwrap(),
+            ServerCheckMethod::HostKeyAlias {
+                alias: "record-alias.example.com".into(),
+                method: Box::new(ServerCheckMethod::AcceptNewKnownHostsFiles {
+                    files: vec![path_str.clone()],
+                    write_path: Some(path_str),
+                }),
+            },
+        );
+
+        assert!(matches!(
+            handler.check_server_key(&host_key(key.public_key())).await,
+            Ok(true)
+        ));
+        let lines = entry_lines(&path);
+        assert_eq!(lines.len(), 1);
+        assert!(
+            lines[0].starts_with("record-alias.example.com "),
+            "HostKeyAlias must be recorded verbatim without port brackets: {}",
+            lines[0]
+        );
+        assert!(!lines[0].contains("connection-target.example.com"));
+        assert!(!lines[0].starts_with("[record-alias.example.com]:4242 "));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Honor `HostKeyAlias` as the known-hosts trust identity while continuing to dial the configured network target and port.

## Changes

- Resolve `HostKeyAlias` from the effective host block and from case-insensitive `-o HostKeyAlias=` overrides with OpenSSH first-value precedence.
- Wrap the selected host verification method with the alias so direct, interactive, forwarding, and jump-host paths share the behavior.
- Look up and record the alias with logical port 22, keeping it unbracketed even when the connection uses a non-default port.
- Preserve strict, accept-new, multi-file, process-pin, and certificate fail-closed behavior under the aliased identity.
- Round-trip the aliased verification method through the shared authentication representation.

## Test plan

- `cargo test --lib host_key_alias`
- `cargo test --lib ssh_option_lookup_is_case_insensitive_and_first_value_wins`
- `cargo test --lib test_host_certificate_is_rejected_by_verifying_modes`
- `cargo check --lib --tests`
- `cargo clippy --lib --tests -- -D warnings`
- `cargo fmt --all -- --check`

Closes #279
