### PR TITLE
feat: add SSH config runtime foundation (#295)

### DIFF
--- a/src/app/initialization.rs
+++ b/src/app/initialization.rs
@@ -186,7 +186,7 @@ pub async fn initialize_app(cli: &mut Cli, args: &[String]) -> Result<AppContext
     let config = Config::load_with_priority(&cli.config).await?;
 
     // Load SSH configuration with caching for improved performance
-    let ssh_config = if let Some(ref ssh_config_path) = cli.ssh_config {
+    let mut ssh_config = if let Some(ref ssh_config_path) = cli.ssh_config {
         SshConfig::load_from_file_cached(ssh_config_path)
             .await
             .with_context(|| format!("Failed to load SSH config from {ssh_config_path:?}"))?
@@ -196,6 +196,10 @@ pub async fn initialize_app(cli: &mut Cli, args: &[String]) -> Result<AppContext
             SshConfig::new()
         })
     };
+    let ssh_config_overrides = cli.ssh_config_overrides();
+    ssh_config
+        .apply_cli_options(&ssh_config_overrides)
+        .context("Failed to apply command-line SSH options")?;
 
     // Determine nodes to execute on
     let (nodes, actual_cluster_name) =

--- a/src/cli/bssh.rs
+++ b/src/cli/bssh.rs
@@ -267,6 +267,22 @@ pub struct Cli {
     pub ssh_options: Vec<String>,
 
     #[arg(
+        short = 'c',
+        long = "cipher",
+        value_name = "cipher_spec",
+        help = "Select SSH transport ciphers (OpenSSH-compatible -c)"
+    )]
+    pub cipher: Option<String>,
+
+    #[arg(
+        short = 'm',
+        long = "macs",
+        value_name = "mac_spec",
+        help = "Select SSH MAC algorithms (OpenSSH-compatible -m)"
+    )]
+    pub macs: Option<String>,
+
+    #[arg(
         short = 'F',
         long = "ssh-config",
         value_name = "configfile",
@@ -613,6 +629,26 @@ impl Cli {
         })
     }
 
+    /// Build parser-ready command-line ssh_config overrides.
+    ///
+    /// Dedicated OpenSSH flags have explicit precedence over generic `-o`
+    /// forms. Within repeated `-o` options, the parser keeps the first value.
+    pub fn ssh_config_overrides(&self) -> Vec<String> {
+        let mut options = Vec::with_capacity(
+            self.ssh_options.len()
+                + usize::from(self.cipher.is_some())
+                + usize::from(self.macs.is_some()),
+        );
+        if let Some(cipher) = &self.cipher {
+            options.push(format!("Ciphers={cipher}"));
+        }
+        if let Some(macs) = &self.macs {
+            options.push(format!("MACs={macs}"));
+        }
+        options.extend(self.ssh_options.iter().cloned());
+        options
+    }
+
     /// Parse port forwarding specifications into ForwardingType instances
     ///
     /// Returns a Result containing a vector of all parsed forwarding specifications
@@ -686,5 +722,64 @@ mod tests {
             cli.get_ssh_option("HostKeyAlias").as_deref(),
             Some("first.example.com")
         );
+    }
+
+    #[test]
+    fn openssh_cipher_and_mac_flags_become_high_precedence_config_overrides() {
+        let cli = Cli::try_parse_from([
+            "bssh",
+            "-c",
+            "aes128-ctr",
+            "-m",
+            "hmac-sha2-256",
+            "-o",
+            "Ciphers=aes256-ctr",
+            "target",
+        ])
+        .unwrap();
+
+        assert_eq!(
+            cli.ssh_config_overrides(),
+            [
+                "Ciphers=aes128-ctr",
+                "MACs=hmac-sha2-256",
+                "Ciphers=aes256-ctr"
+            ]
+        );
+    }
+    #[test]
+    fn openssh_cipher_flag_rejects_unsupported_and_empty_policies() {
+        for value in ["not-a-supported-cipher", ""] {
+            let cli = Cli::try_parse_from(["bssh", "-c", value, "target"]).unwrap();
+            let error = crate::ssh::SshConfig::new()
+                .apply_cli_options(&cli.ssh_config_overrides())
+                .expect_err("invalid -c policy must fail closed");
+            let message = format!("{error:#}").to_ascii_lowercase();
+            assert!(
+                message.contains("cipher")
+                    && (message.contains("unsupported")
+                        || message.contains("at least one valid cipher")
+                        || message.contains("requires a value")),
+                "unexpected -c error: {message}"
+            );
+        }
+    }
+
+    #[test]
+    fn openssh_mac_flag_rejects_unsupported_and_empty_policies() {
+        for value in ["not-a-supported-mac", ""] {
+            let cli = Cli::try_parse_from(["bssh", "-m", value, "target"]).unwrap();
+            let error = crate::ssh::SshConfig::new()
+                .apply_cli_options(&cli.ssh_config_overrides())
+                .expect_err("invalid -m policy must fail closed");
+            let message = format!("{error:#}").to_ascii_lowercase();
+            assert!(
+                message.contains("mac")
+                    && (message.contains("unsupported")
+                        || message.contains("at least one valid mac")
+                        || message.contains("requires a value")),
+                "unexpected -m error: {message}"
+            );
+        }
     }
 }

