### PR TITLE
fix(error): add actionable SSH client diagnostics

### DIFF
--- a/src/commands/exec.rs
+++ b/src/commands/exec.rs
@@ -16,13 +16,15 @@ use anyhow::Result;
 use std::path::Path;
 use std::sync::Arc;
 
-use crate::executor::{ExitCodeStrategy, OutputMode, ParallelExecutor, RankDetector};
+use crate::executor::{
+    ExecutionResult, ExitCodeStrategy, OutputMode, ParallelExecutor, RankDetector,
+};
 use crate::forwarding::ForwardingType;
 use crate::node::Node;
 use crate::security::{Password, SudoPassword};
 use crate::ssh::SshConfig;
 use crate::ssh::known_hosts::StrictHostKeyChecking;
-use crate::ssh::tokio_client::SshConnectionConfigResolver;
+use crate::ssh::tokio_client::{Error as SshError, SshConnectionConfigResolver};
 use crate::ui::OutputFormatter;
 use crate::utils::output::save_outputs_to_files;
 
@@ -57,6 +59,36 @@ pub struct ExecuteCommandParams<'a> {
     pub ssh_config: Option<&'a SshConfig>,
     /// Per-host SSH connection configuration resolver.
     pub ssh_connection_config_resolver: SshConnectionConfigResolver,