--- a/src/cli/pdsh.rs
+++ b/src/cli/pdsh.rs
@@ -316,6 +316,8 @@ impl PdshCli {
             require_all_success: false,
             check_all_nodes: false,
             ssh_options: Vec::new(),
+            cipher: None,
+            macs: None,
             ssh_config: None,
             quiet: false,
             force_tty: false,

--- a/src/jump/chain/tunnel.rs
+++ b/src/jump/chain/tunnel.rs
@@ -163,6 +163,7 @@ pub(super) async fn connect_through_tunnel(
     );
 
     let handler = ClientHandler::new(jump_host.host.clone(), socket_addr, check_method);
+    let fatal_transport = handler.fatal_transport_state();
 
     // Connect through the stream
     let handle = tokio::time::timeout(
@@ -198,6 +199,12 @@ pub(super) async fn connect_through_tunnel(
         &host_desc,
     )
     .await
+    .or_else(|error| {
+        fatal_transport
+            .take_error()
+            .map(anyhow::Error::new)
+            .map_or(Err(error), Err)
+    })
     .with_context(|| {
         format!(
             "Failed to authenticate to {} as user '{}'",
@@ -207,8 +214,12 @@ pub(super) async fn connect_through_tunnel(
     })?;
 
     // Create our Client wrapper
-    let client =
-        Client::from_handle_and_address(Arc::new(handle), jump_host.effective_user(), socket_addr);
+    let client = Client::from_handle_and_address_with_state(
+        Arc::new(handle),
+        jump_host.effective_user(),
+        socket_addr,
+        fatal_transport,
+    );
 
     Ok(client)
 }
@@ -285,6 +296,7 @@ pub(super) async fn connect_to_destination(
     })?;
 
     let handler = ClientHandler::new(destination_host.to_string(), socket_addr, check_method);
+    let fatal_transport = handler.fatal_transport_state();
 
     // Connect through the stream
     let handle = tokio::time::timeout(
@@ -309,6 +321,12 @@ pub(super) async fn connect_to_destination(
     let dest_desc = format!("destination '{}:{}'", destination_host, destination_port);
     authenticate_connection(&mut handle, destination_user, dest_auth_method, &dest_desc)
         .await
+        .or_else(|error| {
+            fatal_transport
+                .take_error()
+                .map(anyhow::Error::new)
+                .map_or(Err(error), Err)
+        })
         .with_context(|| {
             format!(
                 "Failed to authenticate to {} as user '{}'",
@@ -317,10 +335,11 @@ pub(super) async fn connect_to_destination(
         })?;
 
     // Create our Client wrapper
-    let client = Client::from_handle_and_address(
+    let client = Client::from_handle_and_address_with_state(
         Arc::new(handle),
         destination_user.to_string(),
         socket_addr,
+        fatal_transport,
     );
 
     Ok(client)

--- a/src/ssh/ssh_config/include/mod.rs
+++ b/src/ssh/ssh_config/include/mod.rs
@@ -148,12 +148,12 @@ impl IncludeContext {
 #[derive(Debug, Clone)]
 pub struct IncludedFile {
     /// Path to the file
+    #[cfg_attr(not(test), allow(dead_code))]
     pub path: PathBuf,
     /// File content
     pub content: String,
-    /// Line offset in the combined configuration
-    #[allow(dead_code)]
-    pub line_offset: usize,
+    /// One-based line number of the first content line in the source file.
+    pub source_line_start: usize,
 }
 
 /// Resolve Include directives and collect all configuration files
@@ -188,6 +188,7 @@ async fn process_file_with_includes(
 ) -> Result<Vec<IncludedFile>> {
     let mut result = Vec::new();
     let mut current_content = String::new();
+    let mut current_source_line = 1;
 
     for (line_number, line) in content.lines().enumerate() {
         let line_number = line_number + 1; // 1-indexed for error messages
@@ -197,17 +198,14 @@ async fn process_file_with_includes(
         if let Some(patterns) = parse_include_line(trimmed) {
             // Save current accumulated content as an IncludedFile (if not empty)
             if !current_content.is_empty() {
-                let line_offset: usize = result
-                    .iter()
-                    .map(|f: &IncludedFile| f.content.lines().count())
-                    .sum();
                 result.push(IncludedFile {
                     path: file_path.to_path_buf(),
                     content: current_content.clone(),
-                    line_offset,
+                    source_line_start: current_source_line,
                 });
                 current_content.clear();
             }
+            current_source_line = line_number + 1;
 
             // Process each Include pattern
             for pattern in patterns {
@@ -264,14 +262,10 @@ async fn process_file_with_includes(
 
     // Add any remaining content as the final IncludedFile
     if !current_content.is_empty() {
-        let line_offset: usize = result
-            .iter()
-            .map(|f: &IncludedFile| f.content.lines().count())
-            .sum();
         result.push(IncludedFile {
             path: file_path.to_path_buf(),
             content: current_content,
-            line_offset,
+            source_line_start: current_source_line,
         });
     }
 
@@ -280,7 +274,7 @@ async fn process_file_with_includes(
         result.push(IncludedFile {
             path: file_path.to_path_buf(),
             content: content.to_string(),
-            line_offset: 0,
+            source_line_start: 1,
         });
     }
 
@@ -288,6 +282,7 @@ async fn process_file_with_includes(
 }
 
 /// Combine multiple included files into a single configuration string
+#[cfg(test)]
 pub fn combine_included_files(files: &[IncludedFile]) -> String {
     let mut combined = String::new();
 

--- a/src/ssh/ssh_config/integration_tests/certificate_forwarding_integration_test.rs
+++ b/src/ssh/ssh_config/integration_tests/certificate_forwarding_integration_test.rs
@@ -325,7 +325,7 @@ Host web1.prod.example.com
         // Should combine all layers:
         // - Default cert from deep.conf
         // - CA algorithms from middle.conf
-        // - Hostbased auth overridden to yes in middle.conf
+        // - Hostbased auth first obtained as no in deep.conf
         // - Gateway ports from middle.conf
         // - Exit on forward failure from Match block
         // - Permit remote open from Match block
@@ -337,7 +337,7 @@ Host web1.prod.example.com
                 .contains("default-cert.pub")
         );
         assert_eq!(resolved.ca_signature_algorithms.len(), 2);
-        assert_eq!(resolved.hostbased_authentication, Some(true)); // Overridden
+        assert_eq!(resolved.hostbased_authentication, Some(false));
         assert_eq!(resolved.gateway_ports, Some("clientspecified".to_string()));
         assert_eq!(resolved.exit_on_forward_failure, Some(true));
         assert_eq!(resolved.permit_remote_open.len(), 2);
@@ -395,8 +395,8 @@ Host web.secure.prod.example.com
         assert_eq!(resolved.ca_signature_algorithms.len(), 3);
         assert_eq!(resolved.ca_signature_algorithms[0], "ssh-ed25519");
 
-        // HostbasedAuthentication: yes from *.prod.example.com
-        assert_eq!(resolved.hostbased_authentication, Some(true));
+        // HostbasedAuthentication: first obtained as no from Host *
+        assert_eq!(resolved.hostbased_authentication, Some(false));
 
         // HostbasedAcceptedAlgorithms: from *.prod.example.com
         assert_eq!(resolved.hostbased_accepted_algorithms.len(), 2);
@@ -404,8 +404,8 @@ Host web.secure.prod.example.com
         // GatewayPorts: from Match block
         assert_eq!(resolved.gateway_ports, Some("clientspecified".to_string()));
 
-        // ExitOnForwardFailure: yes from Match block (overrides global no)
-        assert_eq!(resolved.exit_on_forward_failure, Some(true));
+        // ExitOnForwardFailure: first obtained as no from Host *
+        assert_eq!(resolved.exit_on_forward_failure, Some(false));
 
         // PermitRemoteOpen: from Match (3) + specific Host (1) = 4 total
         assert_eq!(resolved.permit_remote_open.len(), 4);

--- a/src/ssh/ssh_config/mod.rs
+++ b/src/ssh/ssh_config/mod.rs
@@ -102,6 +102,18 @@ impl SshConfig {
         Ok(Self { hosts })
     }
 
+    /// Prepend command-line `-o` options as a structured `Host *` block.
+    ///
+    /// The resolver visits this block before configuration-file blocks, so
+    /// accepted command-line options have CLI precedence without bypassing
+    /// the parser's validation or first-obtained merge rules.
+    pub fn apply_cli_options(&mut self, options: &[String]) -> Result<()> {
+        if let Some(overlay) = parser::parse_cli_options(options)? {
+            self.hosts.insert(0, overlay);
+        }
+        Ok(())
+    }
+
     /// Parse SSH configuration from a file with Include support
     pub async fn parse_from_file_with_content(path: &Path, content: &str) -> Result<Self> {
         let hosts = parser::parse_from_file(path, content).await?;
@@ -334,7 +346,7 @@ Host db*.example.com
     }
 
     #[test]
-    fn test_find_host_config() {
+    fn test_find_host_config_uses_source_order_first_obtained_values() {
         let config_content = r#"
 Host *.example.com
     User defaultuser
@@ -350,19 +362,67 @@ Host web1.example.com
 
         let config = SshConfig::parse(config_content).unwrap();
 
-        // Test that most specific match wins
+        // Every matching block is visited in source order. The broad first
+        // block obtains both scalar slots before later, narrower blocks.
         let host_config = config.find_host_config("web1.example.com");
-        assert_eq!(host_config.user, Some("webuser".to_string())); // From web*.example.com
-        assert_eq!(host_config.port, Some(9090)); // From web1.example.com (most specific)
+        assert_eq!(host_config.user, Some("defaultuser".to_string()));
+        assert_eq!(host_config.port, Some(22));
 
-        // Test that patterns are applied in order
+        // A second web host gets the same first-obtained scalar defaults.
         let host_config = config.find_host_config("web2.example.com");
-        assert_eq!(host_config.user, Some("webuser".to_string())); // From web*.example.com
-        assert_eq!(host_config.port, Some(8080)); // From web*.example.com
+        assert_eq!(host_config.user, Some("defaultuser".to_string()));
+        assert_eq!(host_config.port, Some(22));
 
         let host_config = config.find_host_config("db1.example.com");
         assert_eq!(host_config.user, Some("defaultuser".to_string())); // From *.example.com
         assert_eq!(host_config.port, Some(22)); // From *.example.com
+    }
+
+    #[test]
+    fn cli_option_overlay_precedes_files_and_repeated_scalars_keep_first_value() {
+        let mut config = SshConfig::parse(
+            "Host *\n    User file-user\n    Port 22\n    ConnectionAttempts 1\n    TCPKeepAlive yes\n",
+        )
+        .unwrap();
+        config
+            .apply_cli_options(&[
+                "User=cli-first".to_string(),
+                "User=cli-later".to_string(),
+                "Port=2200".to_string(),
+                "ConnectionAttempts=3".to_string(),
+                "TCPKeepAlive=no".to_string(),
+                "Ciphers=aes128-ctr".to_string(),
+                "PubkeyAcceptedAlgorithms=rsa-sha2-*".to_string(),
+            ])
+            .unwrap();
+
+        let effective = config.find_host_config("target");
+        assert_eq!(effective.user.as_deref(), Some("cli-first"));
+        assert_eq!(effective.port, Some(2200));
+        assert_eq!(effective.connection_attempts, Some(3));
+        assert_eq!(effective.tcp_keep_alive, Some(false));
+        assert_eq!(
+            effective.resolved_ciphers.unwrap()[0].as_ref(),
+            "aes128-ctr"
+        );
+        assert_eq!(
+            effective.resolved_pubkey_accepted_algorithms.unwrap(),
+            [
+                "rsa-sha2-512-cert-v01@openssh.com",
+                "rsa-sha2-512",
+                "rsa-sha2-256-cert-v01@openssh.com",
+                "rsa-sha2-256"
+            ]
+        );
+    }
+
+    #[test]
+    fn cli_option_overlay_rejects_multiline_injection() {
+        let mut config = SshConfig::new();
+        let error = config
+            .apply_cli_options(&["User=alice\nProxyCommand=evil".to_string()])
+            .unwrap_err();
+        assert!(error.to_string().contains("single configuration line"));
     }
 
     #[test]
@@ -461,16 +521,15 @@ Host web1.example.com
         // Test merging for web1.example.com (should get configs from all three blocks)
         let host_config = config.find_host_config("web1.example.com");
 
-        // Should have certificate files from both *.example.com and web*.example.com (appended)
+        // CertificateFile is explicitly additive in ssh_config(5).
         assert_eq!(host_config.certificate_files.len(), 2);
 
-        // CASignatureAlgorithms should be from web1.example.com (most specific)
-        assert_eq!(host_config.ca_signature_algorithms.len(), 2);
-        assert_eq!(host_config.ca_signature_algorithms[0], "rsa-sha2-512");
-        assert_eq!(host_config.ca_signature_algorithms[1], "rsa-sha2-256");
+        // Replacement lists and scalars use their first obtained value.
+        assert_eq!(host_config.ca_signature_algorithms.len(), 1);
+        assert_eq!(host_config.ca_signature_algorithms[0], "ssh-ed25519");
 
-        // GatewayPorts should be from web*.example.com
-        assert_eq!(host_config.gateway_ports, Some("yes".to_string()));
+        // GatewayPorts was already obtained from the broad first block.
+        assert_eq!(host_config.gateway_ports, Some("no".to_string()));
 
         // ExitOnForwardFailure should be from web1.example.com
         assert_eq!(host_config.exit_on_forward_failure, Some(true));
@@ -648,8 +707,8 @@ Host web1.example.com
             Some("shared.example.com".to_string())
         );
 
-        // NumberOfPasswordPrompts should be from web1.example.com (most specific)
-        assert_eq!(host_config.number_of_password_prompts, Some(1));
+        // NumberOfPasswordPrompts keeps the first value obtained from Host *.
+        assert_eq!(host_config.number_of_password_prompts, Some(3));
 
         // EnableSSHKeysign should be from *.example.com
         assert_eq!(host_config.enable_ssh_keysign, Some(true));
@@ -666,8 +725,8 @@ Host web1.example.com
         // ForwardX11Timeout should be from *.example.com
         assert_eq!(host_config.forward_x11_timeout, Some("30m".to_string()));
 
-        // ForwardX11Trusted should be from web1.example.com (most specific)
-        assert_eq!(host_config.forward_x11_trusted, Some(true));
+        // ForwardX11Trusted keeps the first value obtained from Host *.
+        assert_eq!(host_config.forward_x11_trusted, Some(false));
     }
 
     #[test]

--- a/src/ssh/ssh_config/parser/core.rs
+++ b/src/ssh/ssh_config/parser/core.rs
@@ -17,10 +17,12 @@
 //! This module contains the main parsing logic for SSH configurations,
 //! including the 2-pass parsing strategy for Include and Match directives.
 
-use crate::ssh::ssh_config::include::{combine_included_files, resolve_includes};
+use crate::ssh::ssh_config::include::{IncludedFile, resolve_includes};
 use crate::ssh::ssh_config::match_directive::{MatchBlock, MatchCondition};
+use crate::ssh::ssh_config::resolver::merge_host_config;
 use crate::ssh::ssh_config::types::{ConfigBlock, SshHostConfig};
 use anyhow::{Context, Result};
+use std::collections::HashSet;
 use std::path::Path;
 
 use super::options;
@@ -38,16 +40,82 @@ pub async fn parse_from_file(path: &Path, content: &str) -> Result<Vec<SshHostCo
     let included_files = resolve_includes(path, content)
         .await
         .with_context(|| format!("Failed to resolve includes for {}", path.display()))?;
-
-    // Combine all included files into a single configuration
-    let combined_content = combine_included_files(&included_files);
-
-    // Pass 2: Parse the combined configuration
-    parse_without_includes(&combined_content)
+    parse_included_files(&included_files)
 }
 
 /// Parse SSH configuration content without Include resolution
 pub(super) fn parse_without_includes(content: &str) -> Result<Vec<SshHostConfig>> {
+    parse_lines(
+        content
+            .lines()
+            .enumerate()
+            .map(|(index, line)| (None, index + 1, line)),
+    )
+}
+
+/// Parse raw `-o Key=Value` arguments into a leading `Host *` overlay.
+///
+/// Keeping the overlay as a structured block lets the ordinary resolver apply
+/// OpenSSH's first-obtained rule: CLI options are visited before file blocks,
+/// while repeated `-o` scalars retain the first CLI value.
+pub(crate) fn parse_cli_options(options: &[String]) -> Result<Option<SshHostConfig>> {
+    const MAX_LINE_LENGTH: usize = 8192;
+    const MAX_VALUE_LENGTH: usize = 4096;
+
+    if options.is_empty() {
+        return Ok(None);
+    }
+
+    let mut overlay = SshHostConfig {
+        host_patterns: vec!["*".to_string()],
+        block_type: Some(ConfigBlock::Host(vec!["*".to_string()])),
+        ..Default::default()
+    };
+    let mut reported_diagnostics = HashSet::new();
+
+    for (index, option) in options.iter().enumerate() {
+        let option_number = index + 1;
+        if option.contains(['\r', '\n']) {
+            anyhow::bail!("-o option #{option_number} must be a single configuration line");
+        }
+        if option.len() > MAX_LINE_LENGTH {
+            anyhow::bail!("-o option #{option_number} exceeds {MAX_LINE_LENGTH} bytes");
+        }
+
+        let (keyword, args) = parse_config_line(option, option_number, MAX_VALUE_LENGTH)
+            .with_context(|| format!("Invalid -o option #{option_number}"))?;
+        if keyword.is_empty() {
+            anyhow::bail!("-o option #{option_number} has no keyword");
+        }
+        parse_option_first(
+            &mut overlay,
+            &keyword,
+            &args,
+            None,
+            option_number,
+            &mut reported_diagnostics,
+        )
+        .with_context(|| format!("Invalid -o option #{option_number} ({keyword})"))?;
+    }
+
+    Ok(Some(overlay))
+}
+
+fn parse_included_files(files: &[IncludedFile]) -> Result<Vec<SshHostConfig>> {
+    parse_lines(files.iter().flat_map(|file| {
+        file.content.lines().enumerate().map(move |(index, line)| {
+            (
+                Some(file.path.as_path()),
+                file.source_line_start + index,
+                line,
+            )
+        })
+    }))
+}
+
+fn parse_lines<'a>(
+    lines: impl IntoIterator<Item = (Option<&'a Path>, usize, &'a str)>,
+) -> Result<Vec<SshHostConfig>> {
     // Security: Set reasonable limits to prevent DoS attacks
     const MAX_LINE_LENGTH: usize = 8192; // 8KB per line should be more than enough
     const MAX_VALUE_LENGTH: usize = 4096; // 4KB for individual values
@@ -55,17 +123,10 @@ pub(super) fn parse_without_includes(content: &str) -> Result<Vec<SshHostConfig>
     let mut configs = Vec::new();
     let mut current_config: Option<SshHostConfig> = None;
     let mut current_match: Option<MatchBlock> = None;
-    let mut line_number = 0;
     let mut in_match_block = false;
+    let mut reported_diagnostics = HashSet::new();
 
-    for line in content.lines() {
-        line_number += 1;
-
-        // Skip source file comments added by include resolution
-        if line.starts_with("# Source:") {
-            continue;
-        }
-
+    for (source_path, line_number, line) in lines {
         // Security: Check line length to prevent DoS
         if line.len() > MAX_LINE_LENGTH {
             anyhow::bail!("Line {line_number} exceeds maximum length of {MAX_LINE_LENGTH} bytes");
@@ -165,20 +226,45 @@ pub(super) fn parse_without_includes(content: &str) -> Result<Vec<SshHostConfig>
         // Apply option to current config block
         if in_match_block {
             if let Some(ref mut match_block) = current_match {
-                options::parse_option(&mut match_block.config, &keyword, &args, line_number)
-                    .with_context(|| format!("Error at line {line_number}: {line}"))?;
+                parse_option_first(
+                    &mut match_block.config,
+                    &keyword,
+                    &args,
+                    source_path,
+                    line_number,
+                    &mut reported_diagnostics,
+                )
+                .with_context(|| format!("Error at line {line_number}: {line}"))?;
             }
         } else if let Some(ref mut config) = current_config {
-            options::parse_option(config, &keyword, &args, line_number)
-                .with_context(|| format!("Error at line {line_number}: {line}"))?;
+            parse_option_first(
+                config,
+                &keyword,
+                &args,
+                source_path,
+                line_number,
+                &mut reported_diagnostics,
+            )
+            .with_context(|| format!("Error at line {line_number}: {line}"))?;
         } else {
-            // Global option outside any block
-            // In OpenSSH, these set defaults but we're ignoring them for now
-            tracing::debug!(
-                "Ignoring global option '{}' at line {}",
-                keyword,
-                line_number
-            );
+            // OpenSSH treats options before the first Host/Match directive as
+            // global defaults. Model that region as the first `Host *` block
+            // so the resolver's first-obtained merge semantics apply without
+            // losing the original directive order.
+            let config = current_config.get_or_insert_with(|| SshHostConfig {
+                host_patterns: vec!["*".to_string()],
+                block_type: Some(ConfigBlock::Host(vec!["*".to_string()])),
+                ..Default::default()
+            });
+            parse_option_first(
+                config,
+                &keyword,
+                &args,
+                source_path,
+                line_number,
+                &mut reported_diagnostics,
+            )
+            .with_context(|| format!("Error at line {line_number}: {line}"))?;
         }
     }
 
@@ -191,6 +277,31 @@ pub(super) fn parse_without_includes(content: &str) -> Result<Vec<SshHostConfig>
     }
 
     Ok(configs)
+}
+
+/// Parse one directive independently, then merge it into its surrounding
+/// Host/Match block. This preserves OpenSSH's first-obtained rule even for
+/// repeated directives separated by Include file boundaries, while additive
+/// options continue to accumulate through the shared resolver merge logic.
+fn parse_option_first(
+    target: &mut SshHostConfig,
+    keyword: &str,
+    args: &[String],
+    source_path: Option<&Path>,
+    line_number: usize,
+    reported_diagnostics: &mut HashSet<String>,
+) -> Result<()> {
+    let mut parsed = SshHostConfig::default();
+    options::parse_option(
+        &mut parsed,
+        keyword,
+        args,
+        source_path,
+        line_number,
+        reported_diagnostics,
+    )?;
+    merge_host_config(target, &parsed);
+    Ok(())
 }
 
 /// Parse a Host directive line

--- a/src/ssh/ssh_config/parser/mod.rs
+++ b/src/ssh/ssh_config/parser/mod.rs
@@ -28,7 +28,7 @@ mod options;
 mod tests;
 
 // Re-export public items from core module
-pub(super) use core::{parse, parse_from_file};
+pub(super) use core::{parse, parse_cli_options, parse_from_file};
 
 // Re-export helper functions that might be used elsewhere
 

--- a/src/ssh/ssh_config/parser/options/authentication.rs
+++ b/src/ssh/ssh_config/parser/options/authentication.rs
@@ -148,6 +148,9 @@ pub(super) fn parse_authentication_option(
                             || c == '_'
                             || c == '@'
                             || c == '+'
+                            || c == '^'
+                            || c == '*'
+                            || c == '?'
                     }) {
                         anyhow::bail!(
                             "PubkeyAcceptedAlgorithms at line {line_number} contains invalid characters in algorithm name '{trimmed}'. \
@@ -179,6 +182,10 @@ pub(super) fn parse_authentication_option(
                 );
             }
 
+            let resolved =
+                crate::ssh::tokio_client::algorithms::resolve_pubkey_algorithms(&algorithms)
+                    .map_err(anyhow::Error::msg)?;
+            host.resolved_pubkey_accepted_algorithms = Some(resolved);
             host.pubkey_accepted_algorithms = algorithms;
         }
         "certificatefile" => {

--- a/src/ssh/ssh_config/parser/options/connection.rs
+++ b/src/ssh/ssh_config/parser/options/connection.rs
@@ -75,6 +75,9 @@ pub(super) fn parse_connection_option(
                     args[0], line_number
                 )
             })?;
+            if attempts == 0 {
+                anyhow::bail!("ConnectionAttempts must be at least 1 at line {line_number}");
+            }
             host.connection_attempts = Some(attempts);
         }
         "batchmode" => {

--- a/src/ssh/ssh_config/parser/options/environment.rs
+++ b/src/ssh/ssh_config/parser/options/environment.rs
@@ -52,7 +52,7 @@ pub(super) fn parse_environment_option(
                 if let Some(eq_pos) = pair.find('=') {
                     let name = pair[..eq_pos].to_string();
                     let value = pair[eq_pos + 1..].to_string();
-                    host.set_env.insert(name, value);
+                    host.set_env.entry(name).or_insert(value);
                 } else {
                     anyhow::bail!(
                         "Invalid SetEnv format '{pair}' at line {line_number} (expected name=value)"

--- a/src/ssh/ssh_config/parser/options/mod.rs
+++ b/src/ssh/ssh_config/parser/options/mod.rs
@@ -26,10 +26,12 @@ mod environment;
 mod forwarding;
 mod proxy;
 mod security;
+mod support;
 mod ui;
 
 use crate::ssh::ssh_config::types::SshHostConfig;
 use anyhow::Result;
+use std::{collections::HashSet, path::Path};
 
 /// Parse a configuration option for a host
 ///
@@ -37,10 +39,47 @@ use anyhow::Result;
 /// category-specific parser based on the keyword.
 pub fn parse_option(
     host: &mut SshHostConfig,
-    keyword: &str,
+    accepted_keyword: &str,
     args: &[String],
+    source_path: Option<&Path>,
     line_number: usize,
+    reported_diagnostics: &mut HashSet<String>,
 ) -> Result<()> {
+    let Some(spec) = support::keyword_spec(accepted_keyword) else {
+        if reported_diagnostics.insert(format!("unknown:{accepted_keyword}")) {
+            let location = source_path.map_or_else(
+                || format!("line {line_number}"),
+                |path| format!("{}:{line_number}", path.display()),
+            );
+            crate::diagnosticln!("Unknown SSH config option '{accepted_keyword}' at {location}");
+        }
+        return Ok(());
+    };
+    let keyword = spec.canonical;
+
+    let tracking_issue = match spec.support {
+        support::KeywordSupport::Runtime(_) => None,
+        support::KeywordSupport::Delegated(issue) => Some(issue),
+        support::KeywordSupport::Unimplemented => Some(0),
+    };
+    if let Some(issue) =
+        tracking_issue.filter(|_| reported_diagnostics.insert(format!("unsupported:{keyword}")))
+    {
+        let location = source_path.map_or_else(
+            || format!("line {line_number}"),
+            |path| format!("{}:{line_number}", path.display()),
+        );
+        if issue == 0 {
+            crate::diagnosticln!(
+                "Unsupported SSH config option '{keyword}' at {location}; bssh parses this value for inspection but does not implement its runtime behavior"
+            );
+        } else {
+            crate::diagnosticln!(
+                "SSH config option '{keyword}' at {location} is not implemented yet; tracked in #{issue}"
+            );
+        }
+    }
+
     match keyword {
         // Basic options
         "hostname" | "user" | "port" => basic::parse_basic_option(host, keyword, args, line_number),
@@ -154,10 +193,6 @@ pub fn parse_option(
         | "useroaming"
         | "usersh"
         | "useprivilegedport" => Ok(()),
-
-        _ => {
-            crate::diagnosticln!("Unknown SSH config option '{keyword}' at line {line_number}");
-            Ok(())
-        }
+        _ => unreachable!("accepted keyword is missing a parser: {keyword}"),
     }
 }

--- a/src/ssh/ssh_config/parser/options/security.rs
+++ b/src/ssh/ssh_config/parser/options/security.rs
@@ -95,6 +95,9 @@ pub(super) fn parse_security_option(
                             || c == '_'
                             || c == '@'
                             || c == '+'
+                            || c == '^'
+                            || c == '*'
+                            || c == '?'
                     }) {
                         anyhow::bail!(
                             "HostKeyAlgorithms at line {line_number} contains invalid characters in algorithm name '{trimmed}'. \
@@ -124,6 +127,9 @@ pub(super) fn parse_security_option(
                 );
             }
 
+            let resolved = crate::ssh::tokio_client::algorithms::resolve_host_keys(&algorithms)
+                .map_err(anyhow::Error::msg)?;
+            host.resolved_host_key_algorithms = Some(resolved);
             host.host_key_algorithms = algorithms;
         }
         "kexalgorithms" => {
@@ -168,6 +174,9 @@ pub(super) fn parse_security_option(
                             || c == '_'
                             || c == '@'
                             || c == '+'
+                            || c == '^'
+                            || c == '*'
+                            || c == '?'
                     }) {
                         anyhow::bail!(
                             "KexAlgorithms at line {line_number} contains invalid characters in algorithm name '{trimmed}'. \
@@ -197,6 +206,9 @@ pub(super) fn parse_security_option(
                 );
             }
 
+            let resolved = crate::ssh::tokio_client::algorithms::resolve_kex(&algorithms)
+                .map_err(anyhow::Error::msg)?;
+            host.resolved_kex_algorithms = Some(resolved);
             host.kex_algorithms = algorithms;
         }
         "ciphers" => {
@@ -241,6 +253,9 @@ pub(super) fn parse_security_option(
                             || c == '_'
                             || c == '@'
                             || c == '+'
+                            || c == '^'
+                            || c == '*'
+                            || c == '?'
                     }) {
                         anyhow::bail!(
                             "Ciphers at line {line_number} contains invalid characters in cipher name '{trimmed}'. \
@@ -270,6 +285,9 @@ pub(super) fn parse_security_option(
                 );
             }
 
+            let resolved = crate::ssh::tokio_client::algorithms::resolve_ciphers(&ciphers)
+                .map_err(anyhow::Error::msg)?;
+            host.resolved_ciphers = Some(resolved);
             host.ciphers = ciphers;
         }
         "macs" => {
@@ -314,6 +332,9 @@ pub(super) fn parse_security_option(
                             || c == '_'
                             || c == '@'
                             || c == '+'
+                            || c == '^'
+                            || c == '*'
+                            || c == '?'
                     }) {
                         anyhow::bail!(
                             "MACs at line {line_number} contains invalid characters in MAC name '{trimmed}'. \
@@ -341,6 +362,9 @@ pub(super) fn parse_security_option(
                 anyhow::bail!("MACs at line {line_number} must contain at least one valid MAC");
             }
 
+            let resolved = crate::ssh::tokio_client::algorithms::resolve_macs(&macs)
+                .map_err(anyhow::Error::msg)?;
+            host.resolved_macs = Some(resolved);
             host.macs = macs;
         }
         "casignaturealgorithms" => {

--- a/src/ssh/ssh_config/parser/options/support.rs
+++ b/src/ssh/ssh_config/parser/options/support.rs
@@ -1,0 +1,343 @@
+//! Runtime support classification for accepted `ssh_config` keywords.
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum KeywordSupport {
+    Runtime(RuntimeConsumer),
+    Unimplemented,
+    Delegated(u32),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum RuntimeConsumer {
+    NodeResolution,
+    Authentication,
+    HostVerification,
+    Transport,
+    Proxy,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) struct KeywordSpec {
+    pub canonical: &'static str,
+    pub support: KeywordSupport,
+}
+
+use KeywordSupport::{Delegated, Runtime, Unimplemented};
+use RuntimeConsumer::{Authentication, HostVerification, NodeResolution, Proxy, Transport};
+
+pub(super) const ACCEPTED_KEYWORDS: &[(&str, &str, KeywordSupport)] = &[
+    ("hostname", "hostname", Runtime(NodeResolution)),
+    ("user", "user", Runtime(NodeResolution)),
+    ("port", "port", Runtime(NodeResolution)),
+    ("identityfile", "identityfile", Runtime(Authentication)),
+    ("identitiesonly", "identitiesonly", Delegated(296)),
+    ("addkeystoagent", "addkeystoagent", Unimplemented),
+    ("identityagent", "identityagent", Unimplemented),
+    (
+        "pubkeyacceptedalgorithms",
+        "pubkeyacceptedalgorithms",
+        Runtime(Authentication),
+    ),
+    (
+        "pubkeyacceptedkeytypes",
+        "pubkeyacceptedalgorithms",
+        Runtime(Authentication),
+    ),
+    ("certificatefile", "certificatefile", Delegated(296)),
+    (
+        "pubkeyauthentication",
+        "pubkeyauthentication",
+        Delegated(296),
+    ),
+    (
+        "passwordauthentication",
+        "passwordauthentication",
+        Delegated(296),
+    ),
+    (
+        "kbdinteractiveauthentication",
+        "kbdinteractiveauthentication",
+        Unimplemented,
+    ),
+    (
+        "challengeresponseauthentication",
+        "kbdinteractiveauthentication",
+        Unimplemented,
+    ),
+    (
+        "gssapiauthentication",
+        "gssapiauthentication",
+        Unimplemented,
+    ),
+    (
+        "preferredauthentications",
+        "preferredauthentications",
+        Delegated(296),
+    ),
+    (
+        "hostbasedauthentication",
+        "hostbasedauthentication",
+        Unimplemented,
+    ),
+    (
+        "hostbasedacceptedalgorithms",
+        "hostbasedacceptedalgorithms",
+        Unimplemented,
+    ),
+    (
+        "hostbasedkeytypes",
+        "hostbasedacceptedalgorithms",
+        Unimplemented,
+    ),
+    (
+        "numberofpasswordprompts",
+        "numberofpasswordprompts",
+        Delegated(296),
+    ),
+    ("enablesshkeysign", "enablesshkeysign", Unimplemented),
+    ("usekeychain", "usekeychain", Unimplemented),
+    (
+        "stricthostkeychecking",
+        "stricthostkeychecking",
+        Runtime(HostVerification),
+    ),
+    (
+        "userknownhostsfile",
+        "userknownhostsfile",
+        Runtime(HostVerification),
+    ),
+    (
+        "globalknownhostsfile",
+        "globalknownhostsfile",
+        Runtime(HostVerification),
+    ),
+    ("hostkeyalgorithms", "hostkeyalgorithms", Runtime(Transport)),
+    ("kexalgorithms", "kexalgorithms", Runtime(Transport)),
+    ("ciphers", "ciphers", Runtime(Transport)),
+    ("macs", "macs", Runtime(Transport)),
+    (
+        "casignaturealgorithms",
+        "casignaturealgorithms",
+        Unimplemented,
+    ),
+    (
+        "nohostauthenticationforlocalhost",
+        "nohostauthenticationforlocalhost",
+        Unimplemented,
+    ),
+    ("hashknownhosts", "hashknownhosts", Delegated(299)),
+    ("checkhostip", "checkhostip", Delegated(299)),
+    ("visualhostkey", "visualhostkey", Unimplemented),
+    ("hostkeyalias", "hostkeyalias", Runtime(HostVerification)),
+    ("verifyhostkeydns", "verifyhostkeydns", Delegated(299)),
+    ("updatehostkeys", "updatehostkeys", Delegated(299)),
+    ("requiredrsasize", "requiredrsasize", Unimplemented),
+    ("fingerprinthash", "fingerprinthash", Unimplemented),
+    ("forwardagent", "forwardagent", Unimplemented),
+    ("forwardx11", "forwardx11", Unimplemented),
+    ("localforward", "localforward", Delegated(298)),
+    ("remoteforward", "remoteforward", Delegated(298)),
+    ("dynamicforward", "dynamicforward", Delegated(298)),
+    ("gatewayports", "gatewayports", Unimplemented),
+    (
+        "exitonforwardfailure",
+        "exitonforwardfailure",
+        Delegated(298),
+    ),
+    ("permitremoteopen", "permitremoteopen", Unimplemented),
+    ("clearallforwardings", "clearallforwardings", Delegated(298)),
+    ("forwardx11timeout", "forwardx11timeout", Unimplemented),
+    ("forwardx11trusted", "forwardx11trusted", Unimplemented),
+    (
+        "serveraliveinterval",
+        "serveraliveinterval",
+        Runtime(Transport),
+    ),
+    (
+        "serveralivecountmax",
+        "serveralivecountmax",
+        Runtime(Transport),
+    ),
+    ("connecttimeout", "connecttimeout", Unimplemented),
+    (
+        "connectionattempts",
+        "connectionattempts",
+        Runtime(Transport),
+    ),
+    ("batchmode", "batchmode", Delegated(296)),
+    ("compression", "compression", Runtime(Transport)),
+    ("tcpkeepalive", "tcpkeepalive", Runtime(Transport)),
+    ("addressfamily", "addressfamily", Runtime(Transport)),
+    ("bindaddress", "bindaddress", Delegated(300)),
+    ("bindinterface", "bindinterface", Delegated(300)),
+    ("ipqos", "ipqos", Delegated(300)),
+    ("rekeylimit", "rekeylimit", Delegated(301)),
+    ("proxyjump", "proxyjump", Runtime(Proxy)),
+    ("proxycommand", "proxycommand", Runtime(Proxy)),
+    ("proxyusefdpass", "proxyusefdpass", Runtime(Proxy)),
+    ("controlmaster", "controlmaster", Unimplemented),
+    ("controlpath", "controlpath", Unimplemented),
+    ("controlpersist", "controlpersist", Unimplemented),
+    ("sendenv", "sendenv", Delegated(297)),
+    ("setenv", "setenv", Delegated(297)),
+    ("requesttty", "requesttty", Delegated(297)),
+    ("escapechar", "escapechar", Unimplemented),
+    ("loglevel", "loglevel", Unimplemented),
+    ("syslogfacility", "syslogfacility", Unimplemented),
+    ("protocol", "protocol", Unimplemented),
+    ("permitlocalcommand", "permitlocalcommand", Delegated(297)),
+    ("localcommand", "localcommand", Delegated(297)),
+    ("remotecommand", "remotecommand", Delegated(297)),
+    ("knownhostscommand", "knownhostscommand", Delegated(299)),
+    (
+        "forkafterauthentication",
+        "forkafterauthentication",
+        Unimplemented,
+    ),
+    ("sessiontype", "sessiontype", Delegated(297)),
+    ("stdinnull", "stdinnull", Unimplemented),
+    ("cipher", "cipher", Unimplemented),
+    ("fallbacktorsh", "fallbacktorsh", Unimplemented),
+    (
+        "globalknownhostsfile2",
+        "globalknownhostsfile2",
+        Unimplemented,
+    ),
+    (
+        "rhostsauthentication",
+        "rhostsauthentication",
+        Unimplemented,
+    ),
+    ("securitykeyprovider", "securitykeyprovider", Unimplemented),
+    ("userknownhostsfile2", "userknownhostsfile2", Unimplemented),
+    ("useroaming", "useroaming", Unimplemented),
+    ("usersh", "usersh", Unimplemented),
+    ("useprivilegedport", "useprivilegedport", Unimplemented),
+];
+
+pub(super) fn keyword_spec(keyword: &str) -> Option<KeywordSpec> {
+    ACCEPTED_KEYWORDS
+        .iter()
+        .find_map(|(accepted, canonical, support)| {
+            (*accepted == keyword).then_some(KeywordSpec {
+                canonical,
+                support: *support,
+            })
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::{HashMap, HashSet};
+
+    #[test]
+    fn accepted_keywords_and_aliases_have_one_consistent_classification() {
+        let mut seen = HashSet::new();
+        for (keyword, canonical, support) in ACCEPTED_KEYWORDS {
+            assert!(seen.insert(*keyword), "duplicate keyword: {keyword}");
+            assert_eq!(
+                keyword_spec(keyword),
+                Some(KeywordSpec {
+                    canonical,
+                    support: *support
+                })
+            );
+            let canonical_spec = keyword_spec(canonical)
+                .unwrap_or_else(|| panic!("alias {keyword} has no canonical entry {canonical}"));
+            assert_eq!(canonical_spec.canonical, *canonical);
+            assert_eq!(canonical_spec.support, *support);
+        }
+    }
+
+    #[test]
+    fn runtime_keywords_are_exactly_the_audited_consumer_set() {
+        // Every entry here has both a concrete production consumer and a
+        // behavior test at that consumer boundary. Adding a Runtime entry
+        // requires extending this audited set, making optimistic parse-only
+        // classifications visible in review.
+        let expected = [
+            ("hostname", NodeResolution),
+            ("user", NodeResolution),
+            ("port", NodeResolution),
+            ("identityfile", Authentication),
+            ("pubkeyacceptedalgorithms", Authentication),
+            ("stricthostkeychecking", HostVerification),
+            ("userknownhostsfile", HostVerification),
+            ("globalknownhostsfile", HostVerification),
+            ("hostkeyalgorithms", Transport),
+            ("kexalgorithms", Transport),
+            ("ciphers", Transport),
+            ("macs", Transport),
+            ("hostkeyalias", HostVerification),
+            ("serveraliveinterval", Transport),
+            ("serveralivecountmax", Transport),
+            ("connectionattempts", Transport),
+            ("compression", Transport),
+            ("tcpkeepalive", Transport),
+            ("addressfamily", Transport),
+            ("proxyjump", Proxy),
+            ("proxycommand", Proxy),
+            ("proxyusefdpass", Proxy),
+        ];
+        let runtime = ACCEPTED_KEYWORDS
+            .iter()
+            .filter_map(|(keyword, canonical, support)| {
+                if keyword != canonical {
+                    return None;
+                }
+                match support {
+                    KeywordSupport::Runtime(consumer) => Some((*keyword, *consumer)),
+                    KeywordSupport::Delegated(_) | KeywordSupport::Unimplemented => None,
+                }
+            })
+            .collect::<Vec<_>>();
+
+        assert_eq!(runtime, expected);
+    }
+
+    #[test]
+    fn first_wave_delegations_match_the_split_issue_dag() {
+        let expected = HashMap::from([
+            ("identitiesonly", 296),
+            ("certificatefile", 296),
+            ("preferredauthentications", 296),
+            ("pubkeyauthentication", 296),
+            ("passwordauthentication", 296),
+            ("numberofpasswordprompts", 296),
+            ("batchmode", 296),
+            ("sendenv", 297),
+            ("setenv", 297),
+            ("localcommand", 297),
+            ("permitlocalcommand", 297),
+            ("requesttty", 297),
+            ("sessiontype", 297),
+            ("remotecommand", 297),
+            ("localforward", 298),
+            ("remoteforward", 298),
+            ("dynamicforward", 298),
+            ("clearallforwardings", 298),
+            ("exitonforwardfailure", 298),
+            ("checkhostip", 299),
+            ("updatehostkeys", 299),
+            ("hashknownhosts", 299),
+            ("knownhostscommand", 299),
+            ("verifyhostkeydns", 299),
+            ("ipqos", 300),
+            ("bindaddress", 300),
+            ("bindinterface", 300),
+            ("rekeylimit", 301),
+        ]);
+        let delegated = ACCEPTED_KEYWORDS
+            .iter()
+            .filter_map(|(keyword, canonical, support)| match support {
+                KeywordSupport::Delegated(issue) if keyword == canonical => {
+                    Some((*keyword, *issue))
+                }
+                _ => None,
+            })
+            .collect::<HashMap<_, _>>();
+
+        assert_eq!(delegated, expected);
+    }
+}

--- a/src/ssh/ssh_config/parser/tests.rs
+++ b/src/ssh/ssh_config/parser/tests.rs
@@ -239,8 +239,9 @@ Host example.com
 }
 
 #[test]
-fn test_parse_global_options_ignored() {
-    // Global options should be ignored for now
+fn test_parse_global_options_become_first_host_star_block() {
+    // Options before the first Host directive are the first values obtained
+    // for every destination, just like an explicit leading `Host *` block.
     let content = r#"
 User globaluser
 Port 22
@@ -252,11 +253,14 @@ Host *.example.org
     Port 2222
 "#;
     let hosts = parse(content).unwrap();
-    assert_eq!(hosts.len(), 2);
-    assert_eq!(hosts[0].user, Some("hostuser".to_string()));
-    assert_eq!(hosts[0].port, None); // Global port not inherited
-    assert_eq!(hosts[1].port, Some(2222));
-    assert_eq!(hosts[1].user, None); // Global user not inherited
+    assert_eq!(hosts.len(), 3);
+    assert_eq!(hosts[0].host_patterns, vec!["*"]);
+    assert_eq!(hosts[0].user, Some("globaluser".to_string()));
+    assert_eq!(hosts[0].port, Some(22));
+    assert_eq!(hosts[1].host_patterns, vec!["example.com"]);
+    assert_eq!(hosts[1].user, Some("hostuser".to_string()));
+    assert_eq!(hosts[2].host_patterns, vec!["*.example.org"]);
+    assert_eq!(hosts[2].port, Some(2222));
 }
 
 #[test]
@@ -1569,7 +1573,14 @@ fn test_parse_pubkey_accepted_algorithms_memory_exhaustion() {
     // Test that excessive algorithms are truncated
     let mut algorithms = Vec::new();
     for i in 0..100 {
-        algorithms.push(format!("algo-{i}"));
+        algorithms.push(
+            if i % 2 == 0 {
+                "ssh-ed25519"
+            } else {
+                "rsa-sha2-256"
+            }
+            .to_string(),
+        );
     }
     let content = format!(
         "Host example.com\n    PubkeyAcceptedAlgorithms {}\n",
@@ -1579,6 +1590,13 @@ fn test_parse_pubkey_accepted_algorithms_memory_exhaustion() {
     assert_eq!(hosts.len(), 1);
     // Should be truncated to MAX_ALGORITHMS (50)
     assert_eq!(hosts[0].pubkey_accepted_algorithms.len(), 50);
+    assert_eq!(
+        hosts[0]
+            .resolved_pubkey_accepted_algorithms
+            .as_ref()
+            .unwrap(),
+        &["ssh-ed25519", "rsa-sha2-256"]
+    );
 }
 
 #[test]
@@ -1834,4 +1852,109 @@ Host proxy.example.com
     let hosts = parse(content).unwrap();
     assert_eq!(hosts.len(), 1);
     assert_eq!(hosts[0].proxy_use_fdpass, None);
+}
+
+#[tokio::test]
+async fn test_includes_preserve_global_and_host_first_obtained_context() {
+    use std::fs;
+    use tempfile::TempDir;
+
+    let temp_dir = TempDir::new().unwrap();
+    let nested = temp_dir.path().join("nested.conf");
+    fs::write(&nested, "Port 2200\nSetEnv ORDER=nested NESTED=yes\n").unwrap();
+
+    let global = temp_dir.path().join("global.conf");
+    fs::write(
+        &global,
+        format!(
+            "User include-first\nSetEnv ORDER=global GLOBAL=yes\nInclude {}\nPort 2300\nSetEnv ORDER=global-late\n",
+            nested.display()
+        ),
+    )
+    .unwrap();
+
+    let host = temp_dir.path().join("host.conf");
+    fs::write(
+        &host,
+        "HostName included.example.com\nSetEnv HOST_CONTEXT=yes\n",
+    )
+    .unwrap();
+
+    let main = temp_dir.path().join("config");
+    fs::write(
+        &main,
+        format!(
+            "Include {}\nUser main-late\nSetEnv ORDER=main-late\n\nHost foo\n    HostKeyAlias caller-context\n    Include {}\n    HostName main-late.example.com\n",
+            global.display(),
+            host.display()
+        ),
+    )
+    .unwrap();
+
+    let config = crate::ssh::ssh_config::SshConfig::load_from_file(&main)
+        .await
+        .unwrap();
+    assert_eq!(
+        config.hosts.len(),
+        2,
+        "Include must not create block boundaries"
+    );
+
+    let global_block = &config.hosts[0];
+    assert_eq!(global_block.host_patterns, ["*"]);
+    assert_eq!(global_block.user.as_deref(), Some("include-first"));
+    assert_eq!(global_block.port, Some(2200));
+    assert_eq!(
+        global_block.set_env.get("ORDER").map(String::as_str),
+        Some("global")
+    );
+    assert_eq!(
+        global_block.set_env.get("NESTED").map(String::as_str),
+        Some("yes")
+    );
+
+    let host_block = &config.hosts[1];
+    assert_eq!(host_block.host_patterns, ["foo"]);
+    assert_eq!(host_block.host_key_alias.as_deref(), Some("caller-context"));
+    assert_eq!(host_block.hostname.as_deref(), Some("included.example.com"));
+    assert_eq!(
+        host_block.set_env.get("HOST_CONTEXT").map(String::as_str),
+        Some("yes")
+    );
+
+    let effective = config.find_host_config("foo");
+    assert_eq!(effective.user.as_deref(), Some("include-first"));
+    assert_eq!(effective.port, Some(2200));
+    assert_eq!(effective.hostname.as_deref(), Some("included.example.com"));
+    assert_eq!(
+        effective.set_env.get("ORDER").map(String::as_str),
+        Some("global")
+    );
+}
+
+#[tokio::test]
+async fn include_errors_use_structured_source_lines_not_source_comments() {
+    use std::fs;
+    use tempfile::TempDir;
+
+    let temp_dir = TempDir::new().unwrap();
+    let included = temp_dir.path().join("included.conf");
+    fs::write(
+        &included,
+        "# Source: /spoofed/config:9000\n# ordinary comment\nHost target\nConnectionAttempts 0\n",
+    )
+    .unwrap();
+    let main = temp_dir.path().join("config");
+    fs::write(&main, format!("Include {}\n", included.display())).unwrap();
+
+    let error = crate::ssh::ssh_config::SshConfig::load_from_file(&main)
+        .await
+        .unwrap_err();
+    let chain = format!("{error:#}");
+
+    assert!(chain.contains("line 4"), "unexpected error chain: {chain}");
+    assert!(
+        !chain.contains("9000"),
+        "a user-authored Source comment must not influence provenance: {chain}"
+    );
 }

--- a/src/ssh/ssh_config/resolver.rs
+++ b/src/ssh/ssh_config/resolver.rs
@@ -85,19 +85,19 @@ pub(super) fn find_host_config_with_user(
     merged_config
 }
 
-/// Merge two host configurations (second takes precedence)
+/// Merge a matching block using OpenSSH's first-obtained-value rule.
 pub(super) fn merge_host_config(base: &mut SshHostConfig, overlay: &SshHostConfig) {
-    // For most options, overlay takes precedence if set
-    if !overlay.host_patterns.is_empty() {
+    // Blocks are visited in source order, so scalar values only fill empty slots.
+    if base.host_patterns.is_empty() && !overlay.host_patterns.is_empty() {
         base.host_patterns = overlay.host_patterns.clone();
     }
-    if overlay.hostname.is_some() {
+    if base.hostname.is_none() && overlay.hostname.is_some() {
         base.hostname = overlay.hostname.clone();
     }
-    if overlay.user.is_some() {
+    if base.user.is_none() && overlay.user.is_some() {
         base.user = overlay.user.clone();
     }
-    if overlay.port.is_some() {
+    if base.port.is_none() && overlay.port.is_some() {
         base.port = overlay.port;
     }
     if !overlay.identity_files.is_empty() {
@@ -109,84 +109,91 @@ pub(super) fn merge_host_config(base: &mut SshHostConfig, overlay: &SshHostConfi
     // ProxyJump compete for the same slot, so either one suppresses all later
     // occurrences of both directives.
     if base.proxy_jump.is_none() && base.proxy_command.is_none() {
-        if overlay.proxy_jump.is_some() {
+        if base.proxy_jump.is_none() && overlay.proxy_jump.is_some() {
             base.proxy_jump = overlay.proxy_jump.clone();
-        } else if overlay.proxy_command.is_some() {
+        } else if base.proxy_command.is_none() && overlay.proxy_command.is_some() {
             base.proxy_command = overlay.proxy_command.clone();
         }
     }
     if base.proxy_use_fdpass.is_none() && overlay.proxy_use_fdpass.is_some() {
         base.proxy_use_fdpass = overlay.proxy_use_fdpass;
     }
-    if overlay.strict_host_key_checking.is_some() {
+    if base.strict_host_key_checking.is_none() && overlay.strict_host_key_checking.is_some() {
         base.strict_host_key_checking = overlay.strict_host_key_checking.clone();
     }
-    if overlay.user_known_hosts_file.is_some() {
+    if base.user_known_hosts_file.is_none() && overlay.user_known_hosts_file.is_some() {
         base.user_known_hosts_file = overlay.user_known_hosts_file.clone();
     }
-    if overlay.global_known_hosts_file.is_some() {
+    if base.global_known_hosts_file.is_none() && overlay.global_known_hosts_file.is_some() {
         base.global_known_hosts_file = overlay.global_known_hosts_file.clone();
     }
-    if overlay.forward_agent.is_some() {
+    if base.forward_agent.is_none() && overlay.forward_agent.is_some() {
         base.forward_agent = overlay.forward_agent;
     }
-    if overlay.forward_x11.is_some() {
+    if base.forward_x11.is_none() && overlay.forward_x11.is_some() {
         base.forward_x11 = overlay.forward_x11;
     }
-    if overlay.server_alive_interval.is_some() {
+    if base.server_alive_interval.is_none() && overlay.server_alive_interval.is_some() {
         base.server_alive_interval = overlay.server_alive_interval;
     }
-    if overlay.server_alive_count_max.is_some() {
+    if base.server_alive_count_max.is_none() && overlay.server_alive_count_max.is_some() {
         base.server_alive_count_max = overlay.server_alive_count_max;
     }
-    if overlay.connect_timeout.is_some() {
+    if base.connect_timeout.is_none() && overlay.connect_timeout.is_some() {
         base.connect_timeout = overlay.connect_timeout;
     }
-    if overlay.connection_attempts.is_some() {
+    if base.connection_attempts.is_none() && overlay.connection_attempts.is_some() {
         base.connection_attempts = overlay.connection_attempts;
     }
-    if overlay.batch_mode.is_some() {
+    if base.batch_mode.is_none() && overlay.batch_mode.is_some() {
         base.batch_mode = overlay.batch_mode;
     }
-    if overlay.compression.is_some() {
+    if base.compression.is_none() && overlay.compression.is_some() {
         base.compression = overlay.compression;
     }
-    if overlay.tcp_keep_alive.is_some() {
+    if base.tcp_keep_alive.is_none() && overlay.tcp_keep_alive.is_some() {
         base.tcp_keep_alive = overlay.tcp_keep_alive;
     }
-    if !overlay.preferred_authentications.is_empty() {
+    if base.preferred_authentications.is_empty() && !overlay.preferred_authentications.is_empty() {
         base.preferred_authentications = overlay.preferred_authentications.clone();
     }
-    if overlay.pubkey_authentication.is_some() {
+    if base.pubkey_authentication.is_none() && overlay.pubkey_authentication.is_some() {
         base.pubkey_authentication = overlay.pubkey_authentication;
     }
-    if overlay.password_authentication.is_some() {
+    if base.password_authentication.is_none() && overlay.password_authentication.is_some() {
         base.password_authentication = overlay.password_authentication;
     }
-    if overlay.keyboard_interactive_authentication.is_some() {
+    if base.keyboard_interactive_authentication.is_none()
+        && overlay.keyboard_interactive_authentication.is_some()
+    {
         base.keyboard_interactive_authentication = overlay.keyboard_interactive_authentication;
     }
-    if overlay.gssapi_authentication.is_some() {
+    if base.gssapi_authentication.is_none() && overlay.gssapi_authentication.is_some() {
         base.gssapi_authentication = overlay.gssapi_authentication;
     }
-    if !overlay.host_key_algorithms.is_empty() {
+    if base.host_key_algorithms.is_empty() && !overlay.host_key_algorithms.is_empty() {
         base.host_key_algorithms = overlay.host_key_algorithms.clone();
+        base.resolved_host_key_algorithms = overlay.resolved_host_key_algorithms.clone();
     }
-    if !overlay.kex_algorithms.is_empty() {
+    if base.kex_algorithms.is_empty() && !overlay.kex_algorithms.is_empty() {
         base.kex_algorithms = overlay.kex_algorithms.clone();
+        base.resolved_kex_algorithms = overlay.resolved_kex_algorithms.clone();
     }
-    if !overlay.ciphers.is_empty() {
+    if base.ciphers.is_empty() && !overlay.ciphers.is_empty() {
         base.ciphers = overlay.ciphers.clone();
+        base.resolved_ciphers = overlay.resolved_ciphers.clone();
     }
-    if !overlay.macs.is_empty() {
+    if base.macs.is_empty() && !overlay.macs.is_empty() {
         base.macs = overlay.macs.clone();
+        base.resolved_macs = overlay.resolved_macs.clone();
     }
     if !overlay.send_env.is_empty() {
         base.send_env.extend(overlay.send_env.iter().cloned());
     }
-    if !overlay.set_env.is_empty() {
+    for (name, value) in &overlay.set_env {
         base.set_env
-            .extend(overlay.set_env.iter().map(|(k, v)| (k.clone(), v.clone())));
+            .entry(name.clone())
+            .or_insert_with(|| value.clone());
     }
     if !overlay.local_forward.is_empty() {
         base.local_forward
@@ -200,37 +207,37 @@ pub(super) fn merge_host_config(base: &mut SshHostConfig, overlay: &SshHostConfi
         base.dynamic_forward
             .extend(overlay.dynamic_forward.iter().cloned());
     }
-    if overlay.request_tty.is_some() {
+    if base.request_tty.is_none() && overlay.request_tty.is_some() {
         base.request_tty = overlay.request_tty.clone();
     }
-    if overlay.escape_char.is_some() {
+    if base.escape_char.is_none() && overlay.escape_char.is_some() {
         base.escape_char = overlay.escape_char.clone();
     }
-    if overlay.log_level.is_some() {
+    if base.log_level.is_none() && overlay.log_level.is_some() {
         base.log_level = overlay.log_level.clone();
     }
-    if overlay.syslog_facility.is_some() {
+    if base.syslog_facility.is_none() && overlay.syslog_facility.is_some() {
         base.syslog_facility = overlay.syslog_facility.clone();
     }
-    if !overlay.protocol.is_empty() {
+    if base.protocol.is_empty() && !overlay.protocol.is_empty() {
         base.protocol = overlay.protocol.clone();
     }
-    if overlay.address_family.is_some() {
+    if base.address_family.is_none() && overlay.address_family.is_some() {
         base.address_family = overlay.address_family.clone();
     }
-    if overlay.bind_address.is_some() {
+    if base.bind_address.is_none() && overlay.bind_address.is_some() {
         base.bind_address = overlay.bind_address.clone();
     }
-    if overlay.clear_all_forwardings.is_some() {
+    if base.clear_all_forwardings.is_none() && overlay.clear_all_forwardings.is_some() {
         base.clear_all_forwardings = overlay.clear_all_forwardings;
     }
-    if overlay.control_master.is_some() {
+    if base.control_master.is_none() && overlay.control_master.is_some() {
         base.control_master = overlay.control_master.clone();
     }
-    if overlay.control_path.is_some() {
+    if base.control_path.is_none() && overlay.control_path.is_some() {
         base.control_path = overlay.control_path.clone();
     }
-    if overlay.control_persist.is_some() {
+    if base.control_persist.is_none() && overlay.control_persist.is_some() {
         base.control_persist = overlay.control_persist.clone();
     }
     // Certificate authentication and advanced port forwarding options
@@ -252,13 +259,13 @@ pub(super) fn merge_host_config(base: &mut SshHostConfig, overlay: &SshHostConfi
             }
         }
     }
-    if !overlay.ca_signature_algorithms.is_empty() {
+    if base.ca_signature_algorithms.is_empty() && !overlay.ca_signature_algorithms.is_empty() {
         base.ca_signature_algorithms = overlay.ca_signature_algorithms.clone();
     }
-    if overlay.gateway_ports.is_some() {
+    if base.gateway_ports.is_none() && overlay.gateway_ports.is_some() {
         base.gateway_ports = overlay.gateway_ports.clone();
     }
-    if overlay.exit_on_forward_failure.is_some() {
+    if base.exit_on_forward_failure.is_none() && overlay.exit_on_forward_failure.is_some() {
         base.exit_on_forward_failure = overlay.exit_on_forward_failure;
     }
     if !overlay.permit_remote_open.is_empty() {
@@ -279,104 +286,111 @@ pub(super) fn merge_host_config(base: &mut SshHostConfig, overlay: &SshHostConfi
             }
         }
     }
-    if overlay.hostbased_authentication.is_some() {
+    if base.hostbased_authentication.is_none() && overlay.hostbased_authentication.is_some() {
         base.hostbased_authentication = overlay.hostbased_authentication;
     }
-    if !overlay.hostbased_accepted_algorithms.is_empty() {
+    if base.hostbased_accepted_algorithms.is_empty()
+        && !overlay.hostbased_accepted_algorithms.is_empty()
+    {
         base.hostbased_accepted_algorithms = overlay.hostbased_accepted_algorithms.clone();
     }
     // Command execution and automation options
-    if overlay.permit_local_command.is_some() {
+    if base.permit_local_command.is_none() && overlay.permit_local_command.is_some() {
         base.permit_local_command = overlay.permit_local_command;
     }
-    if overlay.local_command.is_some() {
+    if base.local_command.is_none() && overlay.local_command.is_some() {
         base.local_command = overlay.local_command.clone();
     }
-    if overlay.remote_command.is_some() {
+    if base.remote_command.is_none() && overlay.remote_command.is_some() {
         base.remote_command = overlay.remote_command.clone();
     }
-    if overlay.known_hosts_command.is_some() {
+    if base.known_hosts_command.is_none() && overlay.known_hosts_command.is_some() {
         base.known_hosts_command = overlay.known_hosts_command.clone();
     }
-    if overlay.fork_after_authentication.is_some() {
+    if base.fork_after_authentication.is_none() && overlay.fork_after_authentication.is_some() {
         base.fork_after_authentication = overlay.fork_after_authentication;
     }
-    if overlay.session_type.is_some() {
+    if base.session_type.is_none() && overlay.session_type.is_some() {
         base.session_type = overlay.session_type.clone();
     }
-    if overlay.stdin_null.is_some() {
+    if base.stdin_null.is_none() && overlay.stdin_null.is_some() {
         base.stdin_null = overlay.stdin_null;
     }
     // Host key verification, authentication, and network options
     // Host key verification & security
-    if overlay.no_host_authentication_for_localhost.is_some() {
+    if base.no_host_authentication_for_localhost.is_none()
+        && overlay.no_host_authentication_for_localhost.is_some()
+    {
         base.no_host_authentication_for_localhost = overlay.no_host_authentication_for_localhost;
     }
-    if overlay.hash_known_hosts.is_some() {
+    if base.hash_known_hosts.is_none() && overlay.hash_known_hosts.is_some() {
         base.hash_known_hosts = overlay.hash_known_hosts;
     }
-    if overlay.check_host_ip.is_some() {
+    if base.check_host_ip.is_none() && overlay.check_host_ip.is_some() {
         base.check_host_ip = overlay.check_host_ip;
     }
-    if overlay.visual_host_key.is_some() {
+    if base.visual_host_key.is_none() && overlay.visual_host_key.is_some() {
         base.visual_host_key = overlay.visual_host_key;
     }
-    if overlay.host_key_alias.is_some() {
+    if base.host_key_alias.is_none() && overlay.host_key_alias.is_some() {
         base.host_key_alias = overlay.host_key_alias.clone();
     }
-    if overlay.verify_host_key_dns.is_some() {
+    if base.verify_host_key_dns.is_none() && overlay.verify_host_key_dns.is_some() {
         base.verify_host_key_dns = overlay.verify_host_key_dns.clone();
     }
-    if overlay.update_host_keys.is_some() {
+    if base.update_host_keys.is_none() && overlay.update_host_keys.is_some() {
         base.update_host_keys = overlay.update_host_keys.clone();
     }
     // Authentication
-    if overlay.number_of_password_prompts.is_some() {
+    if base.number_of_password_prompts.is_none() && overlay.number_of_password_prompts.is_some() {
         base.number_of_password_prompts = overlay.number_of_password_prompts;
     }
-    if overlay.enable_ssh_keysign.is_some() {
+    if base.enable_ssh_keysign.is_none() && overlay.enable_ssh_keysign.is_some() {
         base.enable_ssh_keysign = overlay.enable_ssh_keysign;
     }
     // Network & connection
-    if overlay.bind_interface.is_some() {
+    if base.bind_interface.is_none() && overlay.bind_interface.is_some() {
         base.bind_interface = overlay.bind_interface.clone();
     }
-    if overlay.ipqos.is_some() {
+    if base.ipqos.is_none() && overlay.ipqos.is_some() {
         base.ipqos = overlay.ipqos.clone();
     }
-    if overlay.rekey_limit.is_some() {
+    if base.rekey_limit.is_none() && overlay.rekey_limit.is_some() {
         base.rekey_limit = overlay.rekey_limit.clone();
     }
     // X11 forwarding
-    if overlay.forward_x11_timeout.is_some() {
+    if base.forward_x11_timeout.is_none() && overlay.forward_x11_timeout.is_some() {
         base.forward_x11_timeout = overlay.forward_x11_timeout.clone();
     }
-    if overlay.forward_x11_trusted.is_some() {
+    if base.forward_x11_trusted.is_none() && overlay.forward_x11_trusted.is_some() {
         base.forward_x11_trusted = overlay.forward_x11_trusted;
     }
     // Authentication and security management options
     // Authentication & agent management
-    if overlay.identities_only.is_some() {
+    if base.identities_only.is_none() && overlay.identities_only.is_some() {
         base.identities_only = overlay.identities_only;
     }
-    if overlay.add_keys_to_agent.is_some() {
+    if base.add_keys_to_agent.is_none() && overlay.add_keys_to_agent.is_some() {
         base.add_keys_to_agent = overlay.add_keys_to_agent.clone();
     }
-    if overlay.identity_agent.is_some() {
+    if base.identity_agent.is_none() && overlay.identity_agent.is_some() {
         base.identity_agent = overlay.identity_agent.clone();
     }
     #[cfg(target_os = "macos")]
-    if overlay.use_keychain.is_some() {
+    if base.use_keychain.is_none() && overlay.use_keychain.is_some() {
         base.use_keychain = overlay.use_keychain;
     }
     // Security & algorithm management
-    if !overlay.pubkey_accepted_algorithms.is_empty() {
+    if base.pubkey_accepted_algorithms.is_empty() && !overlay.pubkey_accepted_algorithms.is_empty()
+    {
         base.pubkey_accepted_algorithms = overlay.pubkey_accepted_algorithms.clone();
+        base.resolved_pubkey_accepted_algorithms =
+            overlay.resolved_pubkey_accepted_algorithms.clone();
     }
-    if overlay.required_rsa_size.is_some() {
+    if base.required_rsa_size.is_none() && overlay.required_rsa_size.is_some() {
         base.required_rsa_size = overlay.required_rsa_size;
     }
-    if overlay.fingerprint_hash.is_some() {
+    if base.fingerprint_hash.is_none() && overlay.fingerprint_hash.is_some() {
         base.fingerprint_hash = overlay.fingerprint_hash.clone();
     }
 }

--- a/src/ssh/ssh_config/resolver_tests.rs
+++ b/src/ssh/ssh_config/resolver_tests.rs
@@ -128,7 +128,7 @@ Host example.com
     }
 
     #[test]
-    fn test_ca_signature_algorithms_override() {
+    fn test_ca_signature_algorithms_keeps_first_obtained_list() {
         let content = r#"
 Host *
     CASignatureAlgorithms ssh-rsa,ssh-dss
@@ -139,14 +139,14 @@ Host example.com
         let hosts = parse(content).unwrap();
         let config = find_host_config(&hosts, "example.com");
 
-        // Should override (not append) - only the latter values
+        // Replacement list keeps the first matching block value
         assert_eq!(config.ca_signature_algorithms.len(), 2);
-        assert_eq!(config.ca_signature_algorithms[0], "ssh-ed25519");
-        assert_eq!(config.ca_signature_algorithms[1], "rsa-sha2-512");
+        assert_eq!(config.ca_signature_algorithms[0], "ssh-rsa");
+        assert_eq!(config.ca_signature_algorithms[1], "ssh-dss");
     }
 
     #[test]
-    fn test_hostbased_accepted_algorithms_override() {
+    fn test_hostbased_accepted_algorithms_keeps_first_obtained_list() {
         let content = r#"
 Host *
     HostbasedAcceptedAlgorithms ssh-rsa,ssh-dss
@@ -157,17 +157,14 @@ Host example.com
         let hosts = parse(content).unwrap();
         let config = find_host_config(&hosts, "example.com");
 
-        // Should override (not append)
+        // Replacement list keeps the first matching block value
         assert_eq!(config.hostbased_accepted_algorithms.len(), 2);
-        assert_eq!(config.hostbased_accepted_algorithms[0], "ssh-ed25519");
-        assert_eq!(
-            config.hostbased_accepted_algorithms[1],
-            "ecdsa-sha2-nistp256"
-        );
+        assert_eq!(config.hostbased_accepted_algorithms[0], "ssh-rsa");
+        assert_eq!(config.hostbased_accepted_algorithms[1], "ssh-dss");
     }
 
     #[test]
-    fn test_gateway_ports_override() {
+    fn test_gateway_ports_keeps_first_obtained_value() {
         let content = r#"
 Host *
     GatewayPorts no
@@ -178,12 +175,12 @@ Host example.com
         let hosts = parse(content).unwrap();
         let config = find_host_config(&hosts, "example.com");
 
-        // Should override to "yes"
-        assert_eq!(config.gateway_ports, Some("yes".to_string()));
+        // The first matching block wins
+        assert_eq!(config.gateway_ports, Some("no".to_string()));
     }
 
     #[test]
-    fn test_exit_on_forward_failure_override() {
+    fn test_exit_on_forward_failure_keeps_first_obtained_value() {
         let content = r#"
 Host *
     ExitOnForwardFailure no
@@ -194,12 +191,12 @@ Host example.com
         let hosts = parse(content).unwrap();
         let config = find_host_config(&hosts, "example.com");
 
-        // Should override to true
-        assert_eq!(config.exit_on_forward_failure, Some(true));
+        // The first matching block wins
+        assert_eq!(config.exit_on_forward_failure, Some(false));
     }
 
     #[test]
-    fn test_hostbased_authentication_override() {
+    fn test_hostbased_authentication_keeps_first_obtained_value() {
         let content = r#"
 Host *
     HostbasedAuthentication no
@@ -210,13 +207,13 @@ Host example.com
         let hosts = parse(content).unwrap();
         let config = find_host_config(&hosts, "example.com");
 
-        // Should override to true
-        assert_eq!(config.hostbased_authentication, Some(true));
+        // The first matching block wins
+        assert_eq!(config.hostbased_authentication, Some(false));
     }
 
     #[test]
     fn test_multiple_host_blocks_with_priority() {
-        // SSH config: later matches override earlier matches for scalar values
+        // SSH config: the first matching value wins; additive lists accumulate
         // Lists accumulate across all matches
         let content = r#"
 Host example.com
@@ -234,9 +231,9 @@ Host *
         let hosts = parse(content).unwrap();
         let config = find_host_config(&hosts, "example.com");
 
-        // GatewayPorts: Later matches override (*.com overrides example.com)
-        // So the final value should be "no" from *.com
-        assert_eq!(config.gateway_ports, Some("no".to_string()));
+        // GatewayPorts: the first matching example.com block wins
+        // So the final value is "yes" from example.com
+        assert_eq!(config.gateway_ports, Some("yes".to_string()));
 
         // ExitOnForwardFailure: Only set in * block, so it's yes
         assert_eq!(config.exit_on_forward_failure, Some(true));
@@ -389,7 +386,7 @@ Host example.com
         let hosts = parse(content).unwrap();
         let config = find_host_config(&hosts, "example.com");
 
-        // Should override to true (yes)
+        // The first matching block wins (yes)
         assert_eq!(config.use_keychain, Some(true));
     }
 

--- a/src/ssh/ssh_config/types.rs
+++ b/src/ssh/ssh_config/types.rs
@@ -69,6 +69,10 @@ pub struct SshHostConfig {
     pub kex_algorithms: Vec<String>,
     pub ciphers: Vec<String>,
     pub macs: Vec<String>,
+    pub(crate) resolved_host_key_algorithms: Option<Vec<ssh_key::Algorithm>>,
+    pub(crate) resolved_kex_algorithms: Option<Vec<russh::kex::Name>>,
+    pub(crate) resolved_ciphers: Option<Vec<russh::cipher::Name>>,
+    pub(crate) resolved_macs: Option<Vec<russh::mac::Name>>,
     pub send_env: Vec<String>,
     pub set_env: HashMap<String, String>,
     pub local_forward: Vec<String>,
@@ -132,6 +136,8 @@ pub struct SshHostConfig {
     pub use_keychain: Option<bool>,
     // Security & algorithm management
     pub pubkey_accepted_algorithms: Vec<String>,
+    /// Supported public-key signature policy exposed to authentication.
+    pub resolved_pubkey_accepted_algorithms: Option<Vec<String>>,
     pub required_rsa_size: Option<u32>,
     pub fingerprint_hash: Option<String>, // md5/sha256
 }

--- a/src/ssh/tokio_client/algorithms.rs
+++ b/src/ssh/tokio_client/algorithms.rs
@@ -1,0 +1,373 @@
+//! OpenSSH-style algorithm list resolution for the russh transport.
+
+use glob::Pattern;
+use russh::{cipher, kex, mac};
+use ssh_key::Algorithm;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ListMode {
+    Replace,
+    Append,
+    Remove,
+    Prepend,
+}
+
+fn list_mode(values: &[String]) -> (ListMode, Vec<&str>) {
+    let Some((first, rest)) = values.split_first() else {
+        return (ListMode::Replace, Vec::new());
+    };
+    let (mode, first) = match first.as_bytes().first() {
+        Some(b'+') => (ListMode::Append, &first[1..]),
+        Some(b'-') => (ListMode::Remove, &first[1..]),
+        Some(b'^') => (ListMode::Prepend, &first[1..]),
+        _ => (ListMode::Replace, first.as_str()),
+    };
+    let mut names = Vec::with_capacity(values.len());
+    if !first.is_empty() {
+        names.push(first);
+    }
+    names.extend(rest.iter().map(String::as_str));
+    (mode, names)
+}
+
+fn expand_supported<T: Clone + PartialEq>(
+    kind: &str,
+    names: &[&str],
+    supported: &[T],
+    name: impl Fn(&T) -> &str,
+) -> Result<Vec<T>, String> {
+    let mut expanded = Vec::new();
+    for configured in names {
+        let pattern = Pattern::new(configured).map_err(|error| error.to_string())?;
+        let matches = supported
+            .iter()
+            .filter(|algorithm| pattern.matches(name(algorithm)))
+            .cloned()
+            .collect::<Vec<_>>();
+        if matches.is_empty() {
+            return Err(unsupported(
+                kind,
+                configured,
+                supported.iter().map(|value| name(value).to_string()),
+            ));
+        }
+        for algorithm in matches {
+            if !expanded.contains(&algorithm) {
+                expanded.push(algorithm);
+            }
+        }
+    }
+    Ok(expanded)
+}
+
+fn remove_matching<T: Clone>(
+    defaults: &[T],
+    patterns: &[&str],
+    name: impl Fn(&T) -> &str,
+) -> Result<Vec<T>, String> {
+    let patterns = patterns
+        .iter()
+        .map(|pattern| Pattern::new(pattern).map_err(|error| error.to_string()))
+        .collect::<Result<Vec<_>, _>>()?;
+    Ok(defaults
+        .iter()
+        .filter(|algorithm| {
+            !patterns
+                .iter()
+                .any(|pattern| pattern.matches(name(algorithm)))
+        })
+        .cloned()
+        .collect())
+}
+
+fn combine<T: Clone + PartialEq>(defaults: &[T], configured: Vec<T>, mode: ListMode) -> Vec<T> {
+    match mode {
+        ListMode::Replace => configured,
+        ListMode::Append => {
+            defaults
+                .iter()
+                .cloned()
+                .chain(configured)
+                .fold(Vec::new(), |mut result, algorithm| {
+                    if !result.contains(&algorithm) {
+                        result.push(algorithm);
+                    }
+                    result
+                })
+        }
+        ListMode::Prepend => configured.into_iter().chain(defaults.iter().cloned()).fold(
+            Vec::new(),
+            |mut result, algorithm| {
+                if !result.contains(&algorithm) {
+                    result.push(algorithm);
+                }
+                result
+            },
+        ),
+        ListMode::Remove => unreachable!("remove is handled before conversion"),
+    }
+}
+
+fn unsupported(kind: &str, name: &str, supported: impl Iterator<Item = String>) -> String {
+    format!(
+        "unsupported {kind} '{name}'; supported values: {}",
+        supported.collect::<Vec<_>>().join(",")
+    )
+}
+
+fn resolve_policy<T: Clone + PartialEq>(
+    kind: &str,
+    values: &[String],
+    defaults: &[T],
+    supported: &[T],
+    name: impl Fn(&T) -> &str + Copy,
+) -> Result<Vec<T>, String> {
+    let (mode, names) = list_mode(values);
+    let resolved = if mode == ListMode::Remove {
+        remove_matching(defaults, &names, name)?
+    } else {
+        let configured = expand_supported(kind, &names, supported, name)?;
+        combine(defaults, configured, mode)
+    };
+    if resolved.is_empty() {
+        return Err(format!("{kind} policy selects no supported algorithms"));
+    }
+    Ok(resolved)
+}
+
+pub(crate) fn resolve_ciphers(values: &[String]) -> Result<Vec<cipher::Name>, String> {
+    let supported = cipher::ALL_CIPHERS
+        .iter()
+        .map(|value| **value)
+        .collect::<Vec<_>>();
+    resolve_policy(
+        "cipher",
+        values,
+        russh::Preferred::DEFAULT.cipher.as_ref(),
+        &supported,
+        AsRef::as_ref,
+    )
+}
+
+pub(crate) fn resolve_macs(values: &[String]) -> Result<Vec<mac::Name>, String> {
+    let supported = mac::ALL_MAC_ALGORITHMS
+        .iter()
+        .map(|value| **value)
+        .collect::<Vec<_>>();
+    resolve_policy(
+        "MAC",
+        values,
+        russh::Preferred::DEFAULT.mac.as_ref(),
+        &supported,
+        AsRef::as_ref,
+    )
+}
+
+pub(crate) fn resolve_kex(values: &[String]) -> Result<Vec<kex::Name>, String> {
+    let extensions = [
+        kex::EXTENSION_SUPPORT_AS_CLIENT,
+        kex::EXTENSION_SUPPORT_AS_SERVER,
+        kex::EXTENSION_OPENSSH_STRICT_KEX_AS_CLIENT,
+        kex::EXTENSION_OPENSSH_STRICT_KEX_AS_SERVER,
+    ];
+    let defaults = russh::Preferred::DEFAULT
+        .kex
+        .iter()
+        .filter(|value| !extensions.contains(value))
+        .cloned()
+        .collect::<Vec<_>>();
+    let supported = kex::ALL_KEX_ALGORITHMS
+        .iter()
+        .map(|value| **value)
+        .collect::<Vec<_>>();
+    let mut resolved = resolve_policy(
+        "key exchange algorithm",
+        values,
+        &defaults,
+        &supported,
+        AsRef::as_ref,
+    )?;
+    resolved.extend(extensions);
+    Ok(resolved)
+}
+
+fn supported_key_algorithms() -> Vec<Algorithm> {
+    let mut supported = russh::Preferred::DEFAULT.key.to_vec();
+    for algorithm in russh::keys::key::ALL_KEY_TYPES {
+        if !supported.contains(algorithm) {
+            supported.push(algorithm.clone());
+        }
+    }
+    supported
+}
+
+pub(crate) fn resolve_host_keys(values: &[String]) -> Result<Vec<Algorithm>, String> {
+    let defaults = russh::Preferred::DEFAULT.key.as_ref();
+    let supported = supported_key_algorithms();
+    resolve_policy(
+        "host key algorithm",
+        values,
+        defaults,
+        &supported,
+        AsRef::as_ref,
+    )
+}
+
+fn public_key_names(algorithms: &[Algorithm]) -> Vec<String> {
+    algorithms
+        .iter()
+        .flat_map(|algorithm| {
+            [
+                algorithm.to_certificate_type().to_string(),
+                algorithm.to_string(),
+            ]
+        })
+        .collect()
+}
+
+pub(crate) fn resolve_pubkey_algorithms(values: &[String]) -> Result<Vec<String>, String> {
+    let defaults = public_key_names(russh::Preferred::DEFAULT.key.as_ref());
+    let supported = public_key_names(&supported_key_algorithms());
+    resolve_policy(
+        "public key signature algorithm",
+        values,
+        &defaults,
+        &supported,
+        String::as_str,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn modifiers_append_prepend_and_remove_against_transport_defaults() {
+        let appended = resolve_ciphers(&[String::from("+aes128-cbc")]).unwrap();
+        assert_eq!(appended.last(), Some(&cipher::AES_128_CBC));
+        let prepended = resolve_macs(&[String::from("^hmac-sha1")]).unwrap();
+        assert_eq!(prepended.first(), Some(&mac::HMAC_SHA1));
+        let removed = resolve_kex(&[String::from("-*sha1")]).unwrap();
+        assert!(removed.iter().all(|name| !name.as_ref().ends_with("sha1")));
+    }
+
+    #[test]
+    fn wildcards_expand_and_empty_policies_fail_closed() {
+        let ciphers = resolve_ciphers(&[String::from("aes*-ctr")]).unwrap();
+        assert!(!ciphers.is_empty());
+        assert!(
+            ciphers
+                .iter()
+                .all(|algorithm| algorithm.as_ref().starts_with("aes")
+                    && algorithm.as_ref().ends_with("-ctr"))
+        );
+
+        let error = resolve_macs(&[String::from("-*")]).unwrap_err();
+        assert!(error.contains("selects no supported algorithms"));
+    }
+
+    #[test]
+    fn configured_kex_preserves_protocol_extension_markers() {
+        let resolved = resolve_kex(&[String::from("curve25519-sha256")]).unwrap();
+        assert_eq!(resolved[0], kex::CURVE25519);
+        assert!(resolved.contains(&kex::EXTENSION_SUPPORT_AS_CLIENT));
+        assert!(resolved.contains(&kex::EXTENSION_OPENSSH_STRICT_KEX_AS_CLIENT));
+    }
+
+    #[test]
+    fn pubkey_policy_resolves_modifiers_for_authentication_follow_up() {
+        let resolved = resolve_pubkey_algorithms(&[String::from("rsa-sha2-*")]).unwrap();
+        assert_eq!(
+            resolved,
+            [
+                "rsa-sha2-512-cert-v01@openssh.com",
+                "rsa-sha2-512",
+                "rsa-sha2-256-cert-v01@openssh.com",
+                "rsa-sha2-256"
+            ]
+        );
+    }
+
+    #[test]
+    fn host_key_modifiers_use_defaults_as_the_base_and_all_supported_as_candidates() {
+        let defaults = russh::Preferred::DEFAULT.key.as_ref();
+
+        let appended = resolve_host_keys(&[String::from("+ssh-rsa")]).unwrap();
+        assert_eq!(appended, defaults);
+        assert_eq!(
+            appended
+                .iter()
+                .filter(|algorithm| algorithm.as_ref() == "ssh-rsa")
+                .count(),
+            1
+        );
+
+        let removed = resolve_host_keys(&[String::from("-ssh-*")]).unwrap();
+        assert_eq!(
+            removed,
+            defaults
+                .iter()
+                .filter(|algorithm| !algorithm.as_ref().starts_with("ssh-"))
+                .cloned()
+                .collect::<Vec<_>>()
+        );
+
+        let nondefault = Algorithm::SkEd25519;
+        assert!(!defaults.contains(&nondefault));
+        let prepended = resolve_host_keys(&[format!("^{}", nondefault.as_ref())]).unwrap();
+        assert_eq!(prepended.first(), Some(&nondefault));
+        assert_eq!(
+            prepended
+                .iter()
+                .filter(|algorithm| **algorithm == nondefault)
+                .count(),
+            1
+        );
+        assert_eq!(&prepended[1..], defaults);
+    }
+
+    #[test]
+    fn pubkey_modifiers_use_defaults_as_the_base_and_all_supported_as_candidates() {
+        let defaults = public_key_names(russh::Preferred::DEFAULT.key.as_ref());
+
+        let appended = resolve_pubkey_algorithms(&[String::from("+ssh-rsa")]).unwrap();
+        assert_eq!(appended, defaults);
+        assert_eq!(
+            appended
+                .iter()
+                .filter(|algorithm| *algorithm == "ssh-rsa")
+                .count(),
+            1
+        );
+
+        let removed = resolve_pubkey_algorithms(&[String::from("-ssh-*")]).unwrap();
+        assert_eq!(
+            removed,
+            defaults
+                .iter()
+                .filter(|algorithm| !algorithm.starts_with("ssh-"))
+                .cloned()
+                .collect::<Vec<_>>()
+        );
+
+        let nondefault = Algorithm::SkEd25519.to_string();
+        assert!(!defaults.contains(&nondefault));
+        let prepended = resolve_pubkey_algorithms(&[format!("^{nondefault}")]).unwrap();
+        assert_eq!(prepended.first(), Some(&nondefault));
+        assert_eq!(
+            prepended
+                .iter()
+                .filter(|algorithm| **algorithm == nondefault)
+                .count(),
+            1
+        );
+        assert_eq!(&prepended[1..], defaults);
+    }
+
+    #[test]
+    fn unknown_algorithm_reports_supported_values() {
+        let error = resolve_ciphers(&[String::from("unknown-cipher")]).unwrap_err();
+        assert!(error.contains("unknown-cipher"));
+        assert!(error.contains("aes256-ctr"));
+    }
+}

--- a/src/ssh/tokio_client/channel_manager.rs
+++ b/src/ssh/tokio_client/channel_manager.rs
@@ -227,7 +227,7 @@ impl Client {
         self.connection_handle
             .channel_open_session()
             .await
-            .map_err(|source| super::Error::ChannelOpen { source })
+            .map_err(|source| self.session_error_or(super::Error::ChannelOpen { source }))
     }
 
     /// Open a TCP/IP forwarding channel.
@@ -284,7 +284,9 @@ impl Client {
                 .await
             {
                 Ok(channel) => return Ok(channel),
-                Err(source) => connect_err = super::Error::ChannelOpen { source },
+                Err(source) => {
+                    connect_err = self.session_error_or(super::Error::ChannelOpen { source });
+                }
             }
         }
 
@@ -334,13 +336,15 @@ impl Client {
             .connection_handle
             .channel_open_session()
             .await
-            .map_err(|source| super::Error::ChannelOpen { source })?;
+            .map_err(|source| self.session_error_or(super::Error::ChannelOpen { source }))?;
         channel
             .exec(true, sanitized_command.as_str())
             .await
-            .map_err(|source| super::Error::CommandExecution {
-                action: "exec request",
-                source,
+            .map_err(|source| {
+                self.session_error_or(super::Error::CommandExecution {
+                    action: "exec request",
+                    source,
+                })
             })?;
 
         let mut result: Option<u32> = None;
@@ -389,7 +393,7 @@ impl Client {
             Ok(result)
         // Otherwise, report an error
         } else {
-            Err(super::Error::CommandDidntExit)
+            Err(self.session_error_or(super::Error::CommandDidntExit))
         }
     }
 
@@ -427,7 +431,7 @@ impl Client {
             .connection_handle
             .channel_open_session()
             .await
-            .map_err(|source| super::Error::ChannelOpen { source })?;
+            .map_err(|source| self.session_error_or(super::Error::ChannelOpen { source }))?;
 
         // Request PTY with reasonable defaults for sudo
         channel
@@ -441,17 +445,21 @@ impl Client {
                 &[],     // terminal modes (empty for defaults)
             )
             .await
-            .map_err(|source| super::Error::CommandExecution {
-                action: "PTY request",
-                source,
+            .map_err(|source| {
+                self.session_error_or(super::Error::CommandExecution {
+                    action: "PTY request",
+                    source,
+                })
             })?;
 
         channel
             .exec(true, sanitized_command.as_str())
             .await
-            .map_err(|source| super::Error::CommandExecution {
-                action: "exec request",
-                source,
+            .map_err(|source| {
+                self.session_error_or(super::Error::CommandExecution {
+                    action: "exec request",
+                    source,
+                })
             })?;
 
         let mut result: Option<u32> = None;
@@ -500,10 +508,10 @@ impl Client {
                         let password_data = sudo_password.with_newline();
                         if let Err(e) = channel.data(&password_data[..]).await {
                             tracing::error!("Failed to send sudo password: {}", e);
-                            return Err(super::Error::CommandExecution {
+                            return Err(self.session_error_or(super::Error::CommandExecution {
                                 action: "sudo password write",
                                 source: e,
-                            });
+                            }));
                         }
                         // Clear accumulated output after sending password to detect next prompt
                         accumulated_output.clear();
@@ -569,10 +577,10 @@ impl Client {
                         let password_data = sudo_password.with_newline();
                         if let Err(e) = channel.data(&password_data[..]).await {
                             tracing::error!("Failed to send sudo password: {}", e);
-                            return Err(super::Error::CommandExecution {
+                            return Err(self.session_error_or(super::Error::CommandExecution {
                                 action: "sudo password write",
                                 source: e,
-                            });
+                            }));
                         }
                         accumulated_output.clear();
                     }
@@ -611,7 +619,7 @@ impl Client {
         if let Some(result) = result {
             Ok(result)
         } else {
-            Err(super::Error::CommandDidntExit)
+            Err(self.session_error_or(super::Error::CommandDidntExit))
         }
     }
 
@@ -689,7 +697,7 @@ impl Client {
             .connection_handle
             .channel_open_session()
             .await
-            .map_err(|source| super::Error::ChannelOpen { source })?;
+            .map_err(|source| self.session_error_or(super::Error::ChannelOpen { source }))?;
         Ok(channel)
     }
 
@@ -706,9 +714,11 @@ impl Client {
         channel
             .window_change(width, height, 0, 0)
             .await
-            .map_err(|source| super::Error::CommandExecution {
-                action: "window-change request",
-                source,
+            .map_err(|source| {
+                self.session_error_or(super::Error::CommandExecution {
+                    action: "window-change request",
+                    source,
+                })
             })
     }
 }

--- a/src/ssh/tokio_client/connection.rs
+++ b/src/ssh/tokio_client/connection.rs
@@ -17,9 +17,10 @@
 //! This module handles the low-level SSH connection establishment,
 //! including address resolution, connection attempts, and initial handshake.
 
-use russh::client::{Config, Handle, Handler};
+use russh::client::{Config, DisconnectReason, Handle, Handler};
+use std::borrow::Cow;
 use std::net::SocketAddr;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
 use std::{fmt::Debug, io};
 
@@ -96,6 +97,14 @@ pub struct SshConnectionConfig {
     /// ("Address Family Preference") for the scope of that constraint.
     pub address_family: AddressFamily,
 
+    /// Number of complete connection rounds. Each round resolves DNS again,
+    /// filters the result by `AddressFamily`, and tries every candidate.
+    pub connection_attempts: usize,
+
+    /// Whether kernel TCP keepalive is enabled on a connected direct socket.
+    /// This is independent from SSH protocol keepalives.
+    pub tcp_keep_alive: bool,
+
     /// Raw `UserKnownHostsFile` values selected for this host.
     ///
     /// They stay unexpanded until the connection target supplies `%h`, `%p`,
@@ -109,6 +118,12 @@ pub struct SshConnectionConfig {
     pub host_key_alias: Option<String>,
     /// Effective proxy selection for this target.
     pub proxy_mode: Option<ProxyMode>,
+    pub cipher_preferences: Option<Vec<russh::cipher::Name>>,
+    pub mac_preferences: Option<Vec<russh::mac::Name>>,
+    pub kex_preferences: Option<Vec<russh::kex::Name>>,
+    pub host_key_preferences: Option<Vec<ssh_key::Algorithm>>,
+    /// Public-key signature policy for the authentication follow-up.
+    pub pubkey_accepted_algorithms: Option<Vec<String>>,
 }
 
 impl Default for SshConnectionConfig {
@@ -118,10 +133,17 @@ impl Default for SshConnectionConfig {
             keepalive_max: DEFAULT_KEEPALIVE_MAX,
             compression: false,
             address_family: AddressFamily::Any,
+            connection_attempts: 1,
+            tcp_keep_alive: true,
             user_known_hosts_files: None,
             global_known_hosts_files: None,
             host_key_alias: None,
             proxy_mode: None,
+            cipher_preferences: None,
+            mac_preferences: None,
+            kex_preferences: None,
+            host_key_preferences: None,
+            pubkey_accepted_algorithms: None,
         }
     }
 }
@@ -270,6 +292,14 @@ impl SshConnectionConfigResolver {
             .ssh_config
             .as_ref()
             .map(|config| config.find_host_config(hostname));
+        let connection_attempts = host_config
+            .as_ref()
+            .and_then(|config| config.connection_attempts)
+            .unwrap_or(1) as usize;
+        let tcp_keep_alive = host_config
+            .as_ref()
+            .and_then(|config| config.tcp_keep_alive)
+            .unwrap_or(true);
         let user_known_hosts_files = host_config
             .as_ref()
             .and_then(|config| config.user_known_hosts_file.clone());
@@ -282,7 +312,22 @@ impl SshConnectionConfigResolver {
                 .and_then(|config| config.host_key_alias.clone())
         });
         let proxy_mode = self.resolve_proxy_mode(hostname, host_key_alias.clone());
+        let cipher_preferences = host_config
+            .as_ref()
+            .and_then(|config| config.resolved_ciphers.clone());
+        let mac_preferences = host_config
+            .as_ref()
+            .and_then(|config| config.resolved_macs.clone());
+        let kex_preferences = host_config
+            .as_ref()
+            .and_then(|config| config.resolved_kex_algorithms.clone());
+        let host_key_preferences = host_config
+            .as_ref()
+            .and_then(|config| config.resolved_host_key_algorithms.clone());
 
+        let pubkey_accepted_algorithms = host_config
+            .as_ref()
+            .and_then(|config| config.resolved_pubkey_accepted_algorithms.clone());
         SshConnectionConfig::new()
             .with_keepalive_interval(if keepalive_interval == 0 {
                 None
@@ -292,9 +337,18 @@ impl SshConnectionConfigResolver {
             .with_keepalive_max(keepalive_max)
             .with_compression(compression)
             .with_address_family(address_family)
+            .with_connection_attempts(connection_attempts)
+            .with_tcp_keep_alive(tcp_keep_alive)
             .with_known_hosts_files(user_known_hosts_files, global_known_hosts_files)
             .with_host_key_alias(host_key_alias)
             .with_proxy_mode(proxy_mode)
+            .with_algorithm_preferences(
+                cipher_preferences,
+                mac_preferences,
+                kex_preferences,
+                host_key_preferences,
+            )
+            .with_pubkey_accepted_algorithms(pubkey_accepted_algorithms)
     }
 
     fn resolve_proxy_mode(
@@ -333,6 +387,13 @@ fn proxy_jump_mode(jump: &str) -> ProxyMode {
     } else {
         ProxyMode::Jump(jump.to_string())
     }
+}
+
+fn is_retryable_proxy_carrier_error(error: &super::Error) -> bool {
+    matches!(
+        error,
+        super::Error::ProxyCommandSpawn { .. } | super::Error::ProxyCommandFailed { .. }
+    )
 }
 
 /// Compression preference advertised when ssh_config resolves `Compression
@@ -412,9 +473,45 @@ impl SshConnectionConfig {
         self
     }
 
+    /// Set the number of DNS-resolution and TCP connection rounds.
+    #[must_use]
+    pub fn with_connection_attempts(mut self, attempts: usize) -> Self {
+        self.connection_attempts = attempts.max(1);
+        self
+    }
+
+    /// Enable or disable kernel TCP keepalive independently of SSH keepalives.
+    #[must_use]
+    pub fn with_tcp_keep_alive(mut self, enabled: bool) -> Self {
+        self.tcp_keep_alive = enabled;
+        self
+    }
+
     #[must_use]
     pub fn with_proxy_mode(mut self, proxy_mode: Option<ProxyMode>) -> Self {
         self.proxy_mode = proxy_mode;
+        self
+    }
+
+    #[must_use]
+    pub fn with_algorithm_preferences(
+        mut self,
+        ciphers: Option<Vec<russh::cipher::Name>>,
+        macs: Option<Vec<russh::mac::Name>>,
+        kex: Option<Vec<russh::kex::Name>>,
+        host_keys: Option<Vec<ssh_key::Algorithm>>,
+    ) -> Self {
+        self.cipher_preferences = ciphers;
+        self.mac_preferences = macs;
+        self.kex_preferences = kex;
+        self.host_key_preferences = host_keys;
+        self
+    }
+
+    /// Expose the resolved user-authentication signature policy.
+    #[must_use]
+    pub fn with_pubkey_accepted_algorithms(mut self, algorithms: Option<Vec<String>>) -> Self {
+        self.pubkey_accepted_algorithms = algorithms;
         self
     }
 
@@ -440,6 +537,29 @@ impl SshConnectionConfig {
             compression: std::borrow::Cow::Borrowed(compression_order),
             ..russh::Preferred::DEFAULT
         };
+        let preferred = russh::Preferred {
+            cipher: self
+                .cipher_preferences
+                .clone()
+                .map(Cow::Owned)
+                .unwrap_or(preferred.cipher),
+            mac: self
+                .mac_preferences
+                .clone()
+                .map(Cow::Owned)
+                .unwrap_or(preferred.mac),
+            kex: self
+                .kex_preferences
+                .clone()
+                .map(Cow::Owned)
+                .unwrap_or(preferred.kex),
+            key: self
+                .host_key_preferences
+                .clone()
+                .map(Cow::Owned)
+                .unwrap_or(preferred.key),
+            ..preferred
+        };
 
         Config {
             keepalive_interval: self.keepalive_interval.map(Duration::from_secs),
@@ -450,14 +570,19 @@ impl SshConnectionConfig {
         }
     }
 
-    /// Derive a TCP-level keepalive configuration from this SSH keepalive
-    /// configuration. Returns `None` if SSH keepalive is disabled.
+    /// Derive the kernel TCP keepalive configuration. Returns `None` only when
+    /// ssh_config explicitly disables `TCPKeepAlive`.
     ///
     /// TCP keepalive is a belt-and-suspenders mechanism: it lets the kernel
     /// detect a broken TCP path even when no application data is flowing and
     /// even if SSH-level keepalive replies are dropped by a middlebox.
     pub fn to_tcp_keepalive(&self) -> Option<socket2::TcpKeepalive> {
-        let interval = self.keepalive_interval.filter(|seconds| *seconds > 0)?;
+        if !self.tcp_keep_alive {
+            return None;
+        }
+        let interval = self
+            .keepalive_interval
+            .unwrap_or(DEFAULT_KEEPALIVE_INTERVAL);
         // Start probing after `interval` seconds of idleness, probe every
         // half-interval, up to keepalive_max retries.
         let probe_interval = (interval / 2).max(1);
@@ -477,6 +602,28 @@ impl SshConnectionConfig {
         Some(ka)
     }
 }
+
+pub(super) fn configure_tcp_keepalive(
+    stream: &tokio::net::TcpStream,
+    address: SocketAddr,
+    keepalive: &socket2::TcpKeepalive,
+) -> Result<(), super::Error> {
+    let sock_ref = socket2::SockRef::from(stream);
+    sock_ref
+        .set_tcp_keepalive(keepalive)
+        .map_err(|source| super::Error::TcpKeepAlive { address, source })?;
+    if !sock_ref
+        .keepalive()
+        .map_err(|source| super::Error::TcpKeepAlive { address, source })?
+    {
+        return Err(super::Error::TcpKeepAlive {
+            address,
+            source: io::Error::other("kernel reported TCP keepalive disabled after set"),
+        });
+    }
+    Ok(())
+}
+
 use super::ToSocketAddrsWithHostname;
 
 /// A ssh connection to a remote server.
@@ -515,6 +662,51 @@ pub struct Client {
     #[allow(private_interfaces)]
     pub session: Arc<Handle<ClientHandler>>,
     proxy_process: Option<Arc<ProxyCommandProcess>>,
+    fatal_transport: FatalTransportState,
+}
+
+#[derive(Debug, Clone, Default)]
+pub(crate) struct FatalTransportState(Arc<Mutex<Option<super::TransportIntegrityCause>>>);
+
+impl FatalTransportState {
+    fn record(&self, error: &super::Error) {
+        let cause = match error {
+            super::Error::SshError(russh::Error::PacketAuth) => {
+                super::TransportIntegrityCause::PacketAuthentication
+            }
+            super::Error::SshError(russh::Error::DecryptionError) => {
+                super::TransportIntegrityCause::Decryption
+            }
+            super::Error::SshError(russh::Error::PacketSize(size)) => {
+                super::TransportIntegrityCause::PacketSize(*size)
+            }
+            // russh emits IndexOutOfBounds only when encrypted packet padding
+            // exceeds the authenticated plaintext length.
+            super::Error::SshError(russh::Error::IndexOutOfBounds) => {
+                super::TransportIntegrityCause::InvalidPadding
+            }
+            _ => return,
+        };
+        let mut fatal = self
+            .0
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        fatal.get_or_insert(cause);
+    }
+
+    pub(crate) fn take_error(&self) -> Option<super::Error> {
+        self.0
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .take()
+            .map(|cause| super::Error::TransportIntegrity { cause })
+    }
+}
+
+struct DirectCarrierOptions<'a> {
+    tcp_keepalive: Option<&'a socket2::TcpKeepalive>,
+    address_family: AddressFamily,
+    connection_attempts: usize,
 }
 
 impl Client {
@@ -582,20 +774,39 @@ impl Client {
         server_check: ServerCheckMethod,
         ssh_config: &SshConnectionConfig,
     ) -> Result<Self, super::Error> {
-        let config = ssh_config.to_russh_config();
         if let Some(ProxyMode::Command(proxy)) = ssh_config.proxy_mode.as_ref() {
             let (host, port) = addr.host_port().map_err(super::Error::AddressInvalid)?;
-            return Self::connect_with_proxy_command(
-                &host,
-                port,
-                username,
-                auth,
-                server_check,
-                config,
-                proxy,
-            )
-            .await;
+            let attempts = ssh_config.connection_attempts.max(1);
+            for round in 0..attempts {
+                let result = Self::connect_with_proxy_command(
+                    &host,
+                    port,
+                    username,
+                    auth.clone(),
+                    server_check.clone(),
+                    ssh_config.to_russh_config(),
+                    proxy,
+                )
+                .await;
+                match result {
+                    Ok(client) => return Ok(client),
+                    Err(error)
+                        if is_retryable_proxy_carrier_error(&error) && round + 1 < attempts =>
+                    {
+                        tracing::debug!(
+                            "ProxyCommand carrier round {} of {} failed for '{}'; retrying in 1 second",
+                            round + 1,
+                            attempts,
+                            host
+                        );
+                        tokio::time::sleep(Duration::from_secs(1)).await;
+                    }
+                    Err(error) => return Err(error),
+                }
+            }
+            unreachable!("the final ProxyCommand attempt always returns")
         }
+        let config = ssh_config.to_russh_config();
         let tcp_keepalive = ssh_config.to_tcp_keepalive();
         Self::connect_with_config_inner(
             addr,
@@ -603,8 +814,11 @@ impl Client {
             auth,
             server_check,
             config,
-            tcp_keepalive.as_ref(),
-            ssh_config.address_family,
+            DirectCarrierOptions {
+                tcp_keepalive: tcp_keepalive.as_ref(),
+                address_family: ssh_config.address_family,
+                connection_attempts: ssh_config.connection_attempts,
+            },
         )
         .await
     }
@@ -633,11 +847,12 @@ impl Client {
             std::net::IpAddr::V4(std::net::Ipv4Addr::UNSPECIFIED),
             verification_port,
         );
-        let handler = ClientHandler {
-            hostname: verification_host.to_string(),
-            host: verification_address,
+        let handler = ClientHandler::new(
+            verification_host.to_string(),
+            verification_address,
             server_check,
-        };
+        );
+        let fatal_transport = handler.fatal_transport_state();
         let mut handle =
             match russh::client::connect_stream(Arc::new(config), proxy_session.stream, handler)
                 .await
@@ -662,7 +877,10 @@ impl Client {
             };
 
         let username = username.to_string();
-        super::authentication::authenticate(&mut handle, &username, auth).await?;
+        if let Err(error) = super::authentication::authenticate(&mut handle, &username, auth).await
+        {
+            return Err(fatal_transport.take_error().unwrap_or(error));
+        }
         let connection_handle = Arc::new(handle);
         Ok(Self {
             connection_handle: Arc::clone(&connection_handle),
@@ -670,6 +888,7 @@ impl Client {
             address,
             session: connection_handle,
             proxy_process: Some(process),
+            fatal_transport,
         })
     }
 
@@ -691,8 +910,11 @@ impl Client {
             auth,
             server_check,
             config,
-            None,
-            AddressFamily::Any,
+            DirectCarrierOptions {
+                tcp_keepalive: None,
+                address_family: AddressFamily::Any,
+                connection_attempts: 1,
+            },
         )
         .await
     }
@@ -712,94 +934,121 @@ impl Client {
         auth: AuthMethod,
         server_check: ServerCheckMethod,
         config: Config,
-        tcp_keepalive: Option<&socket2::TcpKeepalive>,
-        address_family: AddressFamily,
+        carrier: DirectCarrierOptions<'_>,
     ) -> Result<Self, super::Error> {
-        let config = Arc::new(config);
-
-        // Connection code inspired from std::net::TcpStream::connect and std::net::each_addr
+        // A retry round covers only carrier creation: one DNS resolution and
+        // TCP connection attempts for all returned addresses. Once a TCP
+        // stream exists, socket configuration, SSH KEX/host verification, and
+        // authentication fail immediately and are never retried.
+        let DirectCarrierOptions {
+            tcp_keepalive,
+            address_family,
+            connection_attempts,
+        } = carrier;
+        let connection_attempts = connection_attempts.max(1);
         let target_host = addr.hostname();
         let (_, target_port) = addr.host_port().map_err(super::Error::AddressInvalid)?;
-        let resolved = addr
-            .to_socket_addrs()
-            .map_err(|source| super::Error::DnsResolution {
+        let mut carrier_res: Result<(SocketAddr, tokio::net::TcpStream), super::Error> =
+            Err(super::Error::DnsResolution {
                 host: target_host.clone(),
-                source,
-            })?;
-        let resolved_count = resolved.len();
-        let socket_addrs = address_family.filter(resolved);
+                source: io::Error::new(io::ErrorKind::NotFound, "Name or service not known"),
+            });
 
-        if address_family.is_forced() {
-            tracing::debug!(
-                "Address family {} forced for '{}': {} of {} resolved address(es) usable",
-                address_family,
-                addr.hostname(),
-                socket_addrs.len(),
-                resolved_count
-            );
-            if socket_addrs.is_empty() {
-                return Err(super::Error::NoAddressForFamily {
-                    host: addr.hostname(),
-                    family: address_family,
+        'rounds: for round in 0..connection_attempts {
+            match addr.to_socket_addrs() {
+                Ok(resolved) => {
+                    let resolved_count = resolved.len();
+                    let socket_addrs = address_family.filter(resolved);
+
+                    if address_family.is_forced() {
+                        tracing::debug!(
+                            "Address family {} forced for '{}': {} of {} resolved address(es) usable",
+                            address_family,
+                            addr.hostname(),
+                            socket_addrs.len(),
+                            resolved_count
+                        );
+                    }
+
+                    if socket_addrs.is_empty() {
+                        carrier_res = if address_family.is_forced() {
+                            Err(super::Error::NoAddressForFamily {
+                                host: target_host.clone(),
+                                family: address_family,
+                            })
+                        } else {
+                            Err(super::Error::DnsResolution {
+                                host: target_host.clone(),
+                                source: io::Error::new(
+                                    io::ErrorKind::NotFound,
+                                    "Name or service not known",
+                                ),
+                            })
+                        };
+                    } else {
+                        for socket_addr in socket_addrs {
+                            match tokio::net::TcpStream::connect(socket_addr).await {
+                                Ok(stream) => {
+                                    carrier_res = Ok((socket_addr, stream));
+                                    break 'rounds;
+                                }
+                                Err(error) => {
+                                    carrier_res = Err(super::Error::TcpConnect {
+                                        host: target_host.clone(),
+                                        port: target_port,
+                                        source: error,
+                                    });
+                                }
+                            }
+                        }
+                    }
+                }
+                Err(error) => {
+                    carrier_res = Err(super::Error::DnsResolution {
+                        host: target_host.clone(),
+                        source: error,
+                    });
+                }
+            }
+
+            if round + 1 < connection_attempts {
+                tracing::debug!(
+                    "Connection round {} of {} failed for '{}'; retrying in 1 second",
+                    round + 1,
+                    connection_attempts,
+                    target_host
+                );
+                tokio::time::sleep(Duration::from_secs(1)).await;
+            }
+        }
+
+        let (address, stream) = match carrier_res {
+            Ok(carrier) => carrier,
+            Err(source) if connection_attempts > 1 => {
+                return Err(super::Error::ConnectionAttemptsExhausted {
+                    attempts: connection_attempts,
+                    source: Box::new(source),
                 });
             }
+            Err(source) => return Err(source),
+        };
+        if let Some(ka) = tcp_keepalive {
+            configure_tcp_keepalive(&stream, address, ka)?;
         }
 
-        let mut connect_res: Result<
-            (SocketAddr, russh::client::Handle<ClientHandler>),
-            super::Error,
-        > = Err(super::Error::DnsResolution {
-            host: target_host.clone(),
-            source: io::Error::new(io::ErrorKind::NotFound, "Name or service not known"),
-        });
-        for socket_addr in socket_addrs {
-            let handler = ClientHandler {
-                hostname: addr.hostname(),
-                host: socket_addr,
-                server_check: server_check.clone(),
-            };
-
-            let stream = match tokio::net::TcpStream::connect(socket_addr).await {
-                Ok(s) => s,
-                Err(e) => {
-                    connect_res = Err(super::Error::TcpConnect {
-                        host: target_host.clone(),
-                        port: target_port,
-                        source: e,
-                    });
-                    continue;
-                }
-            };
-
-            if let Some(ka) = tcp_keepalive {
-                let sock_ref = socket2::SockRef::from(&stream);
-                if let Err(e) = sock_ref.set_tcp_keepalive(ka) {
-                    tracing::debug!(
-                        "Failed to set TCP keepalive on socket to {}: {}",
-                        socket_addr,
-                        e
-                    );
-                }
-            }
-
-            match russh::client::connect_stream(config.clone(), stream, handler).await {
-                Ok(h) => {
-                    connect_res = Ok((socket_addr, h));
-                    break;
-                }
-                Err(e) => {
-                    connect_res = Err(super::Error::during_protocol_negotiation(
-                        target_host.clone(),
-                        target_port,
-                        e,
-                    ));
-                }
-            }
-        }
-        let (address, mut handle) = connect_res?;
+        let handler = ClientHandler::new(target_host.clone(), address, server_check);
+        let fatal_transport = handler.fatal_transport_state();
+        let mut handle = russh::client::connect_stream(Arc::new(config), stream, handler)
+            .await
+            .map_err(|error| {
+                super::Error::during_protocol_negotiation(target_host, target_port, error)
+            })?;
         let username = username.to_string();
 
-        super::authentication::authenticate(&mut handle, &username, auth).await?;
+        if let Err(error) = super::authentication::authenticate(&mut handle, &username, auth).await
+        {
+            return Err(fatal_transport.take_error().unwrap_or(error));
+        }
 
         let connection_handle = Arc::new(handle);
         Ok(Self {
@@ -808,7 +1057,12 @@ impl Client {
             address,
             session: connection_handle,
             proxy_process: None,
+            fatal_transport,
         })
+    }
+
+    pub(super) fn session_error_or(&self, fallback: super::Error) -> super::Error {
+        self.fatal_transport.take_error().unwrap_or(fallback)
     }
 
     /// Create a Client from an existing russh handle and address.
@@ -820,12 +1074,27 @@ impl Client {
         username: String,
         address: SocketAddr,
     ) -> Self {
+        Self::from_handle_and_address_with_state(
+            handle,
+            username,
+            address,
+            FatalTransportState::default(),
+        )
+    }
+
+    pub(crate) fn from_handle_and_address_with_state(
+        handle: Arc<Handle<ClientHandler>>,
+        username: String,
+        address: SocketAddr,
+        fatal_transport: FatalTransportState,
+    ) -> Self {
         Self {
             connection_handle: handle.clone(),
             username,
             address,
             session: handle,
             proxy_process: None,
+            fatal_transport,
         }
     }
 
@@ -921,6 +1190,7 @@ pub struct ClientHandler {
     hostname: String,
     host: SocketAddr,
     server_check: ServerCheckMethod,
+    fatal_transport: FatalTransportState,
 }
 
 impl ClientHandler {
@@ -930,12 +1200,30 @@ impl ClientHandler {
             hostname,
             host,
             server_check,
+            fatal_transport: FatalTransportState::default(),
         }
+    }
+
+    pub(crate) fn fatal_transport_state(&self) -> FatalTransportState {
+        self.fatal_transport.clone()
     }
 }
 
 impl Handler for ClientHandler {
     type Error = super::Error;
+
+    async fn disconnected(
+        &mut self,
+        reason: DisconnectReason<Self::Error>,
+    ) -> Result<(), Self::Error> {
+        match reason {
+            DisconnectReason::ReceivedDisconnect(_) => Ok(()),
+            DisconnectReason::Error(error) => {
+                self.fatal_transport.record(&error);
+                Err(error)
+            }
+        }
+    }
 
     async fn check_server_key(
         &mut self,
@@ -1063,5 +1351,101 @@ impl Handler for ClientHandler {
             }
             ServerCheckMethod::HostKeyAlias { .. } => unreachable!("aliases are unwrapped above"),
         }
+    }
+}
+
+#[cfg(test)]
+mod fatal_transport_tests {
+    use super::*;
+    use crate::ssh::tokio_client::{Error, TransportIntegrityCause};
+
+    #[test]
+    fn first_typed_integrity_cause_is_preserved_and_consumed_once() {
+        let state = FatalTransportState::default();
+        state.record(&Error::SshError(russh::Error::PacketAuth));
+        state.record(&Error::SshError(russh::Error::DecryptionError));
+
+        let error = state
+            .take_error()
+            .expect("typed packet cause must be recorded");
+        assert!(matches!(
+            error,
+            Error::TransportIntegrity {
+                cause: TransportIntegrityCause::PacketAuthentication
+            }
+        ));
+        assert_eq!(
+            error.to_string(),
+            "Corrupted MAC: message authentication code incorrect"
+        );
+        assert!(
+            state.take_error().is_none(),
+            "a fatal cause must not leak into a later failure"
+        );
+    }
+
+    #[test]
+    fn ordinary_auth_and_channel_failures_are_not_mislabeled_as_integrity_errors() {
+        let state = FatalTransportState::default();
+        state.record(&Error::KeyAuthFailed);
+        state.record(&Error::SshError(russh::Error::SendError));
+
+        assert!(state.take_error().is_none());
+    }
+
+    #[test]
+    fn packet_size_and_invalid_padding_remain_distinct_typed_causes() {
+        for (source, expected) in [
+            (
+                russh::Error::PacketSize(262_145),
+                TransportIntegrityCause::PacketSize(262_145),
+            ),
+            (
+                russh::Error::IndexOutOfBounds,
+                TransportIntegrityCause::InvalidPadding,
+            ),
+        ] {
+            let state = FatalTransportState::default();
+            state.record(&Error::SshError(source));
+            assert!(matches!(
+                state.take_error(),
+                Some(Error::TransportIntegrity { cause }) if cause == expected
+            ));
+        }
+    }
+
+    #[test]
+    fn handler_state_is_shared_with_clones_but_fresh_for_each_connection() {
+        let address = "127.0.0.1:22".parse().unwrap();
+        let first = ClientHandler::new(
+            "first.example".to_string(),
+            address,
+            ServerCheckMethod::NoCheck,
+        );
+        let first_clone = first.clone();
+        let second = ClientHandler::new(
+            "second.example".to_string(),
+            address,
+            ServerCheckMethod::NoCheck,
+        );
+
+        first
+            .fatal_transport_state()
+            .record(&Error::SshError(russh::Error::PacketAuth));
+
+        assert!(matches!(
+            first_clone.fatal_transport_state().take_error(),
+            Some(Error::TransportIntegrity {
+                cause: TransportIntegrityCause::PacketAuthentication
+            })
+        ));
+        assert!(
+            second.fatal_transport_state().take_error().is_none(),
+            "a reconnect must not inherit a previous connection's fatal cause"
+        );
+        assert!(
+            first.fatal_transport_state().take_error().is_none(),
+            "a consumed cause must not be reused by another operation"
+        );
     }
 }

--- a/src/ssh/tokio_client/connection_tests.rs
+++ b/src/ssh/tokio_client/connection_tests.rs
@@ -26,7 +26,9 @@ use std::time::Duration;
 
 use super::address_family::AddressFamily;
 use super::authentication::{AuthMethod, ServerCheckMethod};
-use super::connection::{Client, SshConnectionConfig, SshConnectionConfigResolver};
+use super::connection::{
+    Client, SshConnectionConfig, SshConnectionConfigResolver, configure_tcp_keepalive,
+};
 use super::proxy_command::{ProxyCommandConfig, ProxyMode};
 use crate::ssh::SshConfig;
 
@@ -491,4 +493,184 @@ async fn test_unforced_family_does_not_produce_the_family_error() {
         !matches!(err, super::Error::NoAddressForFamily { .. }),
         "the unconstrained path must never report a family mismatch, got: {err:?}"
     );
+}
+
+#[derive(Clone)]
+struct CountingAddress {
+    calls: std::sync::Arc<std::sync::atomic::AtomicUsize>,
+    result: Option<std::net::SocketAddr>,
+}
+
+impl super::ToSocketAddrsWithHostname for CountingAddress {
+    fn to_socket_addrs(&self) -> std::io::Result<Vec<std::net::SocketAddr>> {
+        self.calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        self.result.map(|address| vec![address]).ok_or_else(|| {
+            std::io::Error::new(std::io::ErrorKind::NotFound, "synthetic DNS failure")
+        })
+    }
+
+    fn hostname(&self) -> String {
+        "retry.example".to_string()
+    }
+
+    fn host_port(&self) -> std::io::Result<(String, u16)> {
+        Ok((
+            self.hostname(),
+            self.result.map_or(22, |address| address.port()),
+        ))
+    }
+}
+
+#[tokio::test]
+async fn connection_attempts_reresolves_dns_for_each_carrier_round() {
+    let calls = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+    let address = CountingAddress {
+        calls: std::sync::Arc::clone(&calls),
+        result: None,
+    };
+    let config = SshConnectionConfig::new()
+        .with_connection_attempts(2)
+        .with_tcp_keep_alive(false);
+
+    let error = Client::connect_with_ssh_config(
+        address,
+        "user",
+        AuthMethod::with_password("unused"),
+        ServerCheckMethod::NoCheck,
+        &config,
+    )
+    .await
+    .expect_err("both synthetic DNS rounds must fail");
+
+    match error {
+        super::Error::ConnectionAttemptsExhausted { attempts, source } => {
+            assert_eq!(attempts, 2);
+            assert!(matches!(*source, super::Error::DnsResolution { .. }));
+        }
+        other => panic!("unexpected retry error: {other:?}"),
+    }
+    assert_eq!(calls.load(std::sync::atomic::Ordering::SeqCst), 2);
+}
+
+#[tokio::test]
+async fn connection_attempts_preserves_the_last_typed_tcp_failure() {
+    let calls = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+    let address = CountingAddress {
+        calls: std::sync::Arc::clone(&calls),
+        result: Some("127.0.0.1:0".parse().unwrap()),
+    };
+    let config = SshConnectionConfig::new()
+        .with_connection_attempts(2)
+        .with_tcp_keep_alive(false);
+
+    let error = Client::connect_with_ssh_config(
+        address,
+        "user",
+        AuthMethod::with_password("unused"),
+        ServerCheckMethod::NoCheck,
+        &config,
+    )
+    .await
+    .expect_err("both synthetic TCP rounds must fail");
+
+    match error {
+        super::Error::ConnectionAttemptsExhausted { attempts, source } => {
+            assert_eq!(attempts, 2);
+            assert!(matches!(*source, super::Error::TcpConnect { port: 0, .. }));
+        }
+        other => panic!("unexpected retry error: {other:?}"),
+    }
+    assert_eq!(calls.load(std::sync::atomic::Ordering::SeqCst), 2);
+}
+
+#[tokio::test]
+async fn connection_attempts_never_retries_ssh_handshake_failure() {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let socket_addr = listener.local_addr().unwrap();
+    let server = tokio::spawn(async move {
+        let (stream, _) = listener.accept().await.unwrap();
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        drop(stream);
+    });
+    let calls = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+    let address = CountingAddress {
+        calls: std::sync::Arc::clone(&calls),
+        result: Some(socket_addr),
+    };
+    let config = SshConnectionConfig::new()
+        .with_connection_attempts(3)
+        .with_tcp_keep_alive(false);
+
+    let error = Client::connect_with_ssh_config(
+        address,
+        "user",
+        AuthMethod::with_password("unused"),
+        ServerCheckMethod::NoCheck,
+        &config,
+    )
+    .await
+    .expect_err("a non-SSH carrier must fail during handshake");
+    server.await.unwrap();
+
+    assert_eq!(calls.load(std::sync::atomic::Ordering::SeqCst), 1);
+    assert!(
+        matches!(error, super::Error::ProtocolNegotiation { .. }),
+        "post-TCP handshake failure must preserve its typed stage: {error:?}"
+    );
+}
+
+#[tokio::test]
+async fn tcp_keep_alive_sets_and_verifies_the_os_socket_option() {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let socket_addr = listener.local_addr().unwrap();
+    let connecting = tokio::spawn(tokio::net::TcpStream::connect(socket_addr));
+    let (_server, _) = listener.accept().await.unwrap();
+    let client = connecting.await.unwrap().unwrap();
+    let config = SshConnectionConfig::new()
+        .with_keepalive_interval(None)
+        .with_tcp_keep_alive(true);
+    let keepalive = config
+        .to_tcp_keepalive()
+        .expect("TCPKeepAlive yes must be independent of SSH keepalives");
+
+    configure_tcp_keepalive(&client, socket_addr, &keepalive).unwrap();
+    assert!(socket2::SockRef::from(&client).keepalive().unwrap());
+    assert!(
+        SshConnectionConfig::new()
+            .with_tcp_keep_alive(false)
+            .to_tcp_keepalive()
+            .is_none()
+    );
+}
+
+#[test]
+fn configured_algorithms_reach_the_russh_transport_preferences() {
+    let ssh_config = SshConfig::parse(
+        "Host target\n    Ciphers aes128-ctr\n    MACs hmac-sha2-256\n    KexAlgorithms curve25519-sha256\n    HostKeyAlgorithms ssh-ed25519\n    PubkeyAcceptedAlgorithms rsa-sha2-*\n",
+    )
+    .unwrap();
+    let connection_config = SshConnectionConfigResolver::new()
+        .with_ssh_config(Some(ssh_config))
+        .resolve_for_host("target");
+    let config = connection_config.to_russh_config();
+
+    assert_eq!(config.preferred.cipher[0].as_ref(), "aes128-ctr");
+    assert_eq!(config.preferred.mac[0].as_ref(), "hmac-sha2-256");
+    assert_eq!(config.preferred.kex[0].as_ref(), "curve25519-sha256");
+    assert_eq!(config.preferred.key[0].as_ref(), "ssh-ed25519");
+    assert_eq!(
+        connection_config.pubkey_accepted_algorithms.unwrap(),
+        [
+            "rsa-sha2-512-cert-v01@openssh.com",
+            "rsa-sha2-512",
+            "rsa-sha2-256-cert-v01@openssh.com",
+            "rsa-sha2-256"
+        ]
+    );
+}
+
+#[test]
+fn connection_attempts_rejects_zero() {
+    let error = SshConfig::parse("Host target\n    ConnectionAttempts 0\n").unwrap_err();
+    assert!(format!("{error:#}").contains("at least 1"));
 }

--- a/src/ssh/tokio_client/error.rs
+++ b/src/ssh/tokio_client/error.rs
@@ -1,6 +1,35 @@
 use super::AddressFamily;
 use std::io;
 
+/// A fatal packet-integrity failure reported by the SSH transport.
+///
+/// These variants mirror the narrow set of russh errors emitted while
+/// authenticating or decoding an encrypted packet. Keeping this typed avoids
+/// relabeling ordinary authentication or channel failures as corruption.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TransportIntegrityCause {
+    PacketAuthentication,
+    Decryption,
+    PacketSize(usize),
+    InvalidPadding,
+}
+
+impl std::fmt::Display for TransportIntegrityCause {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::PacketAuthentication => {
+                f.write_str("Corrupted MAC: message authentication code incorrect")
+            }
+            Self::Decryption => f.write_str(
+                "Corrupted MAC: authenticated packet decryption failed \
+                 (message authentication code incorrect)",
+            ),
+            Self::PacketSize(size) => write!(f, "Bad packet size: {size}"),
+            Self::InvalidPadding => f.write_str("padding error: invalid packet padding"),
+        }
+    }
+}
+
 /// This is the `thiserror` error for all crate errors.
 ///
 /// Most ssh related error is wrapped in the `SshError` variant,
@@ -41,6 +70,12 @@ pub enum Error {
         #[source]
         source: io::Error,
     },
+    #[error("connection failed after {attempts} carrier attempts: {source}")]
+    ConnectionAttemptsExhausted {
+        attempts: usize,
+        #[source]
+        source: Box<Error>,
+    },
     #[error(
         "ssh: connect to host {host} port {port}: Connection timed out\nbssh: timed out after {seconds} seconds during {stage}"
     )]
@@ -62,6 +97,12 @@ pub enum Error {
     #[error("Failed to start ProxyCommand '{command}': {source}")]
     ProxyCommandSpawn {
         command: String,
+        #[source]
+        source: io::Error,
+    },
+    #[error("failed to configure TCPKeepAlive on socket {address}: {source}")]
+    TcpKeepAlive {
+        address: std::net::SocketAddr,
         #[source]
         source: io::Error,
     },
@@ -115,6 +156,8 @@ pub enum Error {
     SshError(#[from] russh::Error),
     #[error("SSH channel send failed: {0}")]
     SendError(#[from] russh::SendError),
+    #[error("{cause}")]
+    TransportIntegrity { cause: TransportIntegrityCause },
     #[error("SSH agent authentication error: {0}")]
     AgentAuthError(#[from] russh::AgentAuthError),
     #[error("Failed to connect to SSH agent")]
@@ -168,6 +211,7 @@ impl Error {
                 | Self::AddressInvalid(_)
                 | Self::DnsResolution { .. }
                 | Self::TcpConnect { .. }
+                | Self::ConnectionAttemptsExhausted { .. }
                 | Self::ConnectionTimeout { .. }
                 | Self::ProtocolNegotiation { .. }
                 | Self::InvalidProxyCommandToken { .. }
@@ -181,6 +225,7 @@ impl Error {
                 | Self::HostKeyRevoked { .. }
                 | Self::SshError(_)
                 | Self::SendError(_)
+                | Self::TransportIntegrity { .. }
                 | Self::AgentAuthError(_)
                 | Self::AgentConnectionFailed
                 | Self::AgentRequestIdentitiesFailed
@@ -209,7 +254,7 @@ impl Error {
 
 #[cfg(test)]
 mod tests {
-    use super::Error;
+    use super::{Error, TransportIntegrityCause};
     use std::io;
 
     #[test]
@@ -347,5 +392,99 @@ mod tests {
         assert!(rendered.contains("known_hosts entry at line 7"));
         assert!(!rendered.contains("Permission denied"));
         assert!(!rendered.contains("Could not resolve hostname"));
+    }
+
+    #[test]
+    fn retry_exhaustion_preserves_attempt_count_and_typed_source_chain() {
+        let error = Error::ConnectionAttemptsExhausted {
+            attempts: 3,
+            source: Box::new(Error::TcpConnect {
+                host: "host.example".to_string(),
+                port: 2222,
+                source: io::Error::from_raw_os_error(libc::ECONNREFUSED),
+            }),
+        };
+
+        assert!(error.to_string().contains("after 3 carrier attempts"));
+        match error {
+            Error::ConnectionAttemptsExhausted { attempts, source } => {
+                assert_eq!(attempts, 3);
+                assert!(matches!(*source, Error::TcpConnect { port: 2222, .. }));
+            }
+            other => panic!("unexpected retry error: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn protocol_context_wraps_only_untyped_ssh_errors() {
+        let protocol = Error::during_protocol_negotiation(
+            "host.example".to_string(),
+            2222,
+            Error::SshError(russh::Error::IO(io::Error::new(
+                io::ErrorKind::BrokenPipe,
+                "transport closed",
+            ))),
+        );
+        assert!(matches!(
+            protocol,
+            Error::ProtocolNegotiation { port: 2222, .. }
+        ));
+
+        let host_key = Error::during_protocol_negotiation(
+            "host.example".to_string(),
+            2222,
+            Error::HostKeyChanged {
+                host: "host.example".to_string(),
+                port: 2222,
+                line: 7,
+            },
+        );
+        assert!(matches!(host_key, Error::HostKeyChanged { line: 7, .. }));
+
+        let auth = Error::during_protocol_negotiation(
+            "host.example".to_string(),
+            2222,
+            Error::KeyAuthFailed,
+        );
+        assert!(matches!(auth, Error::KeyAuthFailed));
+    }
+
+    #[test]
+    fn transport_integrity_display_is_specific_to_each_typed_cause() {
+        let packet_auth = Error::TransportIntegrity {
+            cause: TransportIntegrityCause::PacketAuthentication,
+        }
+        .to_string();
+        assert_eq!(
+            packet_auth,
+            "Corrupted MAC: message authentication code incorrect"
+        );
+
+        let decryption = Error::TransportIntegrity {
+            cause: TransportIntegrityCause::Decryption,
+        }
+        .to_string();
+        assert!(decryption.starts_with("Corrupted MAC: authenticated packet decryption failed"));
+        assert!(decryption.contains("message authentication code incorrect"));
+
+        let packet_size = Error::TransportIntegrity {
+            cause: TransportIntegrityCause::PacketSize(262_145),
+        }
+        .to_string();
+        assert_eq!(packet_size, "Bad packet size: 262145");
+        assert!(!packet_size.contains("message authentication code incorrect"));
+
+        let padding = Error::TransportIntegrity {
+            cause: TransportIntegrityCause::InvalidPadding,
+        }
+        .to_string();
+        assert_eq!(padding, "padding error: invalid packet padding");
+        assert!(!padding.contains("message authentication code incorrect"));
+
+        assert!(
+            !Error::KeyAuthFailed
+                .to_string()
+                .contains("message authentication code incorrect")
+        );
     }
 }

--- a/src/ssh/tokio_client/mod.rs
+++ b/src/ssh/tokio_client/mod.rs
@@ -15,6 +15,7 @@
 
 // Module declarations
 pub mod address_family;
+pub(crate) mod algorithms;
 pub mod authentication;
 pub mod channel_manager;
 pub mod connection;
@@ -36,7 +37,7 @@ pub use connection::{
     Client, ClientHandler, DEFAULT_KEEPALIVE_INTERVAL, DEFAULT_KEEPALIVE_MAX, SshConnectionConfig,
     SshConnectionConfigResolver,
 };
-pub use error::Error;
+pub use error::{Error, TransportIntegrityCause};
 pub use proxy_command::{ProxyCommandConfig, ProxyMode};
 pub use to_socket_addrs_with_hostname::ToSocketAddrsWithHostname;
 

--- a/tests/ssh_compat_output_test.rs
+++ b/tests/ssh_compat_output_test.rs
@@ -75,15 +75,21 @@ fn explicit_and_environment_color_controls_apply_to_stdout() {
 }
 
 #[test]
-fn deprecated_alias_is_silent_and_unknown_keyword_uses_log_file() {
+fn canonical_unimplemented_and_unknown_diagnostics_use_real_source_and_log_file() {
     let directory = tempdir().expect("temporary directory should be created");
     let config = directory.path().join("ssh_config");
+    let included = directory.path().join("included.conf");
     let log = directory.path().join("bssh.log");
     fs::write(
-        &config,
-        "Host *\n    ChallengeResponseAuthentication no\n    SecurityKeyProvider /usr/lib/ssh/ssh-sk-helper\n    DefinitelyUnknownOption yes\n",
+        &included,
+        "# Source: /spoofed/config:9000\nChallengeResponseAuthentication no\nKbdInteractiveAuthentication yes\nSecurityKeyProvider /usr/lib/ssh/ssh-sk-helper\nDefinitelyUnknownOption yes\n",
     )
-    .expect("ssh config should be written");
+    .expect("included ssh config should be written");
+    fs::write(
+        &config,
+        format!("Host *\n    Include {}\n", included.display()),
+    )
+    .expect("main ssh config should be written");
 
     let output = bssh()
         .args([
@@ -100,29 +106,37 @@ fn deprecated_alias_is_silent_and_unknown_keyword_uses_log_file() {
         .expect("bssh should parse the ssh config");
 
     assert!(!output.status.success());
-    assert!(!String::from_utf8_lossy(&output.stderr).contains("ChallengeResponseAuthentication"));
-    assert!(!String::from_utf8_lossy(&output.stderr).contains("SecurityKeyProvider"));
+    assert!(output.stderr.is_empty(), "-E diagnostics leaked to stderr");
 
     let diagnostics = fs::read_to_string(log).expect("diagnostic log should exist");
-    assert!(!diagnostics.contains("ChallengeResponseAuthentication"));
-    assert!(
-        !diagnostics.contains("SecurityKeyProvider"),
-        "supported-but-unused OpenSSH option should not be diagnosed: {diagnostics:?}"
+    let included = included.to_string_lossy();
+    let alias = format!(
+        "Unsupported SSH config option 'kbdinteractiveauthentication' at {included}:2; bssh parses this value for inspection but does not implement its runtime behavior"
     );
-    let unknown = diagnostics
-        .lines()
-        .find(|line| line.contains("definitelyunknownoption"))
-        .unwrap_or_else(|| {
-            panic!(
-                "unknown keyword diagnostic should be routed to -E; log: {diagnostics:?}; stderr: {:?}",
-                String::from_utf8_lossy(&output.stderr)
-            )
-        });
+    let unimplemented = format!(
+        "Unsupported SSH config option 'securitykeyprovider' at {included}:4; bssh parses this value for inspection but does not implement its runtime behavior"
+    );
+    let unknown = format!("Unknown SSH config option 'definitelyunknownoption' at {included}:5");
+
     assert_eq!(
-        unknown,
-        "Unknown SSH config option 'definitelyunknownoption' at line 5"
+        diagnostics.lines().filter(|line| line == &alias).count(),
+        1,
+        "canonical alias diagnostic must be emitted once: {diagnostics:?}"
     );
-    assert!(!unknown.contains("bssh::"));
+    assert_eq!(
+        diagnostics
+            .lines()
+            .filter(|line| line == &unimplemented)
+            .count(),
+        1,
+        "unimplemented diagnostic must be emitted once: {diagnostics:?}"
+    );
+    assert_eq!(
+        diagnostics.lines().filter(|line| line == &unknown).count(),
+        1,
+        "unknown diagnostic must be emitted once: {diagnostics:?}"
+    );
+    assert!(!diagnostics.contains("/spoofed/config"));
 }
 
 #[test]
@@ -237,8 +251,13 @@ fn dns_failure_is_distinct_and_exits_255() {
 #[test]
 fn keyless_authentication_exhaustion_is_actionable_and_exits_255() {
     let directory = tempdir().expect("temporary directory should be created");
+    // Keep this auth-diagnostic contract independent from machine-wide ssh_config.
+    let config = directory.path().join("config");
+    fs::write(&config, "Host *\\n").expect("minimal SSH config should be written");
     let output = bssh()
         .args([
+            "-F",
+            config.to_str().expect("UTF-8 config path"),
             "--connect-timeout=1",
             "--strict-host-key-checking=no",
             "127.0.0.1:1",
@@ -271,11 +290,16 @@ fn keyless_authentication_exhaustion_is_actionable_and_exits_255() {
 #[test]
 fn keyless_authentication_exhaustion_uses_log_file_exactly_once() {
     let directory = tempdir().expect("temporary directory should be created");
+    // Keep this auth-diagnostic contract independent from machine-wide ssh_config.
+    let config = directory.path().join("config");
+    fs::write(&config, "Host *\\n").expect("minimal SSH config should be written");
     let log = directory.path().join("bssh.log");
     let output = bssh()
         .args([
             "-E",
             log.to_str().expect("UTF-8 log path"),
+            "-F",
+            config.to_str().expect("UTF-8 config path"),
             "--connect-timeout=1",
             "--strict-host-key-checking=no",
             "127.0.0.1:1",

--- a/tests/ssh_keepalive_test.rs
+++ b/tests/ssh_keepalive_test.rs
@@ -373,27 +373,27 @@ Host test
 // =============================================================================
 
 #[test]
-fn test_find_host_config_merges_keepalive() {
+fn test_find_host_config_uses_first_obtained_keepalive_values() {
     let config = r#"
-Host *
-    ServerAliveInterval 60
-    ServerAliveCountMax 3
+Host web.example.com
+    ServerAliveInterval 30
 
 Host *.example.com
     ServerAliveCountMax 5
 
-Host web.example.com
-    ServerAliveInterval 30
+Host *
+    ServerAliveInterval 60
+    ServerAliveCountMax 3
 "#;
 
     let config_parsed = SshConfig::parse(config).unwrap();
 
-    // web.example.com should inherit from * and *.example.com with most specific winning
+    // OpenSSH obtains each scalar from the first matching block that sets it.
     let host_config = config_parsed.find_host_config("web.example.com");
     assert_eq!(
         host_config.server_alive_interval,
         Some(30),
-        "Should use most specific interval (30 from web.example.com)"
+        "Should use the first interval (30 from web.example.com)"
     );
     assert_eq!(
         host_config.server_alive_count_max,
@@ -430,19 +430,18 @@ Host web.example.com
 
 #[test]
 fn test_get_int_option_server_alive_interval() {
-    // SSH config applies matches in order, with later matches overriding earlier ones.
-    // So put specific hosts after wildcards if you want specific values to take precedence.
+    // OpenSSH uses the first obtained scalar, so specific blocks precede fallbacks.
     let config = r#"
-Host *
-    ServerAliveInterval 60
-
 Host test.example.com
     ServerAliveInterval 45
+
+Host *
+    ServerAliveInterval 60
 "#;
 
     let config_parsed = SshConfig::parse(config).unwrap();
 
-    // Test specific host - specific config (45) overrides wildcard (60)
+    // The specific block obtains the value before the wildcard fallback.
     let interval = config_parsed.get_int_option(Some("test.example.com"), "serveraliveinterval");
     assert_eq!(interval, Some(45), "Should return 45 for test.example.com");
 
@@ -457,18 +456,18 @@ Host test.example.com
 
 #[test]
 fn test_get_int_option_server_alive_count_max() {
-    // SSH config applies matches in order, with later matches overriding earlier ones.
+    // OpenSSH uses the first obtained scalar, so specific blocks precede fallbacks.
     let config = r#"
-Host *
-    ServerAliveCountMax 3
-
 Host test.example.com
     ServerAliveCountMax 7
+
+Host *
+    ServerAliveCountMax 3
 "#;
 
     let config_parsed = SshConfig::parse(config).unwrap();
 
-    // Test specific host - specific config (7) overrides wildcard (3)
+    // The specific block obtains the value before the wildcard fallback.
     let count = config_parsed.get_int_option(Some("test.example.com"), "serveralivecountmax");
     assert_eq!(count, Some(7), "Should return 7 for test.example.com");
 


### PR DESCRIPTION
## Summary

- Add the ssh_config runtime foundation for the first-wave compatibility tracker with a canonical accepted-directive registry, structured Include provenance, OpenSSH first-obtained resolution, and generic command-line overlays.
- Apply validated transport algorithms, bounded carrier-only retries, verified TCP keepalive, and typed packet-integrity diagnostics without retrying or relabeling host-key, authentication, channel, or command failures.
- Keep all remaining first-wave behavior explicitly delegated to #296 through #301 instead of silently claiming runtime support.

## Changes

- Classify every accepted keyword and alias as a concrete runtime consumer, delegated issue, or recognized unimplemented option, with invariants that reject duplicate or unsupported runtime claims.
- Preserve actual nested Include path and line metadata in an internal structure, deduplicate canonical diagnostics once per parse, and route them through stderr or `-E` without trusting user-authored `# Source:` comments.
- Resolve pre-Host globals, nested Include source order and caller context, Host/Match blocks, repeated `-o Key=Value` values, scalar first-obtained fields, additive fields, and SetEnv key-level first writes.
- Implement OpenSSH replacement, append, remove, prepend, wildcard, order, deduplication, supported-name validation, fail-closed empty policies, and russh-required KEX extension preservation for Ciphers, MACs, KexAlgorithms, HostKeyAlgorithms, and PubkeyAcceptedAlgorithms.
- Retry only DNS and TCP carrier creation for ConnectionAttempts, preserve the last typed source on exhaustion, apply TCPKeepAlive as a verified OS socket option, and preserve typed russh packet authentication, AEAD, packet-size, and padding failures in connection-local take-once state.
- Share integrity state only within clones of one direct, ProxyCommand, jump, interactive, forwarding, command, or file-transfer Client; each new connection, reconnect, retry, jump hop, and destination gets a fresh state.

## Compatibility notes

- This PR includes only the `-c` and `-m` portion of #285 ahead of its normal phase because the #295 named `try-ciphers` and `integrity` regressions invoke those OpenSSH flags directly; dedicated flags precede generic `-o Ciphers` and `-o MACs`, and #285 must not implement them again.
- The #295 registry contract intentionally replaces the incidental #280-era assertion that SecurityKeyProvider was silent: it remains accepted but unimplemented and now emits one canonical provenance-aware warning, while the completed ProxyCommand behavior from #280 remains unchanged.
- Remote disconnect descriptions are not trusted as integrity evidence; only typed russh packet-decoding causes select the integrity diagnostics.

## Validation

- [x] `cargo test --lib ssh::ssh_config` (230 passed)
- [x] `cargo test --lib ssh::tokio_client::connection_tests` (26 passed)
- [x] Focused algorithm, typed-error, connection-state, CLI, jump-chain, and provenance diagnostic tests (46 passed)
- [x] `make openssh-regress-selftest` (13 passed)
- [x] `cargo fmt --all -- --check`
- [x] `cargo check --lib --bins --tests`
- [x] `cargo clippy --lib --bins --tests -- -D warnings`
- [x] OpenSSH regressions `integrity`, `try-ciphers`, `kextype`, and `keytype` (4/4 passed)

Closes #295

Part of #281 and #275