+}
+
+const SSH_CLIENT_FAILURE_EXIT_CODE: i32 = 255;
+
+pub(crate) fn is_ssh_client_failure(error: &anyhow::Error) -> bool {
+    error.chain().any(|cause| {
+        cause
+            .downcast_ref::<SshError>()
+            .is_some_and(SshError::is_ssh_client_failure)
+    })
+}
+
+fn calculate_execution_exit_code(
+    results: &[ExecutionResult],
+    main_idx: Option<usize>,
+    strategy: ExitCodeStrategy,
+    ssh_single_destination: bool,
+) -> i32 {
+    if ssh_single_destination {
+        return results
+            .first()
+            .map(|result| match &result.result {
+                Ok(_) => result.get_exit_code(),
+                Err(error) if is_ssh_client_failure(error) => SSH_CLIENT_FAILURE_EXIT_CODE,
+                Err(_) => result.get_exit_code(),
+            })
+            .unwrap_or(SSH_CLIENT_FAILURE_EXIT_CODE);
+    }
+
+    strategy.calculate(results, main_idx)
 }
 
 pub async fn execute_command(params: ExecuteCommandParams<'_>) -> Result<()> {
@@ -332,8 +364,15 @@ async fn execute_command_without_forwarding(params: ExecuteCommandParams<'_>) ->
     // Identify main rank
     let main_idx = RankDetector::identify_main_rank(&nodes_for_rank_detection);
 
-    // Calculate exit code using the strategy
-    let exit_code = strategy.calculate(&results, main_idx);
+    // OpenSSH reserves 255 for client-side failures. Apply that contract only
+    // to the byte-transparent, single-destination SSH mode; multi-host bssh
+    // aggregation keeps its existing ExitCodeStrategy behavior.
+    let exit_code = calculate_execution_exit_code(
+        &results,
+        main_idx,
+        strategy,
+        params.byte_transparent && nodes_for_rank_detection.len() == 1,
+    );
 
     // Exit with the calculated exit code
     if exit_code != 0 {
@@ -341,4 +380,90 @@ async fn execute_command_without_forwarding(params: ExecuteCommandParams<'_>) ->
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ssh::client::CommandResult;
+    use anyhow::anyhow;
+
+    fn result(result: Result<CommandResult>) -> ExecutionResult {
+        ExecutionResult {
+            node: Node::new("host".to_string(), 22, "user".to_string()),
+            result,
+            is_main_rank: true,
+        }
+    }
+
+    fn remote_status(status: u32) -> ExecutionResult {
+        result(Ok(CommandResult {
+            host: "host".to_string(),
+            output: Vec::new(),
+            stderr: Vec::new(),
+            exit_status: status,
+        }))
+    }
+
+    #[test]
+    fn ssh_single_destination_client_failure_exits_255() {
+        let results = [result(Err(anyhow::Error::new(SshError::TcpConnect {
+            host: "host".to_string(),
+            port: 22,
+            source: std::io::Error::from_raw_os_error(libc::ECONNREFUSED),
+        })))];
+
+        assert_eq!(
+            calculate_execution_exit_code(&results, Some(0), ExitCodeStrategy::MainRank, true,),
+            255
+        );
+
+        let timeout = [result(Err(anyhow::Error::new(
+            SshError::ConnectionTimeout {
+                host: "host".to_string(),
+                port: 22,
+                seconds: 1,
+                stage: "connection setup or authentication",
+            },
+        )))];
+        assert_eq!(
+            calculate_execution_exit_code(&timeout, Some(0), ExitCodeStrategy::MainRank, true,),
+            255
+        );
+    }
+
+    #[test]
+    fn ssh_single_destination_preserves_remote_status() {
+        for status in [0, 42, 255] {
+            assert_eq!(
+                calculate_execution_exit_code(
+                    &[remote_status(status)],
+                    Some(0),
+                    ExitCodeStrategy::MainRank,
+                    true,
+                ),
+                status as i32
+            );
+        }
+    }
+
+    #[test]
+    fn ssh_single_destination_local_error_keeps_generic_status() {
+        let results = [result(Err(anyhow!("local validation failed")))];
+
+        assert_eq!(
+            calculate_execution_exit_code(&results, Some(0), ExitCodeStrategy::MainRank, true,),
+            1
+        );
+    }
+
+    #[test]
+    fn multi_host_connection_error_keeps_existing_aggregation_status() {
+        let results = [result(Err(anyhow!("connection refused")))];
+
+        assert_eq!(
+            calculate_execution_exit_code(&results, Some(0), ExitCodeStrategy::MainRank, false,),
+            1
+        );
+    }
 }

--- a/src/commands/interactive/connection.rs
+++ b/src/commands/interactive/connection.rs
@@ -66,13 +66,20 @@ impl InteractiveCommand {
         // Use connect_with_ssh_config to properly apply keepalive settings
         let result = timeout(
             connect_timeout,
-            Client::connect_with_ssh_config(addr, username, auth_method, check_method.clone(), ssh_config),
+            Client::connect_with_ssh_config(
+                addr,
+                username,
+                auth_method,
+                check_method.clone(),
+                ssh_config,
+            ),
         )
         .await
-        .with_context(|| {
-            format!(
-                "Connection timeout: Failed to connect to {host}:{port} after {SSH_CONNECT_TIMEOUT_SECS} seconds"
-            )
+        .map_err(|_| SshError::ConnectionTimeout {
+            host: host.to_string(),
+            port,
+            seconds: SSH_CONNECT_TIMEOUT_SECS,
+            stage: "connection setup or authentication",
         })?;
 
         // Check if authentication failed and password fallback is allowed
@@ -101,13 +108,20 @@ impl InteractiveCommand {
                 // Use connect_with_ssh_config for password retry as well
                 timeout(
                     connect_timeout,
-                    Client::connect_with_ssh_config(addr, username, password_auth, check_method, ssh_config),
+                    Client::connect_with_ssh_config(
+                        addr,
+                        username,
+                        password_auth,
+                        check_method,
+                        ssh_config,
+                    ),
                 )
                 .await
-                .with_context(|| {
-                    format!(
-                        "Connection timeout: Failed to connect to {host}:{port} after {SSH_CONNECT_TIMEOUT_SECS} seconds"
-                    )
+                .map_err(|_| SshError::ConnectionTimeout {
+                    host: host.to_string(),
+                    port,
+                    seconds: SSH_CONNECT_TIMEOUT_SECS,
+                    stage: "password authentication retry",
                 })?
                 .with_context(|| format!("SSH connection failed to {host}:{port}"))
             }
@@ -293,11 +307,11 @@ impl InteractiveCommand {
                     ),
                 )
                 .await
-                .with_context(|| {
-                    format!(
-                        "Connection timeout: Failed to connect to {}:{} via jump hosts after {} seconds",
-                        node.host, node.port, adjusted_timeout.as_secs()
-                    )
+                .map_err(|_| SshError::ConnectionTimeout {
+                    host: node.host.clone(),
+                    port: node.port,
+                    seconds: adjusted_timeout.as_secs(),
+                    stage: "jump-host connection setup or authentication",
                 })?
                 .with_context(|| {
                     format!(
@@ -446,11 +460,11 @@ impl InteractiveCommand {
                     ),
                 )
                 .await
-                .with_context(|| {
-                    format!(
-                        "Connection timeout: Failed to connect to {}:{} via jump hosts after {} seconds",
-                        node.host, node.port, adjusted_timeout.as_secs()
-                    )
+                .map_err(|_| SshError::ConnectionTimeout {
+                    host: node.host.clone(),
+                    port: node.port,
+                    seconds: adjusted_timeout.as_secs(),
+                    stage: "jump-host connection setup or authentication",
                 })?
                 .with_context(|| {
                     format!(

--- a/src/executor/parallel.rs
+++ b/src/executor/parallel.rs
@@ -1222,6 +1222,7 @@ impl ParallelExecutor {
         use tokio::sync::mpsc;
 
         let semaphore = Arc::new(Semaphore::new(self.max_parallel));
+        let raw_stream = output_mode.is_raw_stream();
         let mut manager = MultiNodeStreamManager::new();
         let mut handles = Vec::new();
 
@@ -1311,7 +1312,15 @@ impl ParallelExecutor {
                             (node_clone, Ok(exit_status))
                         }
                         Err(e) => {
-                            tracing::error!("Sudo command failed for {}: {}", node_clone.host, e);
+                            if raw_stream {
+                                crate::diagnosticln!("{e:#}");
+                            } else {
+                                tracing::error!(
+                                    "Sudo command failed for {}: {}",
+                                    node_clone.host,
+                                    e
+                                );
+                            }
                             (node_clone, Err(e))
                         }
                     }
@@ -1329,7 +1338,11 @@ impl ParallelExecutor {
                             (node_clone, Ok(exit_status))
                         }
                         Err(e) => {
-                            tracing::error!("Command failed for {}: {}", node_clone.host, e);
+                            if raw_stream {
+                                crate::diagnosticln!("{e:#}");
+                            } else {
+                                tracing::error!("Command failed for {}: {}", node_clone.host, e);
+                            }
                             (node_clone, Err(e))
                         }
                     }
@@ -1346,7 +1359,6 @@ impl ParallelExecutor {
 
         // Execute based on mode and ensure cleanup
         let no_prefix = output_mode.is_no_prefix();
-        let raw_stream = output_mode.is_raw_stream();
 
         if output_mode.is_tui() {
             // TUI mode: interactive terminal UI
@@ -1378,7 +1390,7 @@ impl ParallelExecutor {
         use tokio::signal;
 
         let mut pending_handles = handles;
-        let mut results = Vec::new();
+        let mut task_results: Vec<(Node, Result<u32>)> = Vec::new();
         let mut first_ctrl_c = false;
         let mut ctrl_c_time: Option<std::time::Instant> = None;
 
@@ -1491,10 +1503,12 @@ impl ParallelExecutor {
             while i < pending_handles.len() {
                 if pending_handles[i].is_finished() {
                     let handle = pending_handles.remove(i);
-                    // Check if task panicked
-                    if let Err(e) = &handle.await {
-                        tracing::error!("Task panicked: {}", e);
-                        // Continue processing other nodes
+                    // Preserve each typed task result until final stream collection.
+                    // Reconstructing it from ExecutionStatus would collapse a
+                    // connection failure into a synthetic remote exit status 1.
+                    match handle.await {
+                        Ok(result) => task_results.push(result),
+                        Err(e) => tracing::error!("Task panicked: {}", e),
                     }
                 } else {
                     i += 1;
@@ -1538,9 +1552,24 @@ impl ParallelExecutor {
                 result?;
             }
         }
-        // Collect final results from all streams
+        // Collect final results from all streams. Prefer the task result so
+        // typed connection/authentication errors survive into exit-code mapping.
+        let mut results = Vec::with_capacity(manager.streams().len());
         for stream in manager.streams() {
-            let result = completed_stream_result(stream);
+            let result = if let Some(index) = task_results
+                .iter()
+                .position(|(node, _)| node == &stream.node)
+            {
+                let (_, task_result) = task_results.swap_remove(index);
+                task_result.map(|exit_status| crate::ssh::client::CommandResult {
+                    host: stream.node.host.clone(),
+                    output: Vec::new(),
+                    stderr: Vec::new(),
+                    exit_status,
+                })
+            } else {
+                completed_stream_result(stream)
+            };
 
             results.push(ExecutionResult {
                 node: stream.node.clone(),

--- a/src/jump/chain.rs
+++ b/src/jump/chain.rs
@@ -26,7 +26,9 @@ use super::parser::{JumpHost, get_max_jump_hosts};
 use super::rate_limiter::ConnectionRateLimiter;
 use crate::security::Password;
 use crate::ssh::known_hosts::StrictHostKeyChecking;
-use crate::ssh::tokio_client::{AuthMethod, SshConnectionConfig, SshConnectionConfigResolver};
+use crate::ssh::tokio_client::{
+    AuthMethod, Error as SshError, SshConnectionConfig, SshConnectionConfigResolver,
+};
 use anyhow::{Context, Result};
 use std::path::Path;
 use std::sync::Arc;
@@ -439,13 +441,11 @@ impl JumpHostChain {
             ),
         )
         .await
-        .with_context(|| {
-            format!(
-                "Connection timeout: Failed to connect to jump host {}:{} after {}s",
-                jump_host.host,
-                jump_host.effective_port(),
-                self.connect_timeout.as_secs()
-            )
+        .map_err(|_| SshError::ConnectionTimeout {
+            host: jump_host.host.clone(),
+            port: jump_host.effective_port(),
+            seconds: self.connect_timeout.as_secs(),
+            stage: "first jump-host connection setup or authentication",
         })?
         .with_context(|| {
             format!(

--- a/src/jump/chain/chain_connection.rs
+++ b/src/jump/chain/chain_connection.rs
@@ -15,7 +15,7 @@
 use super::types::{JumpConnection, JumpInfo};
 use crate::jump::rate_limiter::ConnectionRateLimiter;
 use crate::ssh::known_hosts::StrictHostKeyChecking;
-use crate::ssh::tokio_client::{AuthMethod, Client, SshConnectionConfig};
+use crate::ssh::tokio_client::{AuthMethod, Client, Error as SshError, SshConnectionConfig};
 use anyhow::{Context, Result};
 use tracing::{debug, info};
 
@@ -58,13 +58,11 @@ pub(super) async fn connect_direct(
         ),
     )
     .await
-    .with_context(|| {
-        format!(
-            "Connection timeout: Failed to connect to {}:{} after {}s",
-            host,
-            port,
-            connect_timeout.as_secs()
-        )
+    .map_err(|_| SshError::ConnectionTimeout {
+        host: host.to_string(),
+        port,
+        seconds: connect_timeout.as_secs(),
+        stage: "direct connection setup or authentication",
     })?
     .with_context(|| format!("Failed to establish direct connection to {host}:{port}"))?;
 

--- a/src/jump/chain/tunnel.rs
+++ b/src/jump/chain/tunnel.rs
@@ -18,7 +18,7 @@ use crate::jump::rate_limiter::ConnectionRateLimiter;
 use crate::security::Password;
 use crate::ssh::known_hosts::StrictHostKeyChecking;
 use crate::ssh::tokio_client::{
-    AddressFamily, AuthMethod, Client, ClientHandler, SshConnectionConfig,
+    AddressFamily, AuthMethod, Client, ClientHandler, Error as SshError, SshConnectionConfig,
 };
 use anyhow::{Context, Result};
 use std::net::{SocketAddr, ToSocketAddrs};
@@ -104,13 +104,11 @@ pub(super) async fn connect_through_tunnel(
         ),
     )
     .await
-    .with_context(|| {
-        format!(
-            "Timeout opening tunnel to jump host {}:{} after {}s",
-            jump_host.host,
-            jump_host.effective_port(),
-            connect_timeout.as_secs()
-        )
+    .map_err(|_| SshError::ConnectionTimeout {
+        host: jump_host.host.clone(),
+        port: jump_host.effective_port(),
+        seconds: connect_timeout.as_secs(),
+        stage: "jump-host channel open",
     })?
     .with_context(|| {
         format!(
@@ -172,13 +170,11 @@ pub(super) async fn connect_through_tunnel(
         russh::client::connect_stream(config, stream, handler),
     )
     .await
-    .with_context(|| {
-        format!(
-            "Timeout establishing SSH over tunnel to {}:{} after {}s",
-            jump_host.host,
-            jump_host.effective_port(),
-            connect_timeout.as_secs()
-        )
+    .map_err(|_| SshError::ConnectionTimeout {
+        host: jump_host.host.clone(),
+        port: jump_host.effective_port(),
+        seconds: connect_timeout.as_secs(),
+        stage: "jump-host protocol negotiation",
     })?
     .with_context(|| {
         format!(
@@ -251,11 +247,11 @@ pub(super) async fn connect_to_destination(
         ),
     )
     .await
-    .with_context(|| {
-        format!(
-            "Timeout opening tunnel to destination {}:{} after {}s",
-            destination_host, destination_port, connect_timeout.as_secs()
-        )
+    .map_err(|_| SshError::ConnectionTimeout {
+        host: destination_host.to_string(),
+        port: destination_port,
+        seconds: connect_timeout.as_secs(),
+        stage: "destination channel open",
     })?
     .with_context(|| {
         format!(
@@ -296,11 +292,11 @@ pub(super) async fn connect_to_destination(
         russh::client::connect_stream(config, stream, handler),
     )
     .await
-    .with_context(|| {
-        format!(
-            "Timeout establishing SSH to destination {}:{} after {}s",
-            destination_host, destination_port, connect_timeout.as_secs()
-        )
+    .map_err(|_| SshError::ConnectionTimeout {
+        host: destination_host.to_string(),
+        port: destination_port,
+        seconds: connect_timeout.as_secs(),
+        stage: "destination protocol negotiation",
     })?
     .with_context(|| {
         format!(

--- a/src/main.rs
+++ b/src/main.rs
@@ -75,7 +75,7 @@ async fn dispatch_and_exit(cli: &Cli, ctx: &AppContext) -> Result<()> {
     match dispatch_command(cli, ctx).await {
         Ok(0) => Ok(()),
         Ok(exit_code) => std::process::exit(exit_code),
-        Err(e) => Err(map_hard_failure(&cli.command, e)),
+        Err(e) => Err(map_hard_failure(&cli.command, cli.is_ssh_mode(), e)),
     }
 }
 
@@ -88,14 +88,31 @@ async fn dispatch_and_exit(cli: &Cli, ctx: &AppContext) -> Result<()> {
 /// and it keeps the pre-connection case distinct from the exit code 1 that means
 /// "some hosts answered and some did not".
 ///
-/// Every other subcommand keeps the default behavior, where returning `Err` from
-/// `main` prints the error chain and exits 1.
-fn map_hard_failure(command: &Option<Commands>, error: anyhow::Error) -> anyhow::Error {
+/// Typed SSH client failures use OpenSSH's exit status 255. Local validation,
+/// configuration, and other subcommand failures retain the generic exit status 1.
+fn is_ssh_client_failure(error: &anyhow::Error) -> bool {
+    error.chain().any(|cause| {
+        cause
+            .downcast_ref::<bssh::ssh::tokio_client::Error>()
+            .is_some_and(bssh::ssh::tokio_client::Error::is_ssh_client_failure)
+    })
+}
+
+fn map_hard_failure(
+    command: &Option<Commands>,
+    ssh_mode: bool,
+    error: anyhow::Error,
+) -> anyhow::Error {
     if matches!(command, Some(Commands::Ping)) {
         // Match the format anyhow's `Termination` impl uses, since this path
         // replaces it.
         bssh::diagnosticln!("Error: {error:?}");
         std::process::exit(PING_SSH_LEVEL_FAILURE);
+    }
+
+    if ssh_mode && is_ssh_client_failure(&error) {
+        bssh::diagnosticln!("{error:#}");
+        std::process::exit(255);
     }
 
     error
@@ -298,7 +315,7 @@ async fn run_bssh_mode(args: &[String]) -> Result<()> {
     let init_result = initialize_app(&mut cli, args).await;
     let ctx = match init_result {
         Ok(ctx) => ctx,
-        Err(e) => return Err(map_hard_failure(&cli.command, e)),
+        Err(e) => return Err(map_hard_failure(&cli.command, cli.is_ssh_mode(), e)),
     };
 
     // Dispatch to the appropriate command handler

--- a/src/ssh/auth.rs
+++ b/src/ssh/auth.rs
@@ -274,6 +274,26 @@ impl AuthContext {
         result
     }
 
+    fn authentication_exhausted_error(&self, password_status: &'static str) -> anyhow::Error {
+        let agent_status = if cfg!(target_os = "windows") {
+            "not supported on Windows".to_string()
+        } else {
+            match std::env::var_os("SSH_AUTH_SOCK") {
+                Some(socket) if std::path::Path::new(&socket).exists() => {
+                    "available but no usable identities were found".to_string()
+                }
+                Some(_) => "configured socket path does not exist".to_string(),
+                None => "not available (SSH_AUTH_SOCK is not set)".to_string(),
+            }
+        };
+
+        anyhow::Error::new(crate::ssh::tokio_client::Error::AuthenticationExhausted {
+            methods: "publickey",
+            agent_status,
+            password_status,
+        })
+    }
+
     async fn determine_method_internal(&self) -> Result<AuthMethod> {
         // Priority 1: Password authentication (explicit request)
         if self.use_password {
@@ -340,51 +360,12 @@ impl AuthContext {
                         self.password_auth().await
                     } else {
                         // User declined password fallback
-                        anyhow::bail!(
-                            "SSH authentication failed: All key-based methods failed.\n\
-                             \n\
-                             Tried:\n\
-                             - SSH agent: {}\n\
-                             - Default SSH keys: Not found or not authorized\n\
-                             \n\
-                             User declined password authentication fallback.\n\
-                             \n\
-                             Solutions:\n\
-                             - Use --password flag to explicitly enable password authentication\n\
-                             - Start SSH agent and add keys with 'ssh-add'\n\
-                             - Specify a key file with -i/--identity\n\
-                             - Ensure ~/.ssh/id_ed25519 or ~/.ssh/id_rsa exists and is authorized",
-                            if cfg!(target_os = "windows") {
-                                "Not supported on Windows"
-                            } else if std::env::var_os("SSH_AUTH_SOCK").is_some() {
-                                "Available but no identities authorized"
-                            } else {
-                                "Not available (SSH_AUTH_SOCK not set)"
-                            }
-                        )
+                        Err(self.authentication_exhausted_error("declined by user"))
                     }
                 } else {
                     // Non-interactive environment - cannot prompt for password
-                    anyhow::bail!(
-                        "SSH authentication failed: No authentication method available.\n\
-                         \n\
-                         Tried:\n\
-                         - SSH agent: {}\n\
-                         - Default SSH keys: Not found or not authorized\n\
-                         \n\
-                         Solutions:\n\
-                         - Use --password for password authentication\n\
-                         - Start SSH agent and add keys with 'ssh-add'\n\
-                         - Specify a key file with -i/--identity\n\
-                         - Ensure ~/.ssh/id_ed25519 or ~/.ssh/id_rsa exists and is authorized",
-                        if cfg!(target_os = "windows") {
-                            "Not supported on Windows"
-                        } else if std::env::var_os("SSH_AUTH_SOCK").is_some() {
-                            "Available but no identities authorized"
-                        } else {
-                            "Not available (SSH_AUTH_SOCK not set)"
-                        }
-                    )
+                    Err(self
+                        .authentication_exhausted_error("not available in non-interactive mode"))
                 }
             }
         }
@@ -515,12 +496,12 @@ impl AuthContext {
                         Ok(None)
                     }
                 } else {
-                    tracing::warn!("SSH_AUTH_SOCK points to non-existent socket");
+                    tracing::debug!("SSH_AUTH_SOCK points to non-existent socket");
                     Ok(None)
                 }
             }
             None => {
-                tracing::warn!(
+                tracing::debug!(
                     "SSH agent requested but SSH_AUTH_SOCK environment variable not set"
                 );
                 Ok(None)

--- a/src/ssh/client/connection.rs
+++ b/src/ssh/client/connection.rs
@@ -195,10 +195,13 @@ impl SshClient {
                     None => Err(anyhow::Error::new(e)),
                 }
             }
-            Err(_) => Err(anyhow::anyhow!(
-                "Connection timeout after {} seconds. \
-                     Please check if the host is reachable and SSH service is running.",
-                connect_timeout.as_secs()
+            Err(_) => Err(anyhow::Error::new(
+                crate::ssh::tokio_client::Error::ConnectionTimeout {
+                    host: self.host.clone(),
+                    port: self.port,
+                    seconds: connect_timeout.as_secs(),
+                    stage: "connection setup or authentication",
+                },
             )),
         };
 
@@ -535,7 +538,7 @@ mod tests {
 
         let rendered = format!("{err:#}");
         assert_eq!(
-            rendered, "The private key was rejected by the server: Key authentication failed",
+            rendered, "The private key was rejected by the server: Permission denied (publickey).",
             "expected friendly message first, then the cause"
         );
         // The underlying cause must appear after the friendly message, not
@@ -555,7 +558,7 @@ mod tests {
         // Variants whose own `Display` already says everything get no extra
         // context layer, so the same wording is not printed twice. Before this
         // fix, `PasswordWrong` rendered as
-        // "Password authentication failed.: Password authentication failed".
+        // "Permission denied (password).: Permission denied (password).".
         for e in [
             crate::ssh::tokio_client::Error::PasswordWrong,
             crate::ssh::tokio_client::Error::AgentAuthenticationFailed,

--- a/src/ssh/client/file_transfer.rs
+++ b/src/ssh/client/file_transfer.rs
@@ -693,8 +693,13 @@ impl SshClient {
                 let detailed = format_ssh_error(&context, &e);
                 Err(anyhow::Error::new(e).context(detailed))
             }
-            Err(_) => Err(anyhow::anyhow!(
-                "Connection timeout after {timeout_secs} seconds. Host may be unreachable or SSH service not running."
+            Err(_) => Err(anyhow::Error::new(
+                crate::ssh::tokio_client::Error::ConnectionTimeout {
+                    host: self.host.clone(),
+                    port: self.port,
+                    seconds: timeout_secs,
+                    stage: "connection setup or authentication",
+                },
             )),
         }
     }
@@ -821,7 +826,7 @@ mod tests {
             "expected friendly message first, got: {rendered}"
         );
         assert!(
-            rendered[detailed.len()..].contains("Password authentication failed"),
+            rendered[detailed.len()..].contains("Permission denied (password)."),
             "expected the cause to appear after the friendly message, got: {rendered}"
         );
     }

--- a/src/ssh/tokio_client/channel_manager.rs
+++ b/src/ssh/tokio_client/channel_manager.rs
@@ -183,7 +183,10 @@ impl Client {
     ) -> Result<Vec<SocketAddr>, super::Error> {
         let resolved = target
             .to_socket_addrs()
-            .map_err(super::Error::AddressInvalid)?;
+            .map_err(|source| super::Error::DnsResolution {
+                host: target.hostname(),
+                source,
+            })?;
         let targets = address_family.filter(resolved);
 
         if address_family.is_forced() && targets.is_empty() {
@@ -224,7 +227,7 @@ impl Client {
         self.connection_handle
             .channel_open_session()
             .await
-            .map_err(super::Error::SshError)
+            .map_err(|source| super::Error::ChannelOpen { source })
     }
 
     /// Open a TCP/IP forwarding channel.
@@ -281,7 +284,7 @@ impl Client {
                 .await
             {
                 Ok(channel) => return Ok(channel),
-                Err(err) => connect_err = super::Error::SshError(err),
+                Err(source) => connect_err = super::Error::ChannelOpen { source },
             }
         }
 
@@ -327,8 +330,18 @@ impl Client {
         let sanitized_command = crate::utils::sanitize_command(command)
             .map_err(|e| super::Error::CommandValidationFailed(e.to_string()))?;
 
-        let mut channel = self.connection_handle.channel_open_session().await?;
-        channel.exec(true, sanitized_command.as_str()).await?;
+        let mut channel = self
+            .connection_handle
+            .channel_open_session()
+            .await
+            .map_err(|source| super::Error::ChannelOpen { source })?;
+        channel
+            .exec(true, sanitized_command.as_str())
+            .await
+            .map_err(|source| super::Error::CommandExecution {
+                action: "exec request",
+                source,
+            })?;
 
         let mut result: Option<u32> = None;
         let mut output_receiver_open = true;
@@ -410,7 +423,11 @@ impl Client {
 
         // Request a PTY for sudo to properly interact with
         // Sudo requires a PTY to prompt for password
-        let mut channel = self.connection_handle.channel_open_session().await?;
+        let mut channel = self
+            .connection_handle
+            .channel_open_session()
+            .await
+            .map_err(|source| super::Error::ChannelOpen { source })?;
 
         // Request PTY with reasonable defaults for sudo
         channel
@@ -423,9 +440,19 @@ impl Client {
                 0,       // pixel height
                 &[],     // terminal modes (empty for defaults)
             )
-            .await?;
+            .await
+            .map_err(|source| super::Error::CommandExecution {
+                action: "PTY request",
+                source,
+            })?;
 
-        channel.exec(true, sanitized_command.as_str()).await?;
+        channel
+            .exec(true, sanitized_command.as_str())
+            .await
+            .map_err(|source| super::Error::CommandExecution {
+                action: "exec request",
+                source,
+            })?;
 
         let mut result: Option<u32> = None;
         let mut password_send_count: u32 = 0;
@@ -473,7 +500,10 @@ impl Client {
                         let password_data = sudo_password.with_newline();
                         if let Err(e) = channel.data(&password_data[..]).await {
                             tracing::error!("Failed to send sudo password: {}", e);
-                            return Err(super::Error::SshError(e));
+                            return Err(super::Error::CommandExecution {
+                                action: "sudo password write",
+                                source: e,
+                            });
                         }
                         // Clear accumulated output after sending password to detect next prompt
                         accumulated_output.clear();
@@ -539,7 +569,10 @@ impl Client {
                         let password_data = sudo_password.with_newline();
                         if let Err(e) = channel.data(&password_data[..]).await {
                             tracing::error!("Failed to send sudo password: {}", e);
-                            return Err(super::Error::SshError(e));
+                            return Err(super::Error::CommandExecution {
+                                action: "sudo password write",
+                                source: e,
+                            });
                         }
                         accumulated_output.clear();
                     }
@@ -652,7 +685,11 @@ impl Client {
     ) -> Result<Channel<Msg>, super::Error> {
         // Open a session channel - PTY and shell will be requested by the caller
         // (e.g., PtySession::initialize() with proper terminal modes)
-        let channel = self.connection_handle.channel_open_session().await?;
+        let channel = self
+            .connection_handle
+            .channel_open_session()
+            .await
+            .map_err(|source| super::Error::ChannelOpen { source })?;
         Ok(channel)
     }
 
@@ -669,7 +706,10 @@ impl Client {
         channel
             .window_change(width, height, 0, 0)
             .await
-            .map_err(super::Error::SshError)
+            .map_err(|source| super::Error::CommandExecution {
+                action: "window-change request",
+                source,
+            })
     }
 }
 

--- a/src/ssh/tokio_client/connection.rs
+++ b/src/ssh/tokio_client/connection.rs
@@ -653,7 +653,11 @@ impl Client {
                             stderr: failure.stderr,
                         });
                     }
-                    return Err(error);
+                    return Err(super::Error::during_protocol_negotiation(
+                        host.to_string(),
+                        port,
+                        error,
+                    ));
                 }
             };
 
@@ -714,9 +718,14 @@ impl Client {
         let config = Arc::new(config);
 
         // Connection code inspired from std::net::TcpStream::connect and std::net::each_addr
+        let target_host = addr.hostname();
+        let (_, target_port) = addr.host_port().map_err(super::Error::AddressInvalid)?;
         let resolved = addr
             .to_socket_addrs()
-            .map_err(super::Error::AddressInvalid)?;
+            .map_err(|source| super::Error::DnsResolution {
+                host: target_host.clone(),
+                source,
+            })?;
         let resolved_count = resolved.len();
         let socket_addrs = address_family.filter(resolved);
 
@@ -739,10 +748,10 @@ impl Client {
         let mut connect_res: Result<
             (SocketAddr, russh::client::Handle<ClientHandler>),
             super::Error,
-        > = Err(super::Error::AddressInvalid(io::Error::new(
-            io::ErrorKind::InvalidInput,
-            "could not resolve to any addresses",
-        )));
+        > = Err(super::Error::DnsResolution {
+            host: target_host.clone(),
+            source: io::Error::new(io::ErrorKind::NotFound, "Name or service not known"),
+        });
         for socket_addr in socket_addrs {
             let handler = ClientHandler {
                 hostname: addr.hostname(),
@@ -753,7 +762,11 @@ impl Client {
             let stream = match tokio::net::TcpStream::connect(socket_addr).await {
                 Ok(s) => s,
                 Err(e) => {
-                    connect_res = Err(super::Error::IoError(e));
+                    connect_res = Err(super::Error::TcpConnect {
+                        host: target_host.clone(),
+                        port: target_port,
+                        source: e,
+                    });
                     continue;
                 }
             };
@@ -774,7 +787,13 @@ impl Client {
                     connect_res = Ok((socket_addr, h));
                     break;
                 }
-                Err(e) => connect_res = Err(e),
+                Err(e) => {
+                    connect_res = Err(super::Error::during_protocol_negotiation(
+                        target_host.clone(),
+                        target_port,
+                        e,
+                    ));
+                }
             }
         }
         let (address, mut handle) = connect_res?;

--- a/src/ssh/tokio_client/error.rs
+++ b/src/ssh/tokio_client/error.rs
@@ -18,6 +18,14 @@ pub enum Error {
     KeyInvalid(russh::keys::Error),
     #[error("Permission denied (password).")]
     PasswordWrong,
+    #[error(
+        "Permission denied ({methods}).\nbssh: SSH agent: {agent_status}\nbssh: Default SSH keys: not found or not authorized\nbssh: Password authentication: {password_status}\nbssh: use -i/--identity, --password, or ssh-add to configure an authentication method"
+    )]
+    AuthenticationExhausted {
+        methods: &'static str,
+        agent_status: String,
+        password_status: &'static str,
+    },
     #[error("Invalid address was provided: {0}")]
     AddressInvalid(io::Error),
     #[error("ssh: Could not resolve hostname {host}: {source}")]
@@ -156,6 +164,7 @@ impl Error {
                 | Self::KeyAuthFailed
                 | Self::KeyInvalid(_)
                 | Self::PasswordWrong
+                | Self::AuthenticationExhausted { .. }
                 | Self::AddressInvalid(_)
                 | Self::DnsResolution { .. }
                 | Self::TcpConnect { .. }
@@ -274,6 +283,22 @@ mod tests {
                 .to_string()
                 .starts_with("Permission denied (publickey).")
         );
+    }
+
+    #[test]
+    fn authentication_exhaustion_lists_attempted_methods_and_remediation() {
+        let error = Error::AuthenticationExhausted {
+            methods: "publickey",
+            agent_status: "not available".to_string(),
+            password_status: "not available in non-interactive mode",
+        };
+
+        let rendered = error.to_string();
+        assert!(rendered.starts_with("Permission denied (publickey).\n"));
+        assert!(rendered.contains("bssh: SSH agent: not available"));
+        assert!(rendered.contains("bssh: Default SSH keys: not found or not authorized"));
+        assert!(rendered.contains("bssh: Password authentication: not available"));
+        assert!(error.is_ssh_client_failure());
     }
 
     #[test]

--- a/src/ssh/tokio_client/error.rs
+++ b/src/ssh/tokio_client/error.rs
@@ -8,18 +8,47 @@ use std::io;
 #[derive(thiserror::Error, Debug)]
 #[non_exhaustive]
 pub enum Error {
-    #[error("Keyboard-interactive authentication failed")]
+    #[error("Permission denied (keyboard-interactive).")]
     KeyboardInteractiveAuthFailed,
     #[error("No keyboard-interactive response for prompt: {0}")]
     KeyboardInteractiveNoResponseForPrompt(String),
-    #[error("Key authentication failed")]
+    #[error("Permission denied (publickey).")]
     KeyAuthFailed,
     #[error("Unable to load key, bad format or passphrase: {0}")]
     KeyInvalid(russh::keys::Error),
-    #[error("Password authentication failed")]
+    #[error("Permission denied (password).")]
     PasswordWrong,
     #[error("Invalid address was provided: {0}")]
     AddressInvalid(io::Error),
+    #[error("ssh: Could not resolve hostname {host}: {source}")]
+    DnsResolution {
+        host: String,
+        #[source]
+        source: io::Error,
+    },
+    #[error("ssh: connect to host {host} port {port}: {source}")]
+    TcpConnect {
+        host: String,
+        port: u16,
+        #[source]
+        source: io::Error,
+    },
+    #[error(
+        "ssh: connect to host {host} port {port}: Connection timed out\nbssh: timed out after {seconds} seconds during {stage}"
+    )]
+    ConnectionTimeout {
+        host: String,
+        port: u16,
+        seconds: u64,
+        stage: &'static str,
+    },
+    #[error("SSH protocol or version negotiation failed for {host} port {port}: {source}")]
+    ProtocolNegotiation {
+        host: String,
+        port: u16,
+        #[source]
+        source: russh::Error,
+    },
     #[error("ProxyCommand '{command}' contains unsupported token '{token}'")]
     InvalidProxyCommandToken { command: String, token: String },
     #[error("Failed to start ProxyCommand '{command}': {source}")]
@@ -45,9 +74,9 @@ pub enum Error {
     /// can tell a forced-family mismatch from a genuine resolution failure.
     #[error("no {family} address found for {host}")]
     NoAddressForFamily { host: String, family: AddressFamily },
-    #[error("The executed command didn't send an exit code")]
+    #[error("Remote command failed: server did not send an exit status")]
     CommandDidntExit,
-    #[error("Server check failed")]
+    #[error("Host key verification failed")]
     ServerCheckFailed,
     /// `port` is not interpolated into the `Display` text, but carrying it is
     /// what lets the client-facing messages name the actual known_hosts entry
@@ -74,11 +103,11 @@ pub enum Error {
         port: u16,
         line: usize,
     },
-    #[error("SSH error occurred: {0}")]
+    #[error("SSH protocol error: {0}")]
     SshError(#[from] russh::Error),
-    #[error("Send error")]
+    #[error("SSH channel send failed: {0}")]
     SendError(#[from] russh::SendError),
-    #[error("Agent auth error")]
+    #[error("SSH agent authentication error: {0}")]
     AgentAuthError(#[from] russh::AgentAuthError),
     #[error("Failed to connect to SSH agent")]
     AgentConnectionFailed,
@@ -86,12 +115,23 @@ pub enum Error {
     AgentRequestIdentitiesFailed,
     #[error("SSH agent has no identities")]
     AgentNoIdentities,
-    #[error("SSH agent authentication failed")]
+    #[error("Permission denied (publickey). SSH agent identities were rejected")]
     AgentAuthenticationFailed,
     #[error("SFTP error occurred: {0}")]
     SftpError(#[from] russh_sftp::client::error::Error),
-    #[error("I/O error")]
+    #[error("I/O operation failed: {0}")]
     IoError(#[from] io::Error),
+    #[error("SSH channel open failed: {source}")]
+    ChannelOpen {
+        #[source]
+        source: russh::Error,
+    },
+    #[error("Remote command execution failed during {action}: {source}")]
+    CommandExecution {
+        action: &'static str,
+        #[source]
+        source: russh::Error,
+    },
     #[error("Command validation failed: {0}")]
     CommandValidationFailed(String),
     #[error("Port forwarding request failed: {0}")]
@@ -104,4 +144,183 @@ pub enum Error {
     GlobalRequestFailed(String),
     #[error("Task join error: {0}")]
     JoinError(#[from] tokio::task::JoinError),
+}
+
+impl Error {
+    #[must_use]
+    pub fn is_ssh_client_failure(&self) -> bool {
+        matches!(
+            self,
+            Self::KeyboardInteractiveAuthFailed
+                | Self::KeyboardInteractiveNoResponseForPrompt(_)
+                | Self::KeyAuthFailed
+                | Self::KeyInvalid(_)
+                | Self::PasswordWrong
+                | Self::AddressInvalid(_)
+                | Self::DnsResolution { .. }
+                | Self::TcpConnect { .. }
+                | Self::ConnectionTimeout { .. }
+                | Self::ProtocolNegotiation { .. }
+                | Self::InvalidProxyCommandToken { .. }
+                | Self::ProxyCommandSpawn { .. }
+                | Self::ProxyCommandFailed { .. }
+                | Self::ProxyUseFdpassUnsupported { .. }
+                | Self::NoAddressForFamily { .. }
+                | Self::CommandDidntExit
+                | Self::ServerCheckFailed
+                | Self::HostKeyChanged { .. }
+                | Self::HostKeyRevoked { .. }
+                | Self::SshError(_)
+                | Self::SendError(_)
+                | Self::AgentAuthError(_)
+                | Self::AgentConnectionFailed
+                | Self::AgentRequestIdentitiesFailed
+                | Self::AgentNoIdentities
+                | Self::AgentAuthenticationFailed
+                | Self::SftpError(_)
+                | Self::IoError(_)
+                | Self::ChannelOpen { .. }
+                | Self::CommandExecution { .. }
+                | Self::PortForwardRequestFailed(_)
+                | Self::RemotePortForwardFailed(_)
+                | Self::PortForwardingNotSupported
+                | Self::GlobalRequestFailed(_)
+        )
+    }
+
+    /// Add connection-target context only to transport-level handshake errors.
+    /// Typed host-key and other client errors must remain intact for callers.
+    pub(super) fn during_protocol_negotiation(host: String, port: u16, source: Self) -> Self {
+        match source {
+            Self::SshError(source) => Self::ProtocolNegotiation { host, port, source },
+            source => source,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Error;
+    use std::io;
+
+    #[test]
+    fn io_backed_errors_name_the_layer_and_preserve_the_os_cause() {
+        let refused = Error::TcpConnect {
+            host: "127.0.0.1".to_string(),
+            port: 22,
+            source: io::Error::from_raw_os_error(libc::ECONNREFUSED),
+        };
+        let unreachable = Error::TcpConnect {
+            host: "192.0.2.1".to_string(),
+            port: 22,
+            source: io::Error::from_raw_os_error(libc::ENETUNREACH),
+        };
+        let dns = Error::DnsResolution {
+            host: "does-not-exist.invalid".to_string(),
+            source: io::Error::new(io::ErrorKind::NotFound, "Name or service not known"),
+        };
+
+        let refused = refused.to_string();
+        let unreachable = unreachable.to_string();
+        let dns = dns.to_string();
+
+        assert!(refused.contains("connect to host 127.0.0.1 port 22"));
+        assert!(refused.to_ascii_lowercase().contains("refused"));
+        assert!(refused.contains("os error"));
+        assert!(unreachable.to_ascii_lowercase().contains("unreachable"));
+        assert!(unreachable.contains("os error"));
+        assert!(dns.contains("Could not resolve hostname does-not-exist.invalid"));
+        assert!(dns.contains("Name or service not known"));
+    }
+
+    #[test]
+    fn connection_timeout_names_target_and_stage() {
+        let error = Error::ConnectionTimeout {
+            host: "host.example".to_string(),
+            port: 2222,
+            seconds: 7,
+            stage: "protocol negotiation",
+        };
+
+        let rendered = error.to_string();
+        let mut lines = rendered.lines();
+        assert_eq!(
+            lines.next(),
+            Some("ssh: connect to host host.example port 2222: Connection timed out")
+        );
+        assert_eq!(
+            lines.next(),
+            Some("bssh: timed out after 7 seconds during protocol negotiation")
+        );
+        assert!(error.is_ssh_client_failure());
+    }
+
+    #[test]
+    fn authentication_errors_name_the_refused_method() {
+        assert_eq!(
+            Error::KeyAuthFailed.to_string(),
+            "Permission denied (publickey)."
+        );
+        assert_eq!(
+            Error::PasswordWrong.to_string(),
+            "Permission denied (password)."
+        );
+        assert_eq!(
+            Error::KeyboardInteractiveAuthFailed.to_string(),
+            "Permission denied (keyboard-interactive)."
+        );
+        assert!(
+            Error::AgentAuthenticationFailed
+                .to_string()
+                .starts_with("Permission denied (publickey).")
+        );
+    }
+
+    #[test]
+    fn io_backed_error_variants_never_render_as_bare_io_error() {
+        let errors = vec![
+            Error::AddressInvalid(io::Error::new(io::ErrorKind::InvalidInput, "bad address")),
+            Error::DnsResolution {
+                host: "host.invalid".to_string(),
+                source: io::Error::new(io::ErrorKind::NotFound, "name lookup failed"),
+            },
+            Error::TcpConnect {
+                host: "host".to_string(),
+                port: 22,
+                source: io::Error::new(io::ErrorKind::ConnectionRefused, "connection refused"),
+            },
+            Error::ProxyCommandSpawn {
+                command: "proxy".to_string(),
+                source: io::Error::new(io::ErrorKind::NotFound, "executable not found"),
+            },
+            Error::SshError(russh::Error::IO(io::Error::new(
+                io::ErrorKind::BrokenPipe,
+                "transport closed",
+            ))),
+            Error::IoError(io::Error::new(io::ErrorKind::BrokenPipe, "pipe closed")),
+        ];
+
+        for error in errors {
+            let rendered = error.to_string();
+            assert_ne!(rendered, "I/O error");
+            assert_ne!(rendered, "IO error");
+            assert!(rendered.contains(": "), "missing cause in {rendered:?}");
+        }
+    }
+
+    #[test]
+    fn host_key_mismatch_is_distinct_from_other_client_failures() {
+        let rendered = Error::HostKeyChanged {
+            host: "host.example".to_string(),
+            port: 22,
+            line: 7,
+        }
+        .to_string();
+
+        assert!(rendered.contains("host.example"));
+        assert!(rendered.contains("has changed"));
+        assert!(rendered.contains("known_hosts entry at line 7"));
+        assert!(!rendered.contains("Permission denied"));
+        assert!(!rendered.contains("Could not resolve hostname"));
+    }
 }

--- a/tests/ssh_compat_output_test.rs
+++ b/tests/ssh_compat_output_test.rs
@@ -15,6 +15,16 @@ fn bssh() -> Command {
     Command::new(env!("CARGO_BIN_EXE_bssh"))
 }
 
+fn pre_auth_test_key(directory: &std::path::Path) -> std::path::PathBuf {
+    let key = directory.join("test-key");
+    fs::write(
+        &key,
+        "test key material; connection fails before key parsing",
+    )
+    .expect("test key should be written");
+    key
+}
+
 fn contains_ansi(bytes: &[u8]) -> bool {
     bytes.contains(&0x1b)
 }
@@ -117,8 +127,12 @@ fn deprecated_alias_is_silent_and_unknown_keyword_uses_log_file() {
 
 #[test]
 fn connection_refused_is_actionable_and_exits_255() {
+    let directory = tempdir().expect("temporary directory should be created");
+    let key = pre_auth_test_key(directory.path());
     let output = bssh()
         .args([
+            "-i",
+            key.to_str().expect("UTF-8 key path"),
             "--connect-timeout=1",
             "--strict-host-key-checking=no",
             "127.0.0.1:1",
@@ -127,10 +141,13 @@ fn connection_refused_is_actionable_and_exits_255() {
         .output()
         .expect("bssh should report a refused connection");
 
-    assert_eq!(output.status.code(), Some(255));
-    assert!(output.stdout.is_empty());
-
     let stderr = String::from_utf8_lossy(&output.stderr);
+    assert_eq!(
+        output.status.code(),
+        Some(255),
+        "unexpected SSH failure status; stderr: {stderr:?}"
+    );
+    assert!(output.stdout.is_empty());
     assert!(
         stderr.contains("ssh: connect to host 127.0.0.1 port 1:"),
         "missing OpenSSH-compatible connection context: {stderr:?}"
@@ -149,10 +166,13 @@ fn connection_refused_is_actionable_and_exits_255() {
 fn connection_error_uses_log_file_exactly_once() {
     let directory = tempdir().expect("temporary directory should be created");
     let log = directory.path().join("bssh.log");
+    let key = pre_auth_test_key(directory.path());
     let output = bssh()
         .args([
             "-E",
             log.to_str().expect("UTF-8 log path"),
+            "-i",
+            key.to_str().expect("UTF-8 key path"),
             "--connect-timeout=1",
             "--strict-host-key-checking=no",
             "127.0.0.1:1",
@@ -161,11 +181,14 @@ fn connection_error_uses_log_file_exactly_once() {
         .output()
         .expect("bssh should report a refused connection to the log file");
 
-    assert_eq!(output.status.code(), Some(255));
+    let diagnostics = fs::read_to_string(log).expect("diagnostic log should exist");
+    assert_eq!(
+        output.status.code(),
+        Some(255),
+        "unexpected SSH failure status; log: {diagnostics:?}"
+    );
     assert!(output.stdout.is_empty());
     assert!(output.stderr.is_empty());
-
-    let diagnostics = fs::read_to_string(log).expect("diagnostic log should exist");
     let matching_lines = diagnostics
         .lines()
         .filter(|line| line.contains("ssh: connect to host 127.0.0.1 port 1:"))
@@ -182,8 +205,12 @@ fn connection_error_uses_log_file_exactly_once() {
 
 #[test]
 fn dns_failure_is_distinct_and_exits_255() {
+    let directory = tempdir().expect("temporary directory should be created");
+    let key = pre_auth_test_key(directory.path());
     let output = bssh()
         .args([
+            "-i",
+            key.to_str().expect("UTF-8 key path"),
             "--connect-timeout=2",
             "--strict-host-key-checking=no",
             "does-not-exist.invalid",
@@ -192,16 +219,90 @@ fn dns_failure_is_distinct_and_exits_255() {
         .output()
         .expect("bssh should report a DNS failure");
 
-    assert_eq!(output.status.code(), Some(255));
-    assert!(output.stdout.is_empty());
-
     let stderr = String::from_utf8_lossy(&output.stderr);
+    assert_eq!(
+        output.status.code(),
+        Some(255),
+        "unexpected SSH failure status; stderr: {stderr:?}"
+    );
+    assert!(output.stdout.is_empty());
     assert!(
         stderr.contains("ssh: Could not resolve hostname does-not-exist.invalid:"),
         "missing DNS layer context: {stderr:?}"
     );
     assert!(!stderr.to_ascii_lowercase().contains("connect to host"));
     assert!(!stderr.lines().any(|line| line.trim() == "I/O error"));
+}
+
+#[test]
+fn keyless_authentication_exhaustion_is_actionable_and_exits_255() {
+    let directory = tempdir().expect("temporary directory should be created");
+    let output = bssh()
+        .args([
+            "--connect-timeout=1",
+            "--strict-host-key-checking=no",
+            "127.0.0.1:1",
+            "true",
+        ])
+        .env("HOME", directory.path())
+        .env_remove("SSH_AUTH_SOCK")
+        .output()
+        .expect("bssh should report authentication exhaustion");
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert_eq!(
+        output.status.code(),
+        Some(255),
+        "unexpected authentication status; stderr: {stderr:?}"
+    );
+    assert!(output.stdout.is_empty());
+    assert_eq!(
+        stderr.matches("Permission denied (publickey).").count(),
+        1,
+        "authentication diagnostic must be emitted once: {stderr:?}"
+    );
+    assert!(stderr.starts_with("Permission denied (publickey).\n"));
+    assert!(stderr.contains("bssh: SSH agent: not available"));
+    assert!(stderr.contains("bssh: Default SSH keys: not found or not authorized"));
+    assert!(stderr.contains("bssh: Password authentication: not available"));
+    assert!(!stderr.contains(" WARN "));
+}
+
+#[test]
+fn keyless_authentication_exhaustion_uses_log_file_exactly_once() {
+    let directory = tempdir().expect("temporary directory should be created");
+    let log = directory.path().join("bssh.log");
+    let output = bssh()
+        .args([
+            "-E",
+            log.to_str().expect("UTF-8 log path"),
+            "--connect-timeout=1",
+            "--strict-host-key-checking=no",
+            "127.0.0.1:1",
+            "true",
+        ])
+        .env("HOME", directory.path())
+        .env_remove("SSH_AUTH_SOCK")
+        .output()
+        .expect("bssh should route authentication exhaustion to the log");
+
+    let diagnostics = fs::read_to_string(log).expect("diagnostic log should exist");
+    assert_eq!(
+        output.status.code(),
+        Some(255),
+        "unexpected authentication status; log: {diagnostics:?}"
+    );
+    assert!(output.stdout.is_empty());
+    assert!(output.stderr.is_empty());
+    assert_eq!(
+        diagnostics
+            .matches("Permission denied (publickey).")
+            .count(),
+        1,
+        "authentication diagnostic must be logged once: {diagnostics:?}"
+    );
+    assert!(diagnostics.starts_with("Permission denied (publickey).\n"));
+    assert!(!diagnostics.contains(" WARN "));
 }
 
 #[test]

--- a/tests/ssh_compat_output_test.rs
+++ b/tests/ssh_compat_output_test.rs
@@ -114,3 +114,123 @@ fn deprecated_alias_is_silent_and_unknown_keyword_uses_log_file() {
     );
     assert!(!unknown.contains("bssh::"));
 }
+
+#[test]
+fn connection_refused_is_actionable_and_exits_255() {
+    let output = bssh()
+        .args([
+            "--connect-timeout=1",
+            "--strict-host-key-checking=no",
+            "127.0.0.1:1",
+            "true",
+        ])
+        .output()
+        .expect("bssh should report a refused connection");
+
+    assert_eq!(output.status.code(), Some(255));
+    assert!(output.stdout.is_empty());
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("ssh: connect to host 127.0.0.1 port 1:"),
+        "missing OpenSSH-compatible connection context: {stderr:?}"
+    );
+    assert!(
+        stderr.to_ascii_lowercase().contains("refused"),
+        "missing OS refusal cause: {stderr:?}"
+    );
+    assert!(
+        !stderr.lines().any(|line| line.trim() == "I/O error"),
+        "bare I/O error leaked: {stderr:?}"
+    );
+}
+
+#[test]
+fn connection_error_uses_log_file_exactly_once() {
+    let directory = tempdir().expect("temporary directory should be created");
+    let log = directory.path().join("bssh.log");
+    let output = bssh()
+        .args([
+            "-E",
+            log.to_str().expect("UTF-8 log path"),
+            "--connect-timeout=1",
+            "--strict-host-key-checking=no",
+            "127.0.0.1:1",
+            "true",
+        ])
+        .output()
+        .expect("bssh should report a refused connection to the log file");
+
+    assert_eq!(output.status.code(), Some(255));
+    assert!(output.stdout.is_empty());
+    assert!(output.stderr.is_empty());
+
+    let diagnostics = fs::read_to_string(log).expect("diagnostic log should exist");
+    let matching_lines = diagnostics
+        .lines()
+        .filter(|line| line.contains("ssh: connect to host 127.0.0.1 port 1:"))
+        .collect::<Vec<_>>();
+    assert_eq!(
+        matching_lines.len(),
+        1,
+        "diagnostic must be emitted once: {diagnostics:?}"
+    );
+    assert!(matching_lines[0].to_ascii_lowercase().contains("refused"));
+    assert!(matching_lines[0].contains("os error"));
+    assert!(!matching_lines[0].contains(" ERROR "));
+}
+
+#[test]
+fn dns_failure_is_distinct_and_exits_255() {
+    let output = bssh()
+        .args([
+            "--connect-timeout=2",
+            "--strict-host-key-checking=no",
+            "does-not-exist.invalid",
+            "true",
+        ])
+        .output()
+        .expect("bssh should report a DNS failure");
+
+    assert_eq!(output.status.code(), Some(255));
+    assert!(output.stdout.is_empty());
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("ssh: Could not resolve hostname does-not-exist.invalid:"),
+        "missing DNS layer context: {stderr:?}"
+    );
+    assert!(!stderr.to_ascii_lowercase().contains("connect to host"));
+    assert!(!stderr.lines().any(|line| line.trim() == "I/O error"));
+}
+
+#[test]
+fn cli_usage_error_keeps_clap_exit_status() {
+    let output = bssh()
+        .arg("--definitely-invalid-option")
+        .output()
+        .expect("bssh should report an invalid CLI option");
+
+    assert_eq!(output.status.code(), Some(2));
+    assert!(output.stdout.is_empty());
+    assert!(String::from_utf8_lossy(&output.stderr).contains("unexpected argument"));
+}
+
+#[test]
+fn local_config_error_keeps_generic_exit_status() {
+    let directory = tempdir().expect("temporary directory should be created");
+    let config = directory.path().join("missing_config");
+    let output = bssh()
+        .args([
+            "-F",
+            config.to_str().expect("UTF-8 config path"),
+            "127.0.0.1",
+            "true",
+        ])
+        .output()
+        .expect("bssh should report a missing local config file");
+
+    assert_eq!(output.status.code(), Some(1));
+    assert!(output.stdout.is_empty());
+    assert!(String::from_utf8_lossy(&output.stderr).contains("Failed to load SSH config"));
+}


### PR DESCRIPTION
## Summary

- Replace opaque SSH I/O failures with typed DNS, TCP, negotiation, host-key, authentication, channel, command, and stage-aware timeout diagnostics that preserve underlying causes.
- Preserve typed failures through raw streaming so single-destination SSH client failures exit 255 and write one diagnostic to stderr or `-E`, while remote statuses and existing local or multi-host semantics remain unchanged.
- Add focused unit and end-to-end coverage for refused connections, DNS failures, OS causes, timeout context, authentication wording, output routing, Clap usage, local configuration errors, and exit-code behavior.

## Validation

- `cargo test --lib ssh::auth::tests`
- `cargo test --lib ssh::tokio_client::error::tests`
- `cargo test --lib commands::exec::tests`
- `cargo test --test ssh_compat_output_test`
- `cargo test --lib ssh::client::connection::tests::test_connect_error`
- `cargo test --lib ssh::client::file_transfer::tests`
- `cargo check --lib --tests`
- `cargo clippy --lib --tests -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

Closes #284

