### PR TITLE
feat(ssh): apply live session policy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -428,6 +428,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "serial_test",
+ "sha1",
  "shell-words",
  "signal-hook 0.4.4",
  "smallvec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,7 @@ dirs = "6.0"
 chrono = { version = "0.4.44", features = ["serde"] }
 glob = "0.3.3"
 whoami = "2.1.1"
+sha1 = "0.11.0"
 owo-colors = "4.3.0"
 unicode-width = "0.2.2"
 terminal_size = "0.4.4"

--- a/src/app/dispatcher.rs
+++ b/src/app/dispatcher.rs
@@ -29,7 +29,10 @@ use bssh::{
     diagnosticln as eprintln,
     pty::PtyConfig,
     security::{Password, get_password, get_sudo_password},
-    ssh::tokio_client::{AddressFamily, SshConnectionConfigResolver},
+    ssh::{
+        CliTtyMode,
+        tokio_client::{AddressFamily, SshConnectionConfigResolver},
+    },
 };
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -479,8 +482,19 @@ async fn handle_exec_command(
     command: &str,
     ssh_password: Option<Arc<Password>>,
 ) -> Result<()> {
-    // In SSH mode without command, start interactive session
-    if cli.is_ssh_mode() && command.is_empty() {
+    // RemoteCommand and non-default SessionType select a non-interactive
+    // channel even when ssh-compatible mode has no CLI command.
+    let has_configured_session = ctx.nodes.first().is_some_and(|node| {
+        let effective = ctx.ssh_config.find_host_config(node.config_host());
+        effective.remote_command.is_some()
+            || matches!(
+                effective.session_type.as_deref(),
+                Some("none" | "subsystem")
+            )
+    });
+
+    // In SSH mode without a configured channel request, start an interactive session.
+    if cli.is_ssh_mode() && command.is_empty() && !has_configured_session {
         // SSH mode interactive session (like ssh user@host)
         tracing::info!("Starting SSH interactive session to {}", ctx.nodes[0].host);
 
@@ -661,6 +675,13 @@ async fn handle_exec_command(
             batch: cli.batch,
             fail_fast: cli.fail_fast,
             ssh_config: Some(&ctx.ssh_config),
+            tty_mode: if cli.force_tty {
+                CliTtyMode::Force
+            } else if cli.no_tty {
+                CliTtyMode::Disable
+            } else {
+                CliTtyMode::Default
+            },
             ssh_connection_config_resolver,
         };
         execute_command(params).await

--- a/src/app/dispatcher.rs
+++ b/src/app/dispatcher.rs
@@ -14,7 +14,7 @@
 
 //! Command dispatcher for routing CLI commands to their implementations
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use bssh::{
     cli::{Cli, Commands},
     commands::{
@@ -30,10 +30,11 @@ use bssh::{
     pty::PtyConfig,
     security::{Password, get_password, get_sudo_password},
     ssh::{
-        CliTtyMode,
+        CliTtyMode, SessionPolicy, SessionRequest,
         tokio_client::{AddressFamily, SshConnectionConfigResolver},
     },
 };
+use std::io::IsTerminal;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
@@ -464,6 +465,7 @@ async fn handle_interactive_command(
         jump_hosts,
         pty_config,
         use_pty,
+        session_policy: None,
         ssh_connection_config,
     };
 
@@ -475,6 +477,34 @@ async fn handle_interactive_command(
     Ok(())
 }
 
+fn cli_tty_mode(cli: &Cli) -> CliTtyMode {
+    if cli.force_tty {
+        CliTtyMode::Force
+    } else if cli.no_tty {
+        CliTtyMode::Disable
+    } else {
+        CliTtyMode::Default
+    }
+}
+
+fn resolve_ssh_mode_interactive_policy(
+    config: &bssh::ssh::ssh_config::SshHostConfig,
+    node: &bssh::node::Node,
+    tty_mode: CliTtyMode,
+    stdin_is_terminal: bool,
+    jump_spec: Option<&str>,
+) -> Result<Option<SessionPolicy>> {
+    let policy = SessionPolicy::resolve_with_jump_spec(
+        config,
+        node,
+        None,
+        tty_mode,
+        stdin_is_terminal,
+        jump_spec,
+    )?;
+    Ok(matches!(policy.request, SessionRequest::Shell).then_some(policy))
+}
+
 /// Handle exec command or SSH mode interactive session
 async fn handle_exec_command(
     cli: &Cli,
@@ -482,19 +512,30 @@ async fn handle_exec_command(
     command: &str,
     ssh_password: Option<Arc<Password>>,
 ) -> Result<()> {
-    // RemoteCommand and non-default SessionType select a non-interactive
-    // channel even when ssh-compatible mode has no CLI command.
-    let has_configured_session = ctx.nodes.first().is_some_and(|node| {
+    // Resolve policy even for a plain ssh-compatible shell. Remote/subsystem/
+    // none requests stay on the command executor; shell requests retain the
+    // existing interactive stdin, PTY resize, and byte-stream implementation.
+    let interactive_policy = if cli.is_ssh_mode() && command.is_empty() {
+        let node = ctx
+            .nodes
+            .first()
+            .context("SSH interactive mode requires a destination node")?;
         let effective = ctx.ssh_config.find_host_config(node.config_host());
-        effective.remote_command.is_some()
-            || matches!(
-                effective.session_type.as_deref(),
-                Some("none" | "subsystem")
-            )
-    });
+        let effective_cluster_name = ctx.cluster_name.as_deref().or(cli.cluster.as_deref());
+        let yaml_jump = ctx.config.get_cluster_jump_host(effective_cluster_name);
+        let jump_spec = cli.jump_hosts.as_deref().or(yaml_jump.as_deref());
+        resolve_ssh_mode_interactive_policy(
+            &effective,
+            node,
+            cli_tty_mode(cli),
+            std::io::stdin().is_terminal(),
+            jump_spec,
+        )?
+    } else {
+        None
+    };
 
-    // In SSH mode without a configured channel request, start an interactive session.
-    if cli.is_ssh_mode() && command.is_empty() && !has_configured_session {
+    if let Some(session_policy) = interactive_policy {
         // SSH mode interactive session (like ssh user@host)
         tracing::info!("Starting SSH interactive session to {}", ctx.nodes[0].host);
 
@@ -508,18 +549,11 @@ async fn handle_exec_command(
         );
 
         let pty_config = PtyConfig {
-            force_pty: cli.force_tty,
-            disable_pty: cli.no_tty,
+            force_pty: session_policy.request_pty,
+            disable_pty: !session_policy.request_pty,
             ..Default::default()
         };
-
-        let use_pty = if cli.force_tty {
-            Some(true)
-        } else if cli.no_tty {
-            Some(false)
-        } else {
-            None
-        };
+        let use_pty = Some(session_policy.request_pty);
 
         #[cfg(target_os = "macos")]
         let use_keychain = determine_use_keychain(&ctx.ssh_config, hostname.as_deref());
@@ -561,20 +595,16 @@ async fn handle_exec_command(
             jump_hosts,
             pty_config,
             use_pty,
+            session_policy: Some(session_policy),
             ssh_connection_config,
         };
 
         let result = interactive_cmd.execute().await?;
 
-        // Ensure terminal is fully restored before printing
-        bssh::pty::terminal::force_terminal_cleanup();
-        let _ = crossterm::cursor::Show;
-        let _ = std::io::Write::flush(&mut std::io::stdout());
-
-        println!("\nSession ended.");
         if cli.verbose > 0 {
-            println!("Duration: {}", format_duration(result.duration));
-            println!("Commands executed: {}", result.commands_executed);
+            eprintln!("Session ended.");
+            eprintln!("Duration: {}", format_duration(result.duration));
+            eprintln!("Commands executed: {}", result.commands_executed);
         }
 
         // Force exit to ensure proper termination
@@ -675,13 +705,7 @@ async fn handle_exec_command(
             batch: cli.batch,
             fail_fast: cli.fail_fast,
             ssh_config: Some(&ctx.ssh_config),
-            tty_mode: if cli.force_tty {
-                CliTtyMode::Force
-            } else if cli.no_tty {
-                CliTtyMode::Disable
-            } else {
-                CliTtyMode::Default
-            },
+            tty_mode: cli_tty_mode(cli),
             ssh_connection_config_resolver,
         };
         execute_command(params).await
@@ -700,6 +724,63 @@ mod tests {
             history_file: PathBuf::from("~/.bssh_history"),
             work_dir: None,
         })
+    }
+
+    #[test]
+    fn plain_ssh_shell_always_consumes_the_resolved_session_policy() {
+        let node = bssh::node::Node::new("127.0.0.1".into(), 2222, "remote".into())
+            .with_original_host("alias".into());
+
+        let plain = resolve_ssh_mode_interactive_policy(
+            &bssh::ssh::ssh_config::SshHostConfig::default(),
+            &node,
+            CliTtyMode::Default,
+            true,
+            None,
+        )
+        .unwrap()
+        .expect("plain ssh must use the interactive policy path");
+        assert_eq!(plain.request, SessionRequest::Shell);
+        assert!(plain.request_pty);
+        assert!(plain.environment.is_empty());
+        assert!(plain.local_command.is_none());
+
+        let mut configured = bssh::ssh::ssh_config::SshHostConfig::default();
+        configured.permit_local_command = Some(true);
+        configured.local_command = Some("true".into());
+        configured.request_tty = Some("force".into());
+        configured.session_type = Some("default".into());
+        configured.set_env.insert("JUMP".into(), "%j".into());
+        let resolved = resolve_ssh_mode_interactive_policy(
+            &configured,
+            &node,
+            CliTtyMode::Default,
+            false,
+            Some("bastion.example"),
+        )
+        .unwrap()
+        .expect("configured default session must retain the interactive path");
+        assert_eq!(resolved.request, SessionRequest::Shell);
+        assert!(resolved.request_pty);
+        assert_eq!(
+            resolved.environment,
+            [(String::from("JUMP"), String::from("bastion.example"))]
+        );
+        assert_eq!(resolved.local_command.as_deref(), Some("true"));
+
+        configured.remote_command = Some("true".into());
+        assert!(
+            resolve_ssh_mode_interactive_policy(
+                &configured,
+                &node,
+                CliTtyMode::Default,
+                true,
+                None,
+            )
+            .unwrap()
+            .is_none(),
+            "non-shell policies must stay on the command executor"
+        );
     }
 
     #[test]

--- a/src/commands/exec.rs
+++ b/src/commands/exec.rs
@@ -22,9 +22,9 @@ use crate::executor::{
 use crate::forwarding::ForwardingType;
 use crate::node::Node;
 use crate::security::{Password, SudoPassword};
-use crate::ssh::SshConfig;
 use crate::ssh::known_hosts::StrictHostKeyChecking;
 use crate::ssh::tokio_client::{Error as SshError, SshConnectionConfigResolver};
+use crate::ssh::{CliTtyMode, SshConfig};
 use crate::ui::OutputFormatter;
 use crate::utils::output::save_outputs_to_files;
 
@@ -57,6 +57,7 @@ pub struct ExecuteCommandParams<'a> {
     pub batch: bool,
     pub fail_fast: bool,
     pub ssh_config: Option<&'a SshConfig>,
+    pub tty_mode: CliTtyMode,
     /// Per-host SSH connection configuration resolver.
     pub ssh_connection_config_resolver: SshConnectionConfigResolver,
 }
@@ -299,6 +300,7 @@ async fn execute_command_without_forwarding(params: ExecuteCommandParams<'_>) ->
     .with_batch_mode(params.batch)
     .with_fail_fast(params.fail_fast)
     .with_ssh_config(params.ssh_config.cloned())
+    .with_tty_mode(params.tty_mode)
     .with_ssh_connection_config_resolver(params.ssh_connection_config_resolver);
 
     // Set keychain usage if on macOS

--- a/src/commands/interactive/connection.rs
+++ b/src/commands/interactive/connection.rs
@@ -25,6 +25,7 @@ use zeroize::Zeroizing;
 use crate::jump::{JumpHostChain, parse_jump_hosts};
 use crate::node::Node;
 use crate::ssh::{
+    SessionRequest,
     known_hosts::get_check_method_for_target,
     tokio_client::{AuthMethod, Client, Error as SshError, ServerCheckMethod, SshConnectionConfig},
 };
@@ -221,6 +222,28 @@ impl InteractiveCommand {
         }
     }
 
+    /// Run post-authentication policy and open a session channel while
+    /// preserving ownership of the channel for the interactive byte-stream loop.
+    async fn open_interactive_channel(
+        &self,
+        client: &Client,
+        term_type: &str,
+        width: u32,
+        height: u32,
+    ) -> Result<Channel<Msg>> {
+        if let Some(policy) = self.session_policy.as_ref() {
+            if !matches!(policy.request, SessionRequest::Shell) {
+                anyhow::bail!("Interactive mode requires a shell session policy");
+            }
+            policy.run_local_command().await?;
+        }
+
+        client
+            .request_interactive_shell(term_type, width, height)
+            .await
+            .context("Failed to open interactive session channel")
+    }
+
     /// Connect to a single node and establish an interactive shell
     pub(super) async fn connect_to_node(&self, node: Node) -> Result<NodeSession> {
         // Determine authentication method using the same logic as exec mode
@@ -349,9 +372,16 @@ impl InteractiveCommand {
         // Get terminal dimensions
         let (width, height) = terminal::size().unwrap_or((80, 24));
 
-        // Request interactive shell with PTY
-        let channel = client
-            .request_interactive_shell("xterm-256color", u32::from(width), u32::from(height))
+        let channel = self
+            .open_interactive_channel(
+                &client,
+                "xterm-256color",
+                u32::from(width),
+                u32::from(height),
+            )
+            .await?;
+        channel
+            .request_shell(false)
             .await
             .context("Failed to request interactive shell")?;
 
@@ -502,13 +532,10 @@ impl InteractiveCommand {
         // Get terminal dimensions
         let (width, height) = crate::pty::utils::get_terminal_size().unwrap_or((80, 24));
 
-        // Request interactive shell with PTY using the SSH client's method
-        let channel = client
-            .request_interactive_shell(&self.pty_config.term_type, width, height)
+        // The PTY manager retains channel ownership for raw stdin, resize, and
+        // byte-transparent output. It requests PTY and shell after policy env.
+        self.open_interactive_channel(&client, &self.pty_config.term_type, width, height)
             .await
-            .context("Failed to request interactive shell with PTY")?;
-
-        Ok(channel)
     }
 }
 

--- a/src/commands/interactive/execution.rs
+++ b/src/commands/interactive/execution.rs
@@ -30,11 +30,11 @@ use super::types::{InteractiveCommand, InteractiveResult};
 impl InteractiveCommand {
     /// Main entry point for interactive session execution
     pub async fn execute(self) -> Result<InteractiveResult> {
-        let use_pty = self.should_use_pty()?;
+        let use_raw_session = self.should_use_raw_session()?;
 
-        // Choose between PTY mode and traditional interactive mode
-        if use_pty {
-            // Use new PTY implementation for true terminal support
+        // SSH-compatible shells always use the raw byte-stream runner. Regular
+        // bssh interactive sessions retain their traditional line UI fallback.
+        if use_raw_session {
             self.execute_with_pty().await
         } else {
             // Use traditional rustyline-based interactive mode (existing implementation)
@@ -43,10 +43,13 @@ impl InteractiveCommand {
     }
 
     /// Execute interactive session with full PTY support
-    pub(super) async fn execute_with_pty(self) -> Result<InteractiveResult> {
+    pub(super) async fn execute_with_pty(mut self) -> Result<InteractiveResult> {
         let start_time = std::time::Instant::now();
+        let ssh_compatible = self.session_policy.is_some();
 
-        println!("Starting interactive session with PTY support...");
+        if !ssh_compatible {
+            println!("Starting interactive SSH byte-stream session...");
+        }
 
         // Determine which nodes to connect to
         let nodes_to_connect = self.select_nodes_to_connect()?;
@@ -58,7 +61,9 @@ impl InteractiveCommand {
         for node in nodes_to_connect {
             match self.connect_to_node_pty(node.clone()).await {
                 Ok(channel) => {
-                    println!("✓ Connected to {} with PTY", node.to_string().green());
+                    if !ssh_compatible {
+                        println!("✓ Connected to {}", node.to_string().green());
+                    }
                     channels.push(channel);
                     connected_nodes.push(node);
                 }
@@ -78,32 +83,36 @@ impl InteractiveCommand {
 
         let nodes_connected = channels.len();
 
-        // Create PTY manager and sessions
+        let mut session_config = self.pty_config.clone();
+        if let Some(policy) = self.session_policy.take() {
+            session_config.environment = policy.environment;
+        }
+
+        // Create raw stream manager and sessions. PtyConfig::disable_pty only
+        // controls remote PTY/resize requests, not byte-transparent I/O.
+        let requested_remote_pty = !session_config.disable_pty;
         let mut pty_manager = PtyManager::new();
 
         if self.single_node && channels.len() == 1 {
             // Single PTY session
             let session_id = pty_manager
-                .create_single_session(
-                    channels.into_iter().next().unwrap(),
-                    self.pty_config.clone(),
-                )
+                .create_single_session(channels.into_iter().next().unwrap(), session_config.clone())
                 .await?;
 
             pty_manager.run_single_session(session_id).await?;
         } else {
             // Multiple PTY sessions with multiplexing
             let session_ids = pty_manager
-                .create_multiplex_sessions(channels, self.pty_config.clone())
+                .create_multiplex_sessions(channels, session_config)
                 .await?;
 
             pty_manager.run_multiplex_sessions(session_ids).await?;
         }
 
-        // Ensure terminal is fully restored after PTY session ends
-        // Use synchronized cleanup to prevent race conditions
-        crate::pty::terminal::force_terminal_cleanup();
-        let _ = std::io::Write::flush(&mut std::io::stdout());
+        if requested_remote_pty {
+            crate::pty::terminal::force_terminal_cleanup();
+            let _ = std::io::Write::flush(&mut std::io::stdout());
+        }
 
         Ok(InteractiveResult {
             duration: start_time.elapsed(),

--- a/src/commands/interactive/types.rs
+++ b/src/commands/interactive/types.rs
@@ -25,6 +25,7 @@ use crate::config::{Config, InteractiveConfig};
 use crate::node::Node;
 use crate::pty::PtyConfig;
 use crate::security::Password;
+use crate::ssh::SessionPolicy;
 use crate::ssh::known_hosts::StrictHostKeyChecking;
 use crate::ssh::tokio_client::{Client, SshConnectionConfig};
 
@@ -66,6 +67,8 @@ pub struct InteractiveCommand {
     // PTY configuration
     pub pty_config: PtyConfig,
     pub use_pty: Option<bool>, // None = auto-detect, Some(true) = force, Some(false) = disable
+    /// Resolved live ssh_config policy for the SSH-compatible interactive path.
+    pub session_policy: Option<SessionPolicy>,
     // SSH connection configuration (keepalive settings)
     pub ssh_connection_config: SshConnectionConfig,
 }

--- a/src/commands/interactive/utils.rs
+++ b/src/commands/interactive/utils.rs
@@ -23,6 +23,12 @@ use crate::pty::should_allocate_pty;
 use super::types::InteractiveCommand;
 
 impl InteractiveCommand {
+    /// SSH-compatible shells always retain byte-transparent input/output even
+    /// when their resolved policy suppresses the remote PTY request.
+    pub(super) fn should_use_raw_session(&self) -> Result<bool> {
+        Ok(self.session_policy.is_some() || self.should_use_pty()?)
+    }
+
     /// Determine whether to use PTY mode based on configuration
     pub(super) fn should_use_pty(&self) -> Result<bool> {
         match self.use_pty {
@@ -73,6 +79,44 @@ mod tests {
     use crate::ssh::tokio_client::SshConnectionConfig;
 
     #[test]
+    fn ssh_policy_shell_uses_raw_runner_when_remote_pty_is_disabled() {
+        let cmd = InteractiveCommand {
+            single_node: true,
+            multiplex: false,
+            prompt_format: String::new(),
+            history_file: PathBuf::from("~/.bssh_history"),
+            work_dir: None,
+            nodes: vec![],
+            config: Config::default(),
+            interactive_config: InteractiveConfig::default(),
+            cluster_name: None,
+            key_path: None,
+            use_agent: false,
+            use_password: false,
+            ssh_password: None,
+            #[cfg(target_os = "macos")]
+            use_keychain: false,
+            strict_mode: StrictHostKeyChecking::AcceptNew,
+            jump_hosts: None,
+            pty_config: PtyConfig {
+                disable_pty: true,
+                ..Default::default()
+            },
+            use_pty: Some(false),
+            session_policy: Some(crate::ssh::SessionPolicy {
+                environment: vec![("POLICY".into(), "value".into())],
+                local_command: None,
+                request_pty: false,
+                request: crate::ssh::SessionRequest::Shell,
+            }),
+            ssh_connection_config: SshConnectionConfig::default(),
+        };
+
+        assert!(cmd.should_use_raw_session().unwrap());
+        assert!(!cmd.should_use_pty().unwrap());
+    }
+
+    #[test]
     fn test_expand_path_with_tilde() {
         let _home_lock = crate::test_helpers::EnvGuard::lock_home();
         let cmd = InteractiveCommand {
@@ -95,6 +139,7 @@ mod tests {
             jump_hosts: None,
             pty_config: PtyConfig::default(),
             use_pty: None,
+            session_policy: None,
             ssh_connection_config: SshConnectionConfig::default(),
         };
 
@@ -130,6 +175,7 @@ mod tests {
             jump_hosts: None,
             pty_config: PtyConfig::default(),
             use_pty: None,
+            session_policy: None,
             ssh_connection_config: SshConnectionConfig::default(),
         };
 

--- a/src/executor/connection_manager.rs
+++ b/src/executor/connection_manager.rs
@@ -15,13 +15,14 @@
 //! SSH connection management and node operations.
 
 use anyhow::Result;
+use std::io::IsTerminal;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use crate::node::Node;
 use crate::security::{Password, SudoPassword};
 use crate::ssh::{
-    SshClient, SshConfig,
+    CliTtyMode, SessionPolicy, SshClient, SshConfig,
     client::{CommandResult, ConnectionConfig},
     known_hosts::StrictHostKeyChecking,
     tokio_client::{SshConnectionConfig, SshConnectionConfigResolver},
@@ -45,6 +46,7 @@ pub(crate) struct ExecutionConfig<'a> {
     /// `Some(_)`; auth.rs consumes it instead of prompting per node.
     pub ssh_password: Option<Arc<Password>>,
     pub ssh_config: Option<&'a SshConfig>,
+    pub tty_mode: CliTtyMode,
     /// SSH connection configuration (keepalive settings).
     /// Threaded through to `Client::connect_with_ssh_config` so user-configured
     /// `server_alive_interval` / `server_alive_count_max` apply to exec mode.
@@ -78,6 +80,20 @@ pub(crate) async fn execute_on_node_with_jump_hosts(
         ssh_config_jump_hosts.as_deref()
     };
 
+    let session_policy = config
+        .ssh_config
+        .map(|ssh_config| {
+            let effective = ssh_config.find_host_config(node.config_host());
+            SessionPolicy::resolve(
+                &effective,
+                &node,
+                (!command.is_empty()).then_some(command),
+                config.tty_mode,
+                std::io::stdin().is_terminal(),
+            )
+        })
+        .transpose()?;
+
     let connection_config = ConnectionConfig {
         key_path,
         strict_mode: Some(config.strict_mode),
@@ -90,6 +106,7 @@ pub(crate) async fn execute_on_node_with_jump_hosts(
         jump_hosts_spec: effective_jump_hosts,
         ssh_connection_config: config.ssh_connection_config,
         ssh_connection_config_resolver: config.ssh_connection_config_resolver,
+        session_policy: session_policy.as_ref(),
         ssh_password: config.ssh_password.clone(),
     };
 

--- a/src/executor/connection_manager.rs
+++ b/src/executor/connection_manager.rs
@@ -84,12 +84,13 @@ pub(crate) async fn execute_on_node_with_jump_hosts(
         .ssh_config
         .map(|ssh_config| {
             let effective = ssh_config.find_host_config(node.config_host());
-            SessionPolicy::resolve(
+            SessionPolicy::resolve_with_jump_spec(
                 &effective,
                 &node,
                 (!command.is_empty()).then_some(command),
                 config.tty_mode,
                 std::io::stdin().is_terminal(),
+                effective_jump_hosts,
             )
         })
         .transpose()?;

--- a/src/executor/parallel.rs
+++ b/src/executor/parallel.rs
@@ -17,6 +17,7 @@
 use anyhow::Result;
 use futures::future::join_all;
 use indicatif::MultiProgress;
+use std::io::IsTerminal;
 use std::path::Path;
 use std::sync::Arc;
 use tokio::sync::Semaphore;
@@ -24,11 +25,11 @@ use tokio::sync::Semaphore;
 use crate::diagnosticln as eprintln;
 use crate::node::Node;
 use crate::security::{Password, SudoPassword};
-use crate::ssh::SshConfig;
 use crate::ssh::known_hosts::StrictHostKeyChecking;
 use crate::ssh::tokio_client::{
     AddressFamily, CommandOutput, SshConnectionConfig, SshConnectionConfigResolver,
 };
+use crate::ssh::{CliTtyMode, SessionPolicy, SshConfig};
 
 use super::connection_manager::{ExecutionConfig, download_from_node};
 use super::execution_strategy::{
@@ -60,6 +61,7 @@ pub struct ParallelExecutor {
     pub(crate) batch: bool,
     pub(crate) fail_fast: bool,
     pub(crate) ssh_config: Option<SshConfig>,
+    pub(crate) tty_mode: CliTtyMode,
     /// Per-host SSH connection configuration resolver.
     pub(crate) ssh_connection_config_resolver: SshConnectionConfigResolver,
 }
@@ -132,6 +134,7 @@ impl ParallelExecutor {
             batch: false,
             fail_fast: false,
             ssh_config: None,
+            tty_mode: CliTtyMode::Default,
             ssh_connection_config_resolver: SshConnectionConfigResolver::default(),
         }
     }
@@ -161,6 +164,7 @@ impl ParallelExecutor {
             batch: false,
             fail_fast: false,
             ssh_config: None,
+            tty_mode: CliTtyMode::Default,
             ssh_connection_config_resolver: SshConnectionConfigResolver::default(),
         }
     }
@@ -191,6 +195,7 @@ impl ParallelExecutor {
             batch: false,
             fail_fast: false,
             ssh_config: None,
+            tty_mode: CliTtyMode::Default,
             ssh_connection_config_resolver: SshConnectionConfigResolver::default(),
         }
     }
@@ -216,6 +221,11 @@ impl ParallelExecutor {
     /// Set SSH config for ProxyJump directive resolution.
     pub fn with_ssh_config(mut self, ssh_config: Option<SshConfig>) -> Self {
         self.ssh_config = ssh_config;
+        self
+    }
+
+    pub fn with_tty_mode(mut self, tty_mode: CliTtyMode) -> Self {
+        self.tty_mode = tty_mode;
         self
     }
 
@@ -323,6 +333,7 @@ impl ParallelExecutor {
 
     /// Execute a command on all nodes in parallel.
     pub async fn execute(&self, command: &str) -> Result<Vec<ExecutionResult>> {
+        let tty_mode = self.tty_mode;
         use std::time::Duration;
         use tokio::signal;
 
@@ -373,6 +384,7 @@ impl ParallelExecutor {
                         sudo_password: sudo_password.clone(),
                         ssh_password: ssh_password.clone(),
                         ssh_config: ssh_config_ref.as_ref(),
+                        tty_mode,
                         ssh_connection_config: Some(&ssh_connection_config),
                         ssh_connection_config_resolver: Some(&ssh_connection_config_resolver),
                     };
@@ -452,6 +464,7 @@ impl ParallelExecutor {
     /// Stops execution immediately when any node fails (connection error or non-zero exit code).
     /// Cancels pending commands and terminates running commands gracefully.
     async fn execute_with_fail_fast(&self, command: &str) -> Result<Vec<ExecutionResult>> {
+        let tty_mode = self.tty_mode;
         use tokio::sync::watch;
 
         let semaphore = Arc::new(Semaphore::new(self.max_parallel));
@@ -555,6 +568,7 @@ impl ParallelExecutor {
                     sudo_password: sudo_password.clone(),
                     ssh_password: ssh_password.clone(),
                     ssh_config: ssh_config_ref.as_ref(),
+                    tty_mode,
                     ssh_connection_config: Some(&ssh_connection_config),
                     ssh_connection_config_resolver: Some(&ssh_connection_config_resolver_ref),
                 };
@@ -1225,6 +1239,9 @@ impl ParallelExecutor {
         let raw_stream = output_mode.is_raw_stream();
         let mut manager = MultiNodeStreamManager::new();
         let mut handles = Vec::new();
+        let stdin_is_terminal = std::io::stdin().is_terminal();
+        let tty_mode = self.tty_mode;
+        let ssh_config_for_tasks = self.ssh_config.clone();
 
         // Spawn tasks for each node with streaming
         for node in &self.nodes {
@@ -1247,6 +1264,7 @@ impl ParallelExecutor {
             let semaphore = Arc::clone(&semaphore);
             let ssh_connection_config_resolver = self.ssh_connection_config_resolver.clone();
             let ssh_connection_config = self.connection_config_for_node(node);
+            let ssh_config = ssh_config_for_tasks.clone();
 
             let handle = tokio::spawn(async move {
                 // Use defer pattern to ensure cleanup even on panic
@@ -1282,6 +1300,24 @@ impl ParallelExecutor {
                     node_clone.username.clone(),
                 );
 
+                let session_policy = match ssh_config
+                    .as_ref()
+                    .map(|ssh_config| {
+                        let effective = ssh_config.find_host_config(node_clone.config_host());
+                        SessionPolicy::resolve(
+                            &effective,
+                            &node_clone,
+                            (!command.is_empty()).then_some(command.as_str()),
+                            tty_mode,
+                            stdin_is_terminal,
+                        )
+                    })
+                    .transpose()
+                {
+                    Ok(policy) => policy,
+                    Err(error) => return (node_clone, Err(error)),
+                };
+
                 let config = ConnectionConfig {
                     key_path: key_path.as_deref().map(Path::new),
                     strict_mode: Some(strict_mode),
@@ -1294,6 +1330,7 @@ impl ParallelExecutor {
                     jump_hosts_spec: jump_hosts.as_deref(),
                     ssh_connection_config: Some(&ssh_connection_config),
                     ssh_connection_config_resolver: Some(&ssh_connection_config_resolver),
+                    session_policy: session_policy.as_ref(),
                     ssh_password: ssh_password.clone(),
                 };
 

--- a/src/executor/parallel.rs
+++ b/src/executor/parallel.rs
@@ -1304,12 +1304,13 @@ impl ParallelExecutor {
                     .as_ref()
                     .map(|ssh_config| {
                         let effective = ssh_config.find_host_config(node_clone.config_host());
-                        SessionPolicy::resolve(
+                        SessionPolicy::resolve_with_jump_spec(
                             &effective,
                             &node_clone,
                             (!command.is_empty()).then_some(command.as_str()),
                             tty_mode,
                             stdin_is_terminal,
+                            jump_hosts.as_deref(),
                         )
                     })
                     .transpose()

--- a/src/pty/mod.rs
+++ b/src/pty/mod.rs
@@ -53,8 +53,10 @@ pub struct PtyConfig {
     pub term_type: String,
     /// Whether to force PTY allocation
     pub force_pty: bool,
-    /// Whether to disable PTY allocation
+    /// Whether to disable PTY allocation while retaining the raw SSH stream
     pub disable_pty: bool,
+    /// Policy environment requests sent before PTY and shell requests.
+    pub environment: Vec<(String, String)>,
     /// Enable mouse event support
     pub enable_mouse: bool,
     /// Terminal input/output timeout
@@ -73,6 +75,7 @@ impl Default for PtyConfig {
             term_type: "xterm-256color".to_string(),
             force_pty: false,
             disable_pty: false,
+            environment: Vec::new(),
             enable_mouse: false,
             timeout: Duration::from_millis(DEFAULT_PTY_TIMEOUT_MS),
         }
@@ -158,15 +161,17 @@ impl PtyManager {
 
     /// Run a single PTY session
     pub async fn run_single_session(&mut self, session_id: usize) -> Result<()> {
-        let result = if let Some(session) = self.active_sessions.get_mut(session_id) {
-            session.run().await
-        } else {
-            anyhow::bail!("PTY session {session_id} not found")
-        };
+        let (result, requested_remote_pty) =
+            if let Some(session) = self.active_sessions.get_mut(session_id) {
+                let requested_remote_pty = session.requests_remote_pty();
+                (session.run().await, requested_remote_pty)
+            } else {
+                anyhow::bail!("PTY session {session_id} not found")
+            };
 
-        // Ensure terminal is properly restored after session ends
-        // Use synchronized cleanup from terminal module
-        crate::pty::terminal::force_terminal_cleanup();
+        if requested_remote_pty {
+            crate::pty::terminal::force_terminal_cleanup();
+        }
 
         result
     }

--- a/src/pty/session/output_delivery.rs
+++ b/src/pty/session/output_delivery.rs
@@ -18,6 +18,23 @@ use std::io::{self, Write};
 
 use super::escape_filter::EscapeSequenceFilter;
 
+/// Deliver remote bytes for either a PTY terminal or a no-PTY transparent
+/// stream. Transparent delivery does not inspect or mutate escape/binary bytes.
+pub(super) fn deliver_session_output(
+    transparent: bool,
+    filter: &mut EscapeSequenceFilter,
+    writer: &mut impl Write,
+    input: &[u8],
+    commit: impl FnOnce(&[u8]),
+) -> io::Result<()> {
+    if transparent {
+        writer.write_all(input)?;
+        let _ = writer.flush();
+        return Ok(());
+    }
+    deliver_filtered_output(filter, writer, input, commit)
+}
+
 /// Filter remote bytes, write the surviving bytes, then commit only bytes the
 /// terminal actually accepted to the protocol observer.
 pub(super) fn deliver_filtered_output(
@@ -52,6 +69,22 @@ mod tests {
         fn flush(&mut self) -> io::Result<()> {
             Ok(())
         }
+    }
+
+    #[test]
+    fn transparent_delivery_preserves_escape_nul_and_binary_bytes() {
+        let mut filter = EscapeSequenceFilter::new();
+        let input = b"\0\xff\x1b]10;payload\x07\x80";
+        let mut output = Vec::new();
+        let mut committed = false;
+
+        deliver_session_output(true, &mut filter, &mut output, input, |_| {
+            committed = true;
+        })
+        .unwrap();
+
+        assert_eq!(output, input);
+        assert!(!committed);
     }
 
     #[test]

--- a/src/pty/session/raw_input_task.rs
+++ b/src/pty/session/raw_input_task.rs
@@ -27,12 +27,14 @@ pub(crate) fn run(
     input_tx: mpsc::Sender<PtyMessage>,
     cancel_rx: watch::Receiver<bool>,
     pending_input: Vec<u8>,
+    escape_enabled: bool,
 ) {
     let mut reader = RawInputReader::new();
     let mut buffer = [0_u8; 1024];
-    let mut escape_detector = LocalEscapeDetector::new();
+    let mut escape_detector = escape_enabled.then(LocalEscapeDetector::new);
 
-    if !pending_input.is_empty() && !forward_input(&input_tx, &mut escape_detector, &pending_input)
+    if !pending_input.is_empty()
+        && !forward_input(&input_tx, escape_detector.as_mut(), &pending_input)
     {
         return;
     }
@@ -49,7 +51,7 @@ pub(crate) fn run(
                     break;
                 }
                 Ok(read) => {
-                    if !forward_input(&input_tx, &mut escape_detector, &buffer[..read]) {
+                    if !forward_input(&input_tx, escape_detector.as_mut(), &buffer[..read]) {
                         break;
                     }
                 }
@@ -69,10 +71,10 @@ pub(crate) fn run(
 
 fn forward_input(
     input_tx: &mpsc::Sender<PtyMessage>,
-    detector: &mut LocalEscapeDetector,
+    detector: Option<&mut LocalEscapeDetector>,
     bytes: &[u8],
 ) -> bool {
-    if let Some(action) = detector.process(bytes) {
+    if let Some(action) = detector.and_then(|detector| detector.process(bytes)) {
         match action {
             LocalAction::Disconnect => {
                 tracing::debug!("Disconnect escape sequence detected");
@@ -99,10 +101,21 @@ mod tests {
         let mut detector = LocalEscapeDetector::new();
         let bytes = [0x00, 0x01, 0x03, 0x04, 0x1b, 0x7f, 0x80, 0xff];
 
-        assert!(forward_input(&tx, &mut detector, &bytes));
+        assert!(forward_input(&tx, Some(&mut detector), &bytes));
         let PtyMessage::LocalInput(forwarded) = rx.try_recv().unwrap() else {
             panic!("raw input must produce a LocalInput message");
         };
         assert_eq!(forwarded.as_slice(), bytes);
+    }
+
+    #[test]
+    fn no_pty_forwarding_preserves_ssh_escape_sequence() {
+        let (tx, mut rx) = mpsc::channel(1);
+
+        assert!(forward_input(&tx, None, b"~."));
+        let PtyMessage::LocalInput(forwarded) = rx.try_recv().unwrap() else {
+            panic!("no-PTY input must produce a LocalInput message");
+        };
+        assert_eq!(forwarded.as_slice(), b"~.");
     }
 }

--- a/src/pty/session/raw_input_task.rs
+++ b/src/pty/session/raw_input_task.rs
@@ -88,3 +88,21 @@ fn forward_input(
         input_tx.try_send(PtyMessage::LocalInput(data)).is_ok()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn raw_forwarding_preserves_control_nul_escape_and_binary_bytes() {
+        let (tx, mut rx) = mpsc::channel(1);
+        let mut detector = LocalEscapeDetector::new();
+        let bytes = [0x00, 0x01, 0x03, 0x04, 0x1b, 0x7f, 0x80, 0xff];
+
+        assert!(forward_input(&tx, &mut detector, &bytes));
+        let PtyMessage::LocalInput(forwarded) = rx.try_recv().unwrap() else {
+            panic!("raw input must produce a LocalInput message");
+        };
+        assert_eq!(forwarded.as_slice(), bytes);
+    }
+}

--- a/src/pty/session/session_manager.rs
+++ b/src/pty/session/session_manager.rs
@@ -16,7 +16,7 @@
 
 use super::constants::*;
 use super::escape_filter::EscapeSequenceFilter;
-use super::output_delivery::deliver_filtered_output;
+use super::output_delivery::deliver_session_output;
 use super::raw_input_task;
 use super::terminal_modes::configure_terminal_modes;
 use crate::pty::{
@@ -25,9 +25,29 @@ use crate::pty::{
 };
 use anyhow::{Context, Result};
 use russh::{Channel, ChannelMsg, client::Msg};
-use std::io::{self, Write};
+use std::io::{self, IsTerminal, Write};
 use tokio::sync::{mpsc, watch};
 use tokio::time::Duration;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum SessionSetupStep {
+    Environment(usize),
+    TerminalEnvironment,
+    RequestPty,
+    RequestShell,
+}
+
+fn session_setup_plan(config: &PtyConfig) -> Vec<SessionSetupStep> {
+    let mut steps = (0..config.environment.len())
+        .map(SessionSetupStep::Environment)
+        .collect::<Vec<_>>();
+    if !config.disable_pty {
+        steps.push(SessionSetupStep::TerminalEnvironment);
+        steps.push(SessionSetupStep::RequestPty);
+    }
+    steps.push(SessionSetupStep::RequestShell);
+    steps
+}
 
 /// A PTY session managing the bidirectional communication between
 /// local terminal and remote SSH session.
@@ -80,67 +100,70 @@ impl PtySession {
         self.state
     }
 
-    /// Initialize the PTY session with the remote terminal
+    pub(crate) fn requests_remote_pty(&self) -> bool {
+        !self.config.disable_pty
+    }
+
+    /// Initialize the raw session, optionally requesting a remote PTY.
     pub async fn initialize(&mut self) -> Result<()> {
         self.state = PtyState::Initializing;
 
-        // Get terminal size
-        let (width, height) = crate::pty::utils::get_terminal_size()?;
-
-        // Set TERM environment variable before requesting PTY
-        // This ensures the remote shell knows the terminal capabilities
-        // Note: The server may not accept this (AcceptEnv in sshd_config),
-        // but the PTY request will also include the term type
-        if let Err(e) = self
-            .channel
-            .set_env(false, "TERM", &self.config.term_type)
-            .await
-        {
-            // Log but don't fail - server may reject env requests
-            tracing::debug!(
-                "Server did not accept TERM environment variable: {}. \
-                This is expected if AcceptEnv is not configured for TERM in sshd_config. \
-                The terminal type will still be set via the PTY request.",
-                e
-            );
+        for step in session_setup_plan(&self.config) {
+            match step {
+                SessionSetupStep::Environment(index) => {
+                    let (name, value) = &self.config.environment[index];
+                    self.channel
+                        .set_env(false, name, value)
+                        .await
+                        .with_context(|| {
+                            format!("Failed to send SSH environment variable {name}")
+                        })?;
+                }
+                SessionSetupStep::TerminalEnvironment => {
+                    if let Err(error) = self
+                        .channel
+                        .set_env(false, "TERM", &self.config.term_type)
+                        .await
+                    {
+                        tracing::debug!("Server did not accept TERM environment variable: {error}");
+                    }
+                    if let Err(error) = self.channel.set_env(false, "COLORTERM", "truecolor").await
+                    {
+                        tracing::trace!(
+                            "Server did not accept COLORTERM environment variable: {error}"
+                        );
+                    }
+                }
+                SessionSetupStep::RequestPty => {
+                    let (width, height) = crate::pty::utils::get_terminal_size()?;
+                    let terminal_modes = configure_terminal_modes();
+                    self.channel
+                        .request_pty(
+                            false,
+                            &self.config.term_type,
+                            width,
+                            height,
+                            0,
+                            0,
+                            &terminal_modes,
+                        )
+                        .await
+                        .with_context(|| "Failed to request PTY on SSH channel")?;
+                }
+                SessionSetupStep::RequestShell => {
+                    self.channel
+                        .request_shell(false)
+                        .await
+                        .with_context(|| "Failed to request shell on SSH channel")?;
+                }
+            }
         }
-
-        // Also set COLORTERM for better color support detection
-        // Many modern terminals set this to indicate truecolor support
-        if let Err(e) = self.channel.set_env(false, "COLORTERM", "truecolor").await {
-            tracing::trace!(
-                "Server did not accept COLORTERM environment variable: {}",
-                e
-            );
-        }
-
-        // Request PTY on the SSH channel with properly configured terminal modes
-        // Configure terminal modes for proper sudo/passwd password input support
-        let terminal_modes = configure_terminal_modes();
-        self.channel
-            .request_pty(
-                false,
-                &self.config.term_type,
-                width,
-                height,
-                0,               // pixel width (0 means undefined)
-                0,               // pixel height (0 means undefined)
-                &terminal_modes, // Terminal modes using russh Pty enum
-            )
-            .await
-            .with_context(|| "Failed to request PTY on SSH channel")?;
-
-        // Request shell
-        self.channel
-            .request_shell(false)
-            .await
-            .with_context(|| "Failed to request shell on SSH channel")?;
 
         self.state = PtyState::Active;
         tracing::debug!(
-            "PTY session {} initialized with TERM={}",
+            "Raw SSH session {} initialized (remote PTY: {})",
             self.session_id,
-            self.config.term_type
+            !self.config.disable_pty
         );
         Ok(())
     }
@@ -155,8 +178,17 @@ impl PtySession {
             anyhow::bail!("PTY session is not in active state");
         }
 
-        // Set up terminal state guard
-        let mut terminal_guard = TerminalStateGuard::new()?;
+        // Pipes already deliver bytes without terminal line discipline. A local
+        // TTY enters raw mode so control and binary bytes reach the SSH stream.
+        let mut terminal_guard = if io::stdin().is_terminal() && io::stdout().is_terminal() {
+            if self.config.disable_pty {
+                TerminalStateGuard::new_raw_mode_without_protocol()?
+            } else {
+                TerminalStateGuard::new()?
+            }
+        } else {
+            TerminalStateGuard::new_without_raw_mode()?
+        };
         let pending_input = terminal_guard.take_pending_input();
         self.terminal_guard = Some(terminal_guard);
 
@@ -171,50 +203,48 @@ impl PtySession {
             .take()
             .ok_or_else(|| anyhow::anyhow!("Message receiver already taken"))?;
 
-        // Set up resize signal handler
-        let mut resize_signals = crate::pty::utils::setup_resize_handler()?;
-        let cancel_for_resize = self.cancel_rx.clone();
+        // A no-PTY shell keeps the raw byte stream but must not send remote
+        // window-change requests.
+        let resize_task = if self.config.disable_pty {
+            None
+        } else {
+            let mut resize_signals = crate::pty::utils::setup_resize_handler()?;
+            let mut cancel_for_resize = self.cancel_rx.clone();
+            let resize_tx = self
+                .msg_tx
+                .as_ref()
+                .ok_or_else(|| anyhow::anyhow!("Message sender not available"))?
+                .clone();
 
-        // Spawn resize handler task
-        let resize_tx = self
-            .msg_tx
-            .as_ref()
-            .ok_or_else(|| anyhow::anyhow!("Message sender not available"))?
-            .clone();
-
-        let resize_task = tokio::spawn(async move {
-            let mut cancel_for_resize = cancel_for_resize;
-
-            loop {
-                tokio::select! {
-                    // Handle resize signals
-                    signal = async {
-                        for signal in resize_signals.forever() {
-                            if signal == signal_hook::consts::SIGWINCH {
-                                return signal;
-                            }
-                        }
-                        signal_hook::consts::SIGWINCH // fallback, won't be reached
-                    } => {
-                        if signal == signal_hook::consts::SIGWINCH
-                            && let Ok((width, height)) = crate::pty::utils::get_terminal_size() {
-                                // Try to send resize message, but don't block if channel is full
-                                if resize_tx.try_send(PtyMessage::Resize { width, height }).is_err() {
-                                    // Channel full or closed, exit gracefully
-                                    break;
+            Some(tokio::spawn(async move {
+                loop {
+                    tokio::select! {
+                        signal = async {
+                            for signal in resize_signals.forever() {
+                                if signal == signal_hook::consts::SIGWINCH {
+                                    return signal;
                                 }
                             }
-                    }
-
-                    // Handle cancellation
-                    _ = cancel_for_resize.changed() => {
-                        if *cancel_for_resize.borrow() {
-                            break;
+                            signal_hook::consts::SIGWINCH
+                        } => {
+                            if signal == signal_hook::consts::SIGWINCH
+                                && let Ok((width, height)) = crate::pty::utils::get_terminal_size()
+                                && resize_tx
+                                    .try_send(PtyMessage::Resize { width, height })
+                                    .is_err()
+                            {
+                                break;
+                            }
+                        }
+                        _ = cancel_for_resize.changed() => {
+                            if *cancel_for_resize.borrow() {
+                                break;
+                            }
                         }
                     }
                 }
-            }
-        });
+            }))
+        };
 
         // Spawn input reader task
         let input_tx = self
@@ -253,11 +283,9 @@ impl PtySession {
 
                     match msg {
                         Some(ChannelMsg::Data { ref data }) => {
-                            // Filter terminal escape sequence responses before display
-                            // This prevents raw XTGETTCAP, DA1/DA2/DA3 responses from appearing
-                            // on screen when running applications like Neovim
                             let terminal_guard = &mut self.terminal_guard;
-                            if let Err(e) = deliver_filtered_output(
+                            if let Err(e) = deliver_session_output(
+                                self.config.disable_pty,
                                 &mut self.escape_filter,
                                 &mut io::stdout(),
                                 data,
@@ -273,19 +301,30 @@ impl PtySession {
                         }
                         Some(ChannelMsg::ExtendedData { ref data, ext }) => {
                             if ext == 1 {
-                                // stderr - also filter escape sequences
-                                let terminal_guard = &mut self.terminal_guard;
-                                if let Err(e) = deliver_filtered_output(
-                                    &mut self.escape_filter,
-                                    &mut io::stdout(),
-                                    data,
-                                    |delivered| {
-                                        if let Some(guard) = terminal_guard.as_mut() {
-                                            guard.observe_remote_output(delivered);
-                                        }
-                                    },
-                                ) {
-                                    tracing::error!("Failed to write stderr to stdout: {e}");
+                                let result = if self.config.disable_pty {
+                                    deliver_session_output(
+                                        true,
+                                        &mut self.escape_filter,
+                                        &mut io::stderr(),
+                                        data,
+                                        |_| {},
+                                    )
+                                } else {
+                                    let terminal_guard = &mut self.terminal_guard;
+                                    deliver_session_output(
+                                        false,
+                                        &mut self.escape_filter,
+                                        &mut io::stdout(),
+                                        data,
+                                        |delivered| {
+                                            if let Some(guard) = terminal_guard.as_mut() {
+                                                guard.observe_remote_output(delivered);
+                                            }
+                                        },
+                                    )
+                                };
+                                if let Err(e) = result {
+                                    tracing::error!("Failed to write stderr: {e}");
                                     should_terminate = true;
                                 }
                             }
@@ -329,11 +368,9 @@ impl PtySession {
                             }
                         }
                         Some(PtyMessage::RemoteOutput(data)) => {
-                            // Apply escape filter for consistency with SSH channel data
-                            // This path may receive data from other sources that could
-                            // contain terminal responses that shouldn't be displayed
                             let terminal_guard = &mut self.terminal_guard;
-                            if let Err(e) = deliver_filtered_output(
+                            if let Err(e) = deliver_session_output(
+                                self.config.disable_pty,
                                 &mut self.escape_filter,
                                 &mut io::stdout(),
                                 &data,
@@ -348,10 +385,12 @@ impl PtySession {
                             }
                         }
                         Some(PtyMessage::Resize { width, height }) => {
-                            if let Err(e) = self.channel.window_change(width, height, 0, 0).await {
-                                tracing::warn!("Failed to send window resize to remote: {e}");
-                            } else {
-                                tracing::debug!("Terminal resized to {width}x{height}");
+                            if !self.config.disable_pty {
+                                if let Err(e) = self.channel.window_change(width, height, 0, 0).await {
+                                    tracing::warn!("Failed to send window resize to remote: {e}");
+                                } else {
+                                    tracing::debug!("Terminal resized to {width}x{height}");
+                                }
                             }
                         }
                         Some(PtyMessage::Terminate) => {
@@ -410,13 +449,18 @@ impl PtySession {
         // No need to abort since they check cancellation signal
 
         // Wait for tasks to complete gracefully with select!
+        let resize_cleanup = async {
+            if let Some(task) = resize_task {
+                let _ = task.await;
+            } else {
+                std::future::pending::<()>().await;
+            }
+        };
         let _ = tokio::time::timeout(Duration::from_millis(TASK_CLEANUP_TIMEOUT_MS), async {
             tokio::select! {
-                _ = resize_task => {},
+                _ = resize_cleanup => {},
                 _ = input_task => {},
-                _ = tokio::time::sleep(Duration::from_millis(TASK_CLEANUP_TIMEOUT_MS)) => {
-                    // Timeout reached, tasks should have finished by now
-                }
+                _ = tokio::time::sleep(Duration::from_millis(TASK_CLEANUP_TIMEOUT_MS)) => {}
             }
         })
         .await;
@@ -462,5 +506,76 @@ impl Drop for PtySession {
         // Signal cancellation to all tasks when session is dropped
         let _ = self.cancel_tx.send(true);
         // Terminal guard will be dropped automatically, restoring terminal state
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn no_pty_setup_sends_policy_env_once_before_one_shell_request() {
+        let config = PtyConfig {
+            disable_pty: true,
+            environment: vec![
+                ("FIRST".into(), "one".into()),
+                ("SECOND".into(), "two".into()),
+            ],
+            ..Default::default()
+        };
+        let plan = session_setup_plan(&config);
+        assert_eq!(
+            plan,
+            [
+                SessionSetupStep::Environment(0),
+                SessionSetupStep::Environment(1),
+                SessionSetupStep::RequestShell,
+            ]
+        );
+        assert_eq!(
+            plan.iter()
+                .filter(|step| matches!(step, SessionSetupStep::RequestPty))
+                .count(),
+            0
+        );
+        assert_eq!(
+            plan.iter()
+                .filter(|step| matches!(step, SessionSetupStep::RequestShell))
+                .count(),
+            1
+        );
+        let environment_positions = plan
+            .iter()
+            .enumerate()
+            .filter_map(|(index, step)| {
+                matches!(step, SessionSetupStep::Environment(_)).then_some(index)
+            })
+            .collect::<Vec<_>>();
+        let shell_position = plan
+            .iter()
+            .position(|step| matches!(step, SessionSetupStep::RequestShell))
+            .unwrap();
+        assert!(
+            environment_positions
+                .iter()
+                .all(|position| *position < shell_position)
+        );
+    }
+
+    #[test]
+    fn pty_setup_orders_environment_terminal_pty_and_shell() {
+        let config = PtyConfig {
+            environment: vec![("POLICY".into(), "value".into())],
+            ..Default::default()
+        };
+        assert_eq!(
+            session_setup_plan(&config),
+            [
+                SessionSetupStep::Environment(0),
+                SessionSetupStep::TerminalEnvironment,
+                SessionSetupStep::RequestPty,
+                SessionSetupStep::RequestShell,
+            ]
+        );
     }
 }

--- a/src/pty/session/session_manager.rs
+++ b/src/pty/session/session_manager.rs
@@ -178,11 +178,12 @@ impl PtySession {
             anyhow::bail!("PTY session is not in active state");
         }
 
-        // Pipes already deliver bytes without terminal line discipline. A local
-        // TTY enters raw mode so control and binary bytes reach the SSH stream.
+        // Match OpenSSH client_loop semantics: only a session with a remote PTY
+        // changes the local terminal to raw mode. No-PTY shells retain the OS
+        // line discipline and forward the bytes that stdin delivers unchanged.
         let mut terminal_guard = if io::stdin().is_terminal() && io::stdout().is_terminal() {
             if self.config.disable_pty {
-                TerminalStateGuard::new_raw_mode_without_protocol()?
+                TerminalStateGuard::new_without_raw_mode()?
             } else {
                 TerminalStateGuard::new()?
             }
@@ -193,7 +194,7 @@ impl PtySession {
         self.terminal_guard = Some(terminal_guard);
 
         // Enable mouse support if requested
-        if self.config.enable_mouse {
+        if self.config.enable_mouse && !self.config.disable_pty {
             TerminalOps::enable_mouse()?;
         }
 
@@ -254,11 +255,12 @@ impl PtySession {
             .clone();
         let cancel_for_input = self.cancel_rx.clone();
 
-        // Spawn input reader in blocking thread pool to avoid blocking async runtime
-        // NOTE: TerminalStateGuard has already called enable_raw_mode() at this point,
-        // so stdin.read() will return raw bytes without line buffering
+        // Spawn input reader in the blocking thread pool. Local escape handling
+        // is an SSH PTY feature; a no-PTY shell forwards stdin without consuming
+        // sequences such as "~.".
+        let escape_enabled = !self.config.disable_pty;
         let input_task = tokio::task::spawn_blocking(move || {
-            raw_input_task::run(input_tx, cancel_for_input, pending_input);
+            raw_input_task::run(input_tx, cancel_for_input, pending_input, escape_enabled);
         });
 
         // We'll integrate channel reading into the main loop since russh Channel doesn't clone
@@ -466,7 +468,7 @@ impl PtySession {
         .await;
 
         // Disable mouse support if we enabled it
-        if self.config.enable_mouse {
+        if self.config.enable_mouse && !self.config.disable_pty {
             let _ = TerminalOps::disable_mouse();
         }
 

--- a/src/pty/terminal.rs
+++ b/src/pty/terminal.rs
@@ -145,14 +145,6 @@ impl TerminalStateGuard {
         })
     }
 
-    /// Enter raw mode without terminal protocol queries or control-sequence
-    /// setup. Used by no-PTY SSH streams that must not alter remote bytes.
-    pub fn new_raw_mode_without_protocol() -> Result<Self> {
-        let guard = Self::new_without_raw_mode()?;
-        guard.enter_raw_mode()?;
-        Ok(guard)
-    }
-
     /// Create a terminal state guard without entering raw mode
     pub fn new_without_raw_mode() -> Result<Self> {
         let owner = TerminalOwner::acquire()?;

--- a/src/pty/terminal.rs
+++ b/src/pty/terminal.rs
@@ -145,6 +145,14 @@ impl TerminalStateGuard {
         })
     }
 
+    /// Enter raw mode without terminal protocol queries or control-sequence
+    /// setup. Used by no-PTY SSH streams that must not alter remote bytes.
+    pub fn new_raw_mode_without_protocol() -> Result<Self> {
+        let guard = Self::new_without_raw_mode()?;
+        guard.enter_raw_mode()?;
+        Ok(guard)
+    }
+
     /// Create a terminal state guard without entering raw mode
     pub fn new_without_raw_mode() -> Result<Self> {
         let owner = TerminalOwner::acquire()?;

--- a/src/ssh/client/command.rs
+++ b/src/ssh/client/command.rs
@@ -77,6 +77,7 @@ impl SshClient {
             jump_hosts_spec: None,         // No jump hosts
             ssh_connection_config: None,
             ssh_connection_config_resolver: None,
+            session_policy: None,
             ssh_password,
         };
 
@@ -125,11 +126,19 @@ impl SshClient {
             .await?;
 
         tracing::debug!("Connected and authenticated successfully");
+        if let Some(policy) = config.session_policy {
+            policy.run_local_command().await?;
+        }
         tracing::debug!("Executing command: {}", command);
 
         // Execute command with timeout
         let result = self
-            .execute_with_timeout(&client, command, config.timeout_seconds)
+            .execute_with_timeout(
+                &client,
+                command,
+                config.timeout_seconds,
+                config.session_policy,
+            )
             .await?;
 
         tracing::debug!(
@@ -146,18 +155,31 @@ impl SshClient {
         })
     }
 
+    async fn execute_resolved_session(
+        client: &crate::ssh::tokio_client::Client,
+        command: &str,
+        session_policy: Option<&crate::ssh::SessionPolicy>,
+    ) -> Result<crate::ssh::tokio_client::CommandExecutedResult, crate::ssh::tokio_client::Error>
+    {
+        match session_policy {
+            Some(policy) => client.execute_session(policy).await,
+            None => client.execute(command).await,
+        }
+    }
+
     /// Execute a command with the specified timeout
     async fn execute_with_timeout(
         &self,
         client: &crate::ssh::tokio_client::Client,
         command: &str,
         timeout_seconds: Option<u64>,
+        session_policy: Option<&crate::ssh::SessionPolicy>,
     ) -> Result<crate::ssh::tokio_client::CommandExecutedResult> {
         if let Some(timeout_secs) = timeout_seconds {
             if timeout_secs == 0 {
                 // No timeout (unlimited)
                 tracing::debug!("Executing command with no timeout (unlimited)");
-                client.execute(command)
+                Self::execute_resolved_session(client, command, session_policy)
                     .await
                     .with_context(|| format!("Failed to execute command '{}' on {}:{}. The SSH connection was successful but the command could not be executed.", command, self.host, self.port))
             } else {
@@ -166,7 +188,7 @@ impl SshClient {
                 tracing::debug!("Executing command with timeout of {} seconds", timeout_secs);
                 tokio::time::timeout(
                     command_timeout,
-                    client.execute(command)
+                    Self::execute_resolved_session(client, command, session_policy)
                 )
                 .await
                 .with_context(|| format!("Command execution timeout: The command '{}' did not complete within {} seconds on {}:{}", command, timeout_secs, self.host, self.port))?
@@ -178,7 +200,7 @@ impl SshClient {
             tracing::debug!("Executing command with default timeout of 300 seconds");
             tokio::time::timeout(
                 command_timeout,
-                client.execute(command)
+                Self::execute_resolved_session(client, command, session_policy)
             )
             .await
             .with_context(|| format!("Command execution timeout: The command '{}' did not complete within 5 minutes on {}:{}", command, self.host, self.port))?
@@ -239,16 +261,41 @@ impl SshClient {
             .await?;
 
         tracing::debug!("Connected and authenticated successfully");
+        if let Some(policy) = config.session_policy {
+            policy.run_local_command().await?;
+        }
         tracing::debug!("Executing command with streaming: {}", command);
 
         // Execute command with streaming and timeout
         let exit_status = self
-            .execute_streaming_with_timeout(&client, command, config.timeout_seconds, output_sender)
+            .execute_streaming_with_timeout(
+                &client,
+                command,
+                config.timeout_seconds,
+                output_sender,
+                config.session_policy,
+            )
             .await?;
 
         tracing::debug!("Command execution completed with status: {}", exit_status);
 
         Ok(exit_status)
+    }
+
+    async fn execute_resolved_session_streaming(
+        client: &crate::ssh::tokio_client::Client,
+        command: &str,
+        output_sender: Sender<CommandOutput>,
+        session_policy: Option<&crate::ssh::SessionPolicy>,
+    ) -> Result<u32, crate::ssh::tokio_client::Error> {
+        match session_policy {
+            Some(policy) => {
+                client
+                    .execute_session_streaming(policy, output_sender)
+                    .await
+            }
+            None => client.execute_streaming(command, output_sender).await,
+        }
     }
 
     /// Execute a command with streaming output and the specified timeout
@@ -258,12 +305,13 @@ impl SshClient {
         command: &str,
         timeout_seconds: Option<u64>,
         output_sender: Sender<CommandOutput>,
+        session_policy: Option<&crate::ssh::SessionPolicy>,
     ) -> Result<u32> {
         if let Some(timeout_secs) = timeout_seconds {
             if timeout_secs == 0 {
                 // No timeout (unlimited)
                 tracing::debug!("Executing command with streaming, no timeout (unlimited)");
-                client.execute_streaming(command, output_sender)
+                Self::execute_resolved_session_streaming(client, command, output_sender, session_policy)
                     .await
                     .with_context(|| format!("Failed to execute command '{}' on {}:{}. The SSH connection was successful but the command could not be executed.", command, self.host, self.port))
             } else {
@@ -275,7 +323,7 @@ impl SshClient {
                 );
                 tokio::time::timeout(
                     command_timeout,
-                    client.execute_streaming(command, output_sender)
+                    Self::execute_resolved_session_streaming(client, command, output_sender, session_policy)
                 )
                 .await
                 .with_context(|| format!("Command execution timeout: The command '{}' did not complete within {} seconds on {}:{}", command, timeout_secs, self.host, self.port))?
@@ -287,7 +335,7 @@ impl SshClient {
             tracing::debug!("Executing command with streaming, default timeout of 300 seconds");
             tokio::time::timeout(
                 command_timeout,
-                client.execute_streaming(command, output_sender)
+                Self::execute_resolved_session_streaming(client, command, output_sender, session_policy)
             )
             .await
             .with_context(|| format!("Command execution timeout: The command '{}' did not complete within 5 minutes on {}:{}", command, self.host, self.port))?
@@ -354,6 +402,9 @@ impl SshClient {
             .await?;
 
         tracing::debug!("Connected and authenticated successfully");
+        if let Some(policy) = config.session_policy {
+            policy.run_local_command().await?;
+        }
         tracing::debug!("Executing command with sudo support: {}", command);
 
         // Execute command with sudo support and timeout
@@ -364,6 +415,7 @@ impl SshClient {
                 config.timeout_seconds,
                 output_sender,
                 sudo_password,
+                config.session_policy,
             )
             .await?;
 
@@ -380,13 +432,14 @@ impl SshClient {
         timeout_seconds: Option<u64>,
         output_sender: Sender<CommandOutput>,
         sudo_password: &SudoPassword,
+        session_policy: Option<&crate::ssh::SessionPolicy>,
     ) -> Result<u32> {
         if let Some(timeout_secs) = timeout_seconds {
             if timeout_secs == 0 {
                 // No timeout (unlimited)
                 tracing::debug!("Executing sudo command with no timeout (unlimited)");
                 client
-                    .execute_with_sudo(command, output_sender, sudo_password)
+                    .execute_with_sudo_policy(command, output_sender, sudo_password, session_policy)
                     .await
                     .with_context(|| {
                         format!(
@@ -403,7 +456,7 @@ impl SshClient {
                 );
                 tokio::time::timeout(
                     command_timeout,
-                    client.execute_with_sudo(command, output_sender, sudo_password)
+                    client.execute_with_sudo_policy(command, output_sender, sudo_password, session_policy)
                 )
                 .await
                 .with_context(|| format!("Command execution timeout: The sudo command '{}' did not complete within {} seconds on {}:{}", command, timeout_secs, self.host, self.port))?
@@ -415,7 +468,7 @@ impl SshClient {
             tracing::debug!("Executing sudo command with default timeout of 300 seconds");
             tokio::time::timeout(
                 command_timeout,
-                client.execute_with_sudo(command, output_sender, sudo_password)
+                client.execute_with_sudo_policy(command, output_sender, sudo_password, session_policy)
             )
             .await
             .with_context(|| format!("Command execution timeout: The sudo command '{}' did not complete within 5 minutes on {}:{}", command, self.host, self.port))?

--- a/src/ssh/client/config.rs
+++ b/src/ssh/client/config.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use crate::security::Password;
+use crate::ssh::SessionPolicy;
 use crate::ssh::known_hosts::StrictHostKeyChecking;
 use crate::ssh::tokio_client::{SshConnectionConfig, SshConnectionConfigResolver};
 use std::path::Path;
@@ -34,6 +35,8 @@ pub struct ConnectionConfig<'a> {
     pub ssh_connection_config: Option<&'a SshConnectionConfig>,
     /// Per-host connection settings resolver used by jump chains.
     pub ssh_connection_config_resolver: Option<&'a SshConnectionConfigResolver>,
+    /// Resolved environment, command, TTY, and channel request policy.
+    pub session_policy: Option<&'a SessionPolicy>,
     /// Pre-collected SSH password shared with every per-node auth task.
     ///
     /// When `use_password` is `true`, this MUST be `Some(_)`; the dispatcher

--- a/src/ssh/mod.rs
+++ b/src/ssh/mod.rs
@@ -18,6 +18,7 @@ pub mod config_cache;
 pub mod handler;
 pub mod known_hosts;
 pub mod pool;
+pub mod session_policy;
 pub mod ssh_config;
 pub mod tokio_client;
 
@@ -29,4 +30,5 @@ pub use client::SshClient;
 pub use config_cache::{CacheConfig, CacheStats, GLOBAL_CACHE, SshConfigCache};
 pub use handler::BsshHandler;
 pub use pool::ConnectionPool;
+pub use session_policy::{CliTtyMode, SessionPolicy, SessionRequest};
 pub use ssh_config::{SshConfig, SshHostConfig};

--- a/src/ssh/session_policy.rs
+++ b/src/ssh/session_policy.rs
@@ -69,6 +69,7 @@ struct TokenContext {
     local_host: String,
     local_host_short: String,
     local_uid: String,
+    jump_host: String,
     connection_hash: String,
 }
 
@@ -80,16 +81,36 @@ impl SessionPolicy {
         cli_tty: CliTtyMode,
         stdin_is_terminal: bool,
     ) -> Result<Self> {
-        Self::resolve_with_environment(
+        Self::resolve_with_jump_spec(
             config,
             node,
             explicit_command,
             cli_tty,
             stdin_is_terminal,
+            None,
+        )
+    }
+
+    pub fn resolve_with_jump_spec(
+        config: &SshHostConfig,
+        node: &Node,
+        explicit_command: Option<&str>,
+        cli_tty: CliTtyMode,
+        stdin_is_terminal: bool,
+        jump_spec: Option<&str>,
+    ) -> Result<Self> {
+        Self::resolve_with_environment_and_jump_spec(
+            config,
+            node,
+            explicit_command,
+            cli_tty,
+            stdin_is_terminal,
+            jump_spec,
             std::env::vars_os(),
         )
     }
 
+    #[cfg(test)]
     fn resolve_with_environment<I>(
         config: &SshHostConfig,
         node: &Node,
@@ -101,13 +122,49 @@ impl SessionPolicy {
     where
         I: IntoIterator<Item = (OsString, OsString)>,
     {
-        let tokens = TokenContext::for_node(config, node)?;
-        let environment = resolve_environment(config, local_environment, &tokens)?;
+        Self::resolve_with_environment_and_jump_spec(
+            config,
+            node,
+            explicit_command,
+            cli_tty,
+            stdin_is_terminal,
+            None,
+            local_environment,
+        )
+    }
+
+    fn resolve_with_environment_and_jump_spec<I>(
+        config: &SshHostConfig,
+        node: &Node,
+        explicit_command: Option<&str>,
+        cli_tty: CliTtyMode,
+        stdin_is_terminal: bool,
+        jump_spec: Option<&str>,
+        local_environment: I,
+    ) -> Result<Self>
+    where
+        I: IntoIterator<Item = (OsString, OsString)>,
+    {
+        let tokens = TokenContext::for_node(config, node, jump_spec)?;
+        let local_environment = local_environment
+            .into_iter()
+            .filter_map(|(name, value)| Some((name.into_string().ok()?, value.into_string().ok()?)))
+            .collect::<BTreeMap<_, _>>();
+        let environment = resolve_environment(config, &local_environment, &tokens)?;
         let local_command = if config.permit_local_command.unwrap_or(false) {
             config
                 .local_command
                 .as_deref()
-                .map(|command| expand_tokens(command, &tokens, true, MAX_EXPANDED_COMMAND_BYTES))
+                .map(|command| {
+                    expand_tokens(
+                        command,
+                        &tokens,
+                        TokenSet::LocalCommand,
+                        true,
+                        None,
+                        MAX_EXPANDED_COMMAND_BYTES,
+                    )
+                })
                 .transpose()?
                 .map(|command| validate_local_shell_command(&command).map(|()| command))
                 .transpose()?
@@ -118,7 +175,16 @@ impl SessionPolicy {
         let configured_command = config
             .remote_command
             .as_deref()
-            .map(|command| expand_tokens(command, &tokens, true, MAX_EXPANDED_COMMAND_BYTES))
+            .map(|command| {
+                expand_tokens(
+                    command,
+                    &tokens,
+                    TokenSet::Default,
+                    true,
+                    None,
+                    MAX_EXPANDED_COMMAND_BYTES,
+                )
+            })
             .transpose()?
             .map(|command| crate::utils::sanitize_command(&command))
             .transpose()?;
@@ -173,7 +239,7 @@ impl SessionPolicy {
 }
 
 impl TokenContext {
-    fn for_node(config: &SshHostConfig, node: &Node) -> Result<Self> {
+    fn for_node(config: &SshHostConfig, node: &Node, jump_spec: Option<&str>) -> Result<Self> {
         let local_user = whoami::username().unwrap_or_else(|_| "user".to_string());
         let local_home = dirs::home_dir()
             .unwrap_or_default()
@@ -190,11 +256,17 @@ impl TokenContext {
             .host_key_alias
             .clone()
             .unwrap_or_else(|| node.original_host.clone());
+        let jump_host = jump_spec
+            .or(config.proxy_jump.as_deref())
+            .filter(|value| !value.eq_ignore_ascii_case("none"))
+            .unwrap_or("")
+            .to_string();
         let mut digest = Sha1::new();
         digest.update(local_host.as_bytes());
         digest.update(node.host.as_bytes());
         digest.update(node.port.to_string().as_bytes());
         digest.update(node.username.as_bytes());
+        digest.update(jump_host.as_bytes());
         let digest = digest.finalize();
         let mut connection_hash = String::with_capacity(digest.len() * 2);
         for byte in digest {
@@ -212,36 +284,38 @@ impl TokenContext {
             local_host,
             local_host_short,
             local_uid,
+            jump_host,
             connection_hash,
         })
     }
 }
 
-fn resolve_environment<I>(
+fn resolve_environment(
     config: &SshHostConfig,
-    local_environment: I,
+    local_environment: &BTreeMap<String, String>,
     tokens: &TokenContext,
-) -> Result<Vec<(String, String)>>
-where
-    I: IntoIterator<Item = (OsString, OsString)>,
-{
+) -> Result<Vec<(String, String)>> {
     if config.send_env.len() > MAX_ENVIRONMENT_REQUESTS {
         anyhow::bail!("Too many SendEnv patterns (max {MAX_ENVIRONMENT_REQUESTS})");
     }
     let send_env_patterns = resolve_send_env_patterns(&config.send_env)?;
     let mut environment = BTreeMap::new();
     for (name, value) in local_environment {
-        let (Ok(name), Ok(value)) = (name.into_string(), value.into_string()) else {
-            continue;
-        };
-        if send_env_selected(&name, &send_env_patterns) {
-            validate_environment(&name, &value)?;
-            environment.insert(name, value);
+        if send_env_selected(name, &send_env_patterns) {
+            validate_environment(name, value)?;
+            environment.insert(name.clone(), value.clone());
             validate_environment_count(environment.len())?;
         }
     }
     for (name, value) in &config.set_env {
-        let value = expand_tokens(value, tokens, false, MAX_ENVIRONMENT_VALUE_BYTES)?;
+        let value = expand_tokens(
+            value,
+            tokens,
+            TokenSet::Default,
+            false,
+            Some(local_environment),
+            MAX_ENVIRONMENT_VALUE_BYTES,
+        )?;
         validate_environment(name, &value)?;
         environment.insert(name.clone(), value);
         validate_environment_count(environment.len())?;
@@ -302,18 +376,50 @@ pub(crate) fn validate_environment(name: &str, value: &str) -> Result<()> {
     Ok(())
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum TokenSet {
+    Default,
+    LocalCommand,
+}
+
 fn expand_tokens(
     value: &str,
     tokens: &TokenContext,
+    token_set: TokenSet,
     shell_safe: bool,
+    local_environment: Option<&BTreeMap<String, String>>,
     max_bytes: usize,
 ) -> Result<String> {
     if value.len() > max_bytes {
         anyhow::bail!("SSH value is too long before token expansion (max {max_bytes} bytes)");
     }
     let mut expanded = String::with_capacity(value.len());
-    let mut chars = value.chars();
+    let mut chars = value.chars().peekable();
     while let Some(ch) = chars.next() {
+        if ch == '$' && chars.peek() == Some(&'{') && local_environment.is_some() {
+            chars.next();
+            let mut name = String::new();
+            loop {
+                match chars.next() {
+                    Some('}') => break,
+                    Some(ch) => name.push(ch),
+                    None => {
+                        anyhow::bail!("Environment variable expansion is missing closing '}}'")
+                    }
+                }
+            }
+            if name.is_empty() {
+                anyhow::bail!("Environment variable expansion has an empty name");
+            }
+            let replacement = local_environment
+                .and_then(|environment| environment.get(&name))
+                .with_context(|| format!("Environment variable ${{{name}}} is not set"))?;
+            expanded.push_str(replacement);
+            if expanded.len() > max_bytes {
+                anyhow::bail!("Expanded SSH value is too long (max {max_bytes} bytes)");
+            }
+            continue;
+        }
         if ch != '%' {
             expanded.push(ch);
             continue;
@@ -325,15 +431,16 @@ fn expand_tokens(
             '%' => ("literal percent", "%"),
             'C' => ("connection hash", tokens.connection_hash.as_str()),
             'd' => ("local home", tokens.local_home.as_str()),
-            'h' | 'H' => ("effective host", tokens.effective_host.as_str()),
+            'h' => ("effective host", tokens.effective_host.as_str()),
             'i' => ("local uid", tokens.local_uid.as_str()),
+            'j' => ("proxy jump", tokens.jump_host.as_str()),
             'k' => ("host key alias", tokens.host_key_alias.as_str()),
             'L' => ("short local host", tokens.local_host_short.as_str()),
             'l' => ("local host", tokens.local_host.as_str()),
             'n' => ("original host", tokens.original_host.as_str()),
             'p' => ("port", tokens.port.as_str()),
             'r' => ("remote user", tokens.remote_user.as_str()),
-            'T' => ("tun/tap device", "NONE"),
+            'T' if token_set == TokenSet::LocalCommand => ("tun/tap device", "NONE"),
             'u' => ("local user", tokens.local_user.as_str()),
             _ => anyhow::bail!("Unsupported SSH percent token: %{token}"),
         };

--- a/src/ssh/session_policy.rs
+++ b/src/ssh/session_policy.rs
@@ -1,0 +1,434 @@
+// Copyright 2025 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Runtime application of ssh_config channel and command policy.
+
+use std::collections::BTreeMap;
+use std::ffi::OsString;
+use std::fmt::Write as _;
+use std::process::ExitStatus;
+
+use anyhow::{Context, Result};
+use glob::Pattern;
+use sha1::{Digest, Sha1};
+use tokio::process::Command;
+
+use crate::node::Node;
+
+use super::ssh_config::SshHostConfig;
+
+pub const MAX_ENVIRONMENT_NAME_BYTES: usize = 256;
+pub const MAX_ENVIRONMENT_VALUE_BYTES: usize = 32 * 1024;
+pub const MAX_ENVIRONMENT_REQUESTS: usize = 1024;
+const MAX_EXPANDED_COMMAND_BYTES: usize = 16 * 1024;
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum CliTtyMode {
+    #[default]
+    Default,
+    Force,
+    Disable,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SessionRequest {
+    Exec(String),
+    Shell,
+    Subsystem(String),
+    None,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SessionPolicy {
+    pub environment: Vec<(String, String)>,
+    pub local_command: Option<String>,
+    pub request_pty: bool,
+    pub request: SessionRequest,
+}
+
+#[derive(Debug, Clone)]
+struct TokenContext {
+    effective_host: String,
+    original_host: String,
+    host_key_alias: String,
+    port: String,
+    remote_user: String,
+    local_user: String,
+    local_home: String,
+    local_host: String,
+    local_host_short: String,
+    local_uid: String,
+    connection_hash: String,
+}
+
+impl SessionPolicy {
+    pub fn resolve(
+        config: &SshHostConfig,
+        node: &Node,
+        explicit_command: Option<&str>,
+        cli_tty: CliTtyMode,
+        stdin_is_terminal: bool,
+    ) -> Result<Self> {
+        Self::resolve_with_environment(
+            config,
+            node,
+            explicit_command,
+            cli_tty,
+            stdin_is_terminal,
+            std::env::vars_os(),
+        )
+    }
+
+    fn resolve_with_environment<I>(
+        config: &SshHostConfig,
+        node: &Node,
+        explicit_command: Option<&str>,
+        cli_tty: CliTtyMode,
+        stdin_is_terminal: bool,
+        local_environment: I,
+    ) -> Result<Self>
+    where
+        I: IntoIterator<Item = (OsString, OsString)>,
+    {
+        let tokens = TokenContext::for_node(config, node)?;
+        let environment = resolve_environment(config, local_environment, &tokens)?;
+        let local_command = if config.permit_local_command.unwrap_or(false) {
+            config
+                .local_command
+                .as_deref()
+                .map(|command| expand_tokens(command, &tokens, true, MAX_EXPANDED_COMMAND_BYTES))
+                .transpose()?
+                .map(|command| validate_local_shell_command(&command).map(|()| command))
+                .transpose()?
+        } else {
+            None
+        };
+
+        let configured_command = config
+            .remote_command
+            .as_deref()
+            .map(|command| expand_tokens(command, &tokens, true, MAX_EXPANDED_COMMAND_BYTES))
+            .transpose()?
+            .map(|command| crate::utils::sanitize_command(&command))
+            .transpose()?;
+        if configured_command.is_some() && explicit_command.is_some_and(|value| !value.is_empty()) {
+            anyhow::bail!("RemoteCommand cannot be used together with an explicit command");
+        }
+        let command = configured_command.or_else(|| {
+            explicit_command
+                .filter(|value| !value.is_empty())
+                .map(str::to_owned)
+        });
+
+        let request =
+            match config.session_type.as_deref().unwrap_or("default") {
+                "default" => command.map_or(SessionRequest::Shell, SessionRequest::Exec),
+                "subsystem" => SessionRequest::Subsystem(command.context(
+                    "SessionType subsystem requires RemoteCommand to name the subsystem",
+                )?),
+                "none" if command.is_some() => {
+                    anyhow::bail!("SessionType none cannot be used with a command")
+                }
+                "none" => SessionRequest::None,
+                value => anyhow::bail!("Unsupported SessionType value: {value}"),
+            };
+        let interactive = matches!(request, SessionRequest::Shell);
+        let request_pty = resolve_request_pty(
+            cli_tty,
+            config.request_tty.as_deref(),
+            stdin_is_terminal,
+            interactive,
+        )?;
+
+        Ok(Self {
+            environment,
+            local_command,
+            request_pty,
+            request,
+        })
+    }
+
+    /// Run the configured local command once after authentication.
+    pub async fn run_local_command(&self) -> Result<()> {
+        let Some(command) = self.local_command.as_deref() else {
+            return Ok(());
+        };
+        let status = local_shell(command)
+            .status()
+            .await
+            .with_context(|| "Failed to execute LocalCommand")?;
+        ensure_local_command_success(status)
+    }
+}
+
+impl TokenContext {
+    fn for_node(config: &SshHostConfig, node: &Node) -> Result<Self> {
+        let local_user = whoami::username().unwrap_or_else(|_| "user".to_string());
+        let local_home = dirs::home_dir()
+            .unwrap_or_default()
+            .to_string_lossy()
+            .into_owned();
+        let local_host = whoami::hostname().unwrap_or_else(|_| "localhost".to_string());
+        let local_host_short = local_host
+            .split('.')
+            .next()
+            .unwrap_or(&local_host)
+            .to_string();
+        let local_uid = local_uid();
+        let host_key_alias = config
+            .host_key_alias
+            .clone()
+            .unwrap_or_else(|| node.original_host.clone());
+        let mut digest = Sha1::new();
+        digest.update(local_host.as_bytes());
+        digest.update(node.host.as_bytes());
+        digest.update(node.port.to_string().as_bytes());
+        digest.update(node.username.as_bytes());
+        let digest = digest.finalize();
+        let mut connection_hash = String::with_capacity(digest.len() * 2);
+        for byte in digest {
+            write!(connection_hash, "{byte:02x}").expect("writing to a String cannot fail");
+        }
+
+        Ok(Self {
+            effective_host: node.host.clone(),
+            original_host: node.original_host.clone(),
+            host_key_alias,
+            port: node.port.to_string(),
+            remote_user: node.username.clone(),
+            local_user,
+            local_home,
+            local_host,
+            local_host_short,
+            local_uid,
+            connection_hash,
+        })
+    }
+}
+
+fn resolve_environment<I>(
+    config: &SshHostConfig,
+    local_environment: I,
+    tokens: &TokenContext,
+) -> Result<Vec<(String, String)>>
+where
+    I: IntoIterator<Item = (OsString, OsString)>,
+{
+    if config.send_env.len() > MAX_ENVIRONMENT_REQUESTS {
+        anyhow::bail!("Too many SendEnv patterns (max {MAX_ENVIRONMENT_REQUESTS})");
+    }
+    let send_env_patterns = resolve_send_env_patterns(&config.send_env)?;
+    let mut environment = BTreeMap::new();
+    for (name, value) in local_environment {
+        let (Ok(name), Ok(value)) = (name.into_string(), value.into_string()) else {
+            continue;
+        };
+        if send_env_selected(&name, &send_env_patterns) {
+            validate_environment(&name, &value)?;
+            environment.insert(name, value);
+            validate_environment_count(environment.len())?;
+        }
+    }
+    for (name, value) in &config.set_env {
+        let value = expand_tokens(value, tokens, false, MAX_ENVIRONMENT_VALUE_BYTES)?;
+        validate_environment(name, &value)?;
+        environment.insert(name.clone(), value);
+        validate_environment_count(environment.len())?;
+    }
+    Ok(environment.into_iter().collect())
+}
+
+fn resolve_send_env_patterns(patterns: &[String]) -> Result<Vec<(String, Pattern)>> {
+    let mut active = Vec::new();
+    for raw in patterns {
+        if raw.len() > MAX_ENVIRONMENT_NAME_BYTES + usize::from(raw.starts_with('-'))
+            || raw.contains('=')
+            || raw.contains('\0')
+        {
+            anyhow::bail!("Invalid or oversized SendEnv pattern: {raw}");
+        }
+        if let Some(removal) = raw.strip_prefix('-') {
+            if removal.is_empty() {
+                anyhow::bail!("SendEnv removal pattern cannot be empty");
+            }
+            let removal = Pattern::new(removal)
+                .with_context(|| format!("Invalid SendEnv removal pattern: {raw}"))?;
+            active.retain(|(source, _): &(String, Pattern)| !removal.matches(source));
+        } else {
+            let pattern =
+                Pattern::new(raw).with_context(|| format!("Invalid SendEnv pattern: {raw}"))?;
+            active.push((raw.clone(), pattern));
+        }
+    }
+    Ok(active)
+}
+
+fn send_env_selected(name: &str, patterns: &[(String, Pattern)]) -> bool {
+    patterns.iter().any(|(_, pattern)| pattern.matches(name))
+}
+
+fn validate_environment_count(count: usize) -> Result<()> {
+    if count > MAX_ENVIRONMENT_REQUESTS {
+        anyhow::bail!(
+            "Too many SSH environment requests: {count} (max {MAX_ENVIRONMENT_REQUESTS})"
+        );
+    }
+    Ok(())
+}
+
+pub(crate) fn validate_environment(name: &str, value: &str) -> Result<()> {
+    if name.is_empty() || name.contains('=') || name.contains('\0') {
+        anyhow::bail!("SSH environment name is empty or contains '=' or NUL");
+    }
+    if name.len() > MAX_ENVIRONMENT_NAME_BYTES {
+        anyhow::bail!("SSH environment name is too long (max {MAX_ENVIRONMENT_NAME_BYTES} bytes)");
+    }
+    if value.contains('\0') || value.len() > MAX_ENVIRONMENT_VALUE_BYTES {
+        anyhow::bail!(
+            "SSH environment value is invalid or too long (max {MAX_ENVIRONMENT_VALUE_BYTES} bytes)"
+        );
+    }
+    Ok(())
+}
+
+fn expand_tokens(
+    value: &str,
+    tokens: &TokenContext,
+    shell_safe: bool,
+    max_bytes: usize,
+) -> Result<String> {
+    if value.len() > max_bytes {
+        anyhow::bail!("SSH value is too long before token expansion (max {max_bytes} bytes)");
+    }
+    let mut expanded = String::with_capacity(value.len());
+    let mut chars = value.chars();
+    while let Some(ch) = chars.next() {
+        if ch != '%' {
+            expanded.push(ch);
+            continue;
+        }
+        let token = chars
+            .next()
+            .context("Incomplete '%' token in SSH command")?;
+        let (name, replacement) = match token {
+            '%' => ("literal percent", "%"),
+            'C' => ("connection hash", tokens.connection_hash.as_str()),
+            'd' => ("local home", tokens.local_home.as_str()),
+            'h' | 'H' => ("effective host", tokens.effective_host.as_str()),
+            'i' => ("local uid", tokens.local_uid.as_str()),
+            'k' => ("host key alias", tokens.host_key_alias.as_str()),
+            'L' => ("short local host", tokens.local_host_short.as_str()),
+            'l' => ("local host", tokens.local_host.as_str()),
+            'n' => ("original host", tokens.original_host.as_str()),
+            'p' => ("port", tokens.port.as_str()),
+            'r' => ("remote user", tokens.remote_user.as_str()),
+            'T' => ("tun/tap device", "NONE"),
+            'u' => ("local user", tokens.local_user.as_str()),
+            _ => anyhow::bail!("Unsupported SSH percent token: %{token}"),
+        };
+        if shell_safe {
+            validate_shell_token_value(name, replacement)?;
+        }
+        expanded.push_str(replacement);
+        if expanded.len() > max_bytes {
+            anyhow::bail!("Expanded SSH value is too long (max {max_bytes} bytes)");
+        }
+    }
+    Ok(expanded)
+}
+
+fn resolve_request_pty(
+    cli: CliTtyMode,
+    configured: Option<&str>,
+    stdin_is_terminal: bool,
+    interactive: bool,
+) -> Result<bool> {
+    match cli {
+        CliTtyMode::Force => return Ok(true),
+        CliTtyMode::Disable => return Ok(false),
+        CliTtyMode::Default => {}
+    }
+    match configured.unwrap_or("auto").to_ascii_lowercase().as_str() {
+        "force" => Ok(true),
+        "yes" => Ok(stdin_is_terminal),
+        "auto" => Ok(interactive && stdin_is_terminal),
+        "no" => Ok(false),
+        value => anyhow::bail!("Unsupported RequestTTY value: {value}"),
+    }
+}
+
+fn validate_local_shell_command(command: &str) -> Result<()> {
+    if command.trim().is_empty() {
+        anyhow::bail!("LocalCommand cannot be empty");
+    }
+    if let Some(value) = command
+        .chars()
+        .find(|value| matches!(value, '\0' | '\n' | '\r'))
+    {
+        anyhow::bail!("LocalCommand contains invalid control character {value:?}");
+    }
+    Ok(())
+}
+
+fn validate_shell_token_value(name: &str, value: &str) -> Result<()> {
+    if value.len() > 1024
+        || value.chars().any(|ch| {
+            ch.is_control()
+                || matches!(
+                    ch,
+                    '\'' | '"' | '`' | '$' | ';' | '&' | '|' | '<' | '>' | '\\'
+                )
+        })
+    {
+        anyhow::bail!("Unsafe {name} value for SSH command token expansion");
+    }
+    Ok(())
+}
+
+fn ensure_local_command_success(status: ExitStatus) -> Result<()> {
+    if status.success() {
+        Ok(())
+    } else {
+        anyhow::bail!("LocalCommand exited with status {status}")
+    }
+}
+
+#[cfg(unix)]
+fn local_uid() -> String {
+    // SAFETY: getuid has no arguments, dereferences no pointers, and cannot fail.
+    unsafe { libc::getuid() }.to_string()
+}
+
+#[cfg(not(unix))]
+fn local_uid() -> String {
+    "0".to_string()
+}
+
+#[cfg(unix)]
+fn local_shell(command: &str) -> Command {
+    let mut child = Command::new(std::env::var_os("SHELL").unwrap_or_else(|| "/bin/sh".into()));
+    child.arg("-c").arg(command);
+    child
+}
+
+#[cfg(windows)]
+fn local_shell(command: &str) -> Command {
+    let mut child = Command::new("cmd.exe");
+    child.arg("/C").arg(command);
+    child
+}
+
+#[cfg(test)]
+#[path = "session_policy_tests.rs"]
+mod tests;

--- a/src/ssh/session_policy_tests.rs
+++ b/src/ssh/session_policy_tests.rs
@@ -1,0 +1,238 @@
+// Copyright 2025 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::*;
+
+fn node() -> Node {
+    Node::new("127.0.0.1".into(), 2222, "remote".into()).with_original_host("alias".into())
+}
+
+#[test]
+fn environment_requests_are_sorted_removed_bounded_and_setenv_wins() {
+    let mut config = SshHostConfig::default();
+    config.send_env = vec![
+        "TEST_*".into(),
+        "-TEST_*".into(),
+        "TEST_A".into(),
+        "TEST_B".into(),
+    ];
+    config.set_env.insert("TEST_A".into(), "configured".into());
+    config.set_env.insert("ZZZ".into(), "%n:%p".into());
+    let local = [
+        (OsString::from("TEST_B"), OsString::from("second")),
+        (OsString::from("TEST_DROP"), OsString::from("removed")),
+        (OsString::from("TEST_A"), OsString::from("local")),
+    ];
+
+    let policy = SessionPolicy::resolve_with_environment(
+        &config,
+        &node(),
+        Some("true"),
+        CliTtyMode::Default,
+        false,
+        local,
+    )
+    .unwrap();
+    assert_eq!(
+        policy.environment,
+        [
+            ("TEST_A".into(), "configured".into()),
+            ("TEST_B".into(), "second".into()),
+            ("ZZZ".into(), "alias:2222".into())
+        ]
+    );
+
+    config.set_env.insert(
+        "TOO_BIG".into(),
+        "x".repeat(MAX_ENVIRONMENT_VALUE_BYTES + 1),
+    );
+    assert!(
+        SessionPolicy::resolve(&config, &node(), Some("true"), CliTtyMode::Default, false).is_err()
+    );
+}
+
+#[test]
+fn remote_command_conflicts_and_session_request_kinds_are_exact() {
+    let mut config = SshHostConfig {
+        remote_command: Some("echo %n %% %h".into()),
+        ..Default::default()
+    };
+    assert!(
+        SessionPolicy::resolve(&config, &node(), Some("true"), CliTtyMode::Default, false).is_err()
+    );
+    let policy =
+        SessionPolicy::resolve(&config, &node(), None, CliTtyMode::Default, false).unwrap();
+    assert_eq!(
+        policy.request,
+        SessionRequest::Exec("echo alias % 127.0.0.1".into())
+    );
+
+    config.session_type = Some("subsystem".into());
+    config.remote_command = Some("sftp".into());
+    let policy =
+        SessionPolicy::resolve(&config, &node(), None, CliTtyMode::Default, false).unwrap();
+    assert_eq!(policy.request, SessionRequest::Subsystem("sftp".into()));
+
+    config.session_type = Some("none".into());
+    config.remote_command = None;
+    let policy =
+        SessionPolicy::resolve(&config, &node(), None, CliTtyMode::Default, false).unwrap();
+    assert_eq!(policy.request, SessionRequest::None);
+}
+
+#[test]
+fn request_tty_obeys_cli_precedence_and_config_modes() {
+    let mut config = SshHostConfig::default();
+    config.request_tty = Some("force".into());
+    assert!(
+        !SessionPolicy::resolve(&config, &node(), None, CliTtyMode::Disable, true)
+            .unwrap()
+            .request_pty
+    );
+    config.request_tty = Some("no".into());
+    assert!(
+        SessionPolicy::resolve(&config, &node(), Some("true"), CliTtyMode::Force, false)
+            .unwrap()
+            .request_pty
+    );
+    config.request_tty = Some("yes".into());
+    assert!(
+        !SessionPolicy::resolve(&config, &node(), Some("true"), CliTtyMode::Default, false)
+            .unwrap()
+            .request_pty
+    );
+    config.request_tty = Some("auto".into());
+    assert!(
+        SessionPolicy::resolve(&config, &node(), None, CliTtyMode::Default, true)
+            .unwrap()
+            .request_pty
+    );
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn local_command_runs_once_and_propagates_failure() {
+    let denied = SshHostConfig {
+        permit_local_command: Some(false),
+        local_command: Some("exit 99".into()),
+        ..Default::default()
+    };
+    let policy =
+        SessionPolicy::resolve(&denied, &node(), Some("true"), CliTtyMode::Default, false).unwrap();
+    assert_eq!(policy.local_command, None);
+    policy.run_local_command().await.unwrap();
+
+    let directory = tempfile::tempdir().unwrap();
+    let marker = directory.path().join("marker");
+    let mut config = SshHostConfig {
+        permit_local_command: Some(true),
+        local_command: Some(format!("printf x >> {}", marker.display())),
+        ..Default::default()
+    };
+    let policy =
+        SessionPolicy::resolve(&config, &node(), Some("true"), CliTtyMode::Default, false).unwrap();
+    policy.run_local_command().await.unwrap();
+    assert_eq!(std::fs::read_to_string(&marker).unwrap(), "x");
+
+    config.local_command = Some("exit 23".into());
+    let policy =
+        SessionPolicy::resolve(&config, &node(), Some("true"), CliTtyMode::Default, false).unwrap();
+    assert!(
+        policy
+            .run_local_command()
+            .await
+            .unwrap_err()
+            .to_string()
+            .contains("23")
+    );
+}
+
+#[test]
+fn environment_name_value_and_request_count_bounds_are_enforced() {
+    assert!(validate_environment("BAD=NAME", "value").is_err());
+    assert!(validate_environment(&"N".repeat(MAX_ENVIRONMENT_NAME_BYTES + 1), "value").is_err());
+    assert!(validate_environment("NAME", &"v".repeat(MAX_ENVIRONMENT_VALUE_BYTES + 1)).is_err());
+
+    let mut config = SshHostConfig::default();
+    config.send_env = vec!["BAD=PATTERN".into()];
+    assert!(
+        SessionPolicy::resolve_with_environment(
+            &config,
+            &node(),
+            Some("true"),
+            CliTtyMode::Default,
+            false,
+            [],
+        )
+        .is_err()
+    );
+
+    config.send_env = vec!["BOUND_*".into()];
+    let local = (0..=MAX_ENVIRONMENT_REQUESTS).map(|index| {
+        (
+            OsString::from(format!("BOUND_{index}")),
+            OsString::from("value"),
+        )
+    });
+    assert!(
+        SessionPolicy::resolve_with_environment(
+            &config,
+            &node(),
+            Some("true"),
+            CliTtyMode::Default,
+            false,
+            local,
+        )
+        .is_err()
+    );
+}
+
+#[test]
+fn percent_tokens_expand_exactly_and_reject_unsafe_or_oversized_values() {
+    let mut config = SshHostConfig {
+        remote_command: Some("%C|%d|%h|%H|%i|%k|%L|%l|%n|%p|%r|%T|%u|%%".into()),
+        ..Default::default()
+    };
+    let policy =
+        SessionPolicy::resolve(&config, &node(), None, CliTtyMode::Default, false).unwrap();
+    let SessionRequest::Exec(expanded) = policy.request else {
+        panic!("RemoteCommand must select an exec request");
+    };
+    let fields = expanded.split("|").collect::<Vec<_>>();
+    assert_eq!(fields.len(), 14);
+    assert_eq!(fields[0].len(), 40);
+    assert!(fields[0].chars().all(|ch| ch.is_ascii_hexdigit()));
+    assert_eq!(fields[2], "127.0.0.1");
+    assert_eq!(fields[3], "127.0.0.1");
+    assert_eq!(fields[5], "alias");
+    assert_eq!(fields[8], "alias");
+    assert_eq!(fields[9], "2222");
+    assert_eq!(fields[10], "remote");
+    assert_eq!(fields[11], "NONE");
+    assert_eq!(fields[13], "%");
+
+    config.remote_command = Some("echo %h".into());
+    let unsafe_node = Node::new("bad;host".into(), 22, "remote".into());
+    assert!(
+        SessionPolicy::resolve(&config, &unsafe_node, None, CliTtyMode::Default, false)
+            .unwrap_err()
+            .to_string()
+            .contains("Unsafe effective host")
+    );
+
+    config.remote_command = Some("echo %x".into());
+    assert!(SessionPolicy::resolve(&config, &node(), None, CliTtyMode::Default, false).is_err());
+    config.remote_command = Some("x".repeat(MAX_EXPANDED_COMMAND_BYTES + 1));
+    assert!(SessionPolicy::resolve(&config, &node(), None, CliTtyMode::Default, false).is_err());
+}

--- a/src/ssh/session_policy_tests.rs
+++ b/src/ssh/session_policy_tests.rs
@@ -28,11 +28,14 @@ fn environment_requests_are_sorted_removed_bounded_and_setenv_wins() {
         "TEST_B".into(),
     ];
     config.set_env.insert("TEST_A".into(), "configured".into());
-    config.set_env.insert("ZZZ".into(), "%n:%p".into());
+    config
+        .set_env
+        .insert("ZZZ".into(), "${EXPAND_TEST}:%n:%p".into());
     let local = [
         (OsString::from("TEST_B"), OsString::from("second")),
         (OsString::from("TEST_DROP"), OsString::from("removed")),
         (OsString::from("TEST_A"), OsString::from("local")),
+        (OsString::from("EXPAND_TEST"), OsString::from("expanded")),
     ];
 
     let policy = SessionPolicy::resolve_with_environment(
@@ -49,7 +52,7 @@ fn environment_requests_are_sorted_removed_bounded_and_setenv_wins() {
         [
             ("TEST_A".into(), "configured".into()),
             ("TEST_B".into(), "second".into()),
-            ("ZZZ".into(), "alias:2222".into())
+            ("ZZZ".into(), "expanded:alias:2222".into())
         ]
     );
 
@@ -199,30 +202,129 @@ fn environment_name_value_and_request_count_bounds_are_enforced() {
 }
 
 #[test]
-fn percent_tokens_expand_exactly_and_reject_unsafe_or_oversized_values() {
+fn directive_token_sets_jump_hash_and_setenv_dollar_expansion_are_exact() {
+    let jump_spec = "jump@example.net:2200";
     let mut config = SshHostConfig {
-        remote_command: Some("%C|%d|%h|%H|%i|%k|%L|%l|%n|%p|%r|%T|%u|%%".into()),
+        proxy_jump: Some("ignored-config-jump".into()),
+        remote_command: Some("%C|%d|%h|%i|%j|%k|%L|%l|%n|%p|%r|%u|%%".into()),
         ..Default::default()
     };
-    let policy =
-        SessionPolicy::resolve(&config, &node(), None, CliTtyMode::Default, false).unwrap();
+    let policy = SessionPolicy::resolve_with_jump_spec(
+        &config,
+        &node(),
+        None,
+        CliTtyMode::Default,
+        false,
+        Some(jump_spec),
+    )
+    .unwrap();
     let SessionRequest::Exec(expanded) = policy.request else {
         panic!("RemoteCommand must select an exec request");
     };
-    let fields = expanded.split("|").collect::<Vec<_>>();
-    assert_eq!(fields.len(), 14);
-    assert_eq!(fields[0].len(), 40);
-    assert!(fields[0].chars().all(|ch| ch.is_ascii_hexdigit()));
+    let fields = expanded.split('|').collect::<Vec<_>>();
+    assert_eq!(fields.len(), 13);
     assert_eq!(fields[2], "127.0.0.1");
-    assert_eq!(fields[3], "127.0.0.1");
+    assert_eq!(fields[4], jump_spec);
     assert_eq!(fields[5], "alias");
     assert_eq!(fields[8], "alias");
     assert_eq!(fields[9], "2222");
     assert_eq!(fields[10], "remote");
-    assert_eq!(fields[11], "NONE");
-    assert_eq!(fields[13], "%");
+    assert_eq!(fields[12], "%");
 
-    config.remote_command = Some("echo %h".into());
+    let local_host = whoami::hostname().unwrap_or_else(|_| "localhost".to_string());
+    let mut digest = Sha1::new();
+    digest.update(local_host.as_bytes());
+    digest.update(b"127.0.0.1");
+    digest.update(b"2222");
+    digest.update(b"remote");
+    digest.update(jump_spec.as_bytes());
+    let expected_hash = digest
+        .finalize()
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect::<String>();
+    assert_eq!(fields[0], expected_hash);
+
+    for invalid in ["echo %H", "echo %T"] {
+        config.remote_command = Some(invalid.into());
+        assert!(
+            SessionPolicy::resolve(&config, &node(), None, CliTtyMode::Default, false).is_err()
+        );
+    }
+
+    config.remote_command = None;
+    config.permit_local_command = Some(true);
+    config.local_command = Some("echo %C %d %h %i %j %k %L %l %n %p %r %T %u %%".into());
+    let policy = SessionPolicy::resolve_with_jump_spec(
+        &config,
+        &node(),
+        Some("true"),
+        CliTtyMode::Default,
+        false,
+        Some(jump_spec),
+    )
+    .unwrap();
+    let local = policy.local_command.unwrap();
+    assert!(local.contains(jump_spec));
+    assert!(local.contains(" NONE "));
+    assert!(local.ends_with(" %"));
+
+    config.local_command = Some("echo %H".into());
+    assert!(
+        SessionPolicy::resolve(&config, &node(), Some("true"), CliTtyMode::Default, false).is_err()
+    );
+
+    config.local_command = None;
+    config.permit_local_command = None;
+    config
+        .set_env
+        .insert("EXPANDED".into(), "%C|%j|${SOURCE_VALUE}|%%".into());
+    let policy = SessionPolicy::resolve_with_environment_and_jump_spec(
+        &config,
+        &node(),
+        Some("true"),
+        CliTtyMode::Default,
+        false,
+        Some(jump_spec),
+        [(
+            OsString::from("SOURCE_VALUE"),
+            OsString::from("from-environment"),
+        )],
+    )
+    .unwrap();
+    assert_eq!(
+        policy.environment,
+        [(
+            "EXPANDED".into(),
+            format!("{expected_hash}|{jump_spec}|from-environment|%")
+        )]
+    );
+
+    for invalid in ["%H", "%T"] {
+        config
+            .set_env
+            .insert("EXPANDED".into(), invalid.to_string());
+        assert!(
+            SessionPolicy::resolve_with_environment_and_jump_spec(
+                &config,
+                &node(),
+                Some("true"),
+                CliTtyMode::Default,
+                false,
+                Some(jump_spec),
+                [],
+            )
+            .is_err()
+        );
+    }
+}
+
+#[test]
+fn expanded_shell_values_and_command_size_remain_bounded() {
+    let mut config = SshHostConfig {
+        remote_command: Some("echo %h".into()),
+        ..Default::default()
+    };
     let unsafe_node = Node::new("bad;host".into(), 22, "remote".into());
     assert!(
         SessionPolicy::resolve(&config, &unsafe_node, None, CliTtyMode::Default, false)

--- a/src/ssh/ssh_config/parser/options/command.rs
+++ b/src/ssh/ssh_config/parser/options/command.rs
@@ -41,9 +41,8 @@ pub(super) fn parse_command_option(
                 anyhow::bail!("LocalCommand requires a value at line {line_number}");
             }
             let command = args.join(" ");
-            // Security: Validate the command to prevent injection attacks
-            // LocalCommand supports token substitution: %h, %H, %n, %p, %r, %u
-            // These tokens are safe and will be substituted by the client
+            // LocalCommand accepts the default OpenSSH client token set plus %T.
+            // Expanded values are checked again at the runtime shell boundary.
             validate_command_with_tokens(&command, "LocalCommand", line_number)?;
             host.local_command = Some(command);
         }
@@ -52,6 +51,11 @@ pub(super) fn parse_command_option(
                 anyhow::bail!("RemoteCommand requires a value at line {line_number}");
             }
             let command = args.join(" ");
+            if command.trim().is_empty() {
+                anyhow::bail!("RemoteCommand cannot be empty at line {line_number}");
+            }
+
+            validate_default_percent_tokens(&command, "RemoteCommand", line_number, 16 * 1024)?;
 
             // Security: Warn about potentially dangerous patterns even though it runs remotely
             // This helps prevent lateral movement attacks
@@ -170,118 +174,126 @@ fn validate_remote_command_warnings(command: &str, line_number: usize) {
     }
 }
 
-/// Validate command strings that support token substitution
-///
-/// This function validates commands while allowing SSH token substitution patterns.
-/// Supports the OpenSSH LocalCommand percent-token set: `%C`, `%d`, `%h`, `%H`,
-/// `%i`, `%k`, `%L`, `%l`, `%n`, `%p`, `%r`, `%T`, `%u`, and `%%`.
-///
-/// The actual token substitution is performed by the SSH client, not the parser.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PercentTokenSet {
+    Default,
+    LocalCommand,
+    KnownHostsCommand,
+}
+
+impl PercentTokenSet {
+    fn accepts(self, token: char) -> bool {
+        let default = matches!(
+            token,
+            '%' | 'C' | 'd' | 'h' | 'i' | 'j' | 'k' | 'L' | 'l' | 'n' | 'p' | 'r' | 'u'
+        );
+        default
+            || matches!((self, token), (Self::LocalCommand, 'T'))
+            || matches!(
+                (self, token),
+                (Self::KnownHostsCommand, 'f' | 'H' | 'I' | 'K' | 't')
+            )
+    }
+
+    fn description(self) -> &'static str {
+        match self {
+            Self::Default => "%%, %C, %d, %h, %i, %j, %k, %L, %l, %n, %p, %r, %u",
+            Self::LocalCommand => "%%, %C, %d, %h, %i, %j, %k, %L, %l, %n, %p, %r, %T, %u",
+            Self::KnownHostsCommand => {
+                "%%, %C, %d, %f, %H, %h, %I, %i, %j, %K, %k, %L, %l, %n, %p, %r, %t, %u"
+            }
+        }
+    }
+}
+
+/// Validate the OpenSSH default client percent-token set without applying
+/// local-shell restrictions. RemoteCommand and SetEnv both use this set.
+pub(super) fn validate_default_percent_tokens(
+    value: &str,
+    option_name: &str,
+    line_number: usize,
+    max_bytes: usize,
+) -> Result<()> {
+    validate_percent_tokens(
+        value,
+        option_name,
+        line_number,
+        PercentTokenSet::Default,
+        max_bytes,
+    )
+}
+
+fn validate_percent_tokens(
+    value: &str,
+    option_name: &str,
+    line_number: usize,
+    token_set: PercentTokenSet,
+    max_bytes: usize,
+) -> Result<()> {
+    if value.len() > max_bytes {
+        anyhow::bail!("{option_name} exceeds the {max_bytes}-byte limit at line {line_number}");
+    }
+
+    const MAX_TOKENS: usize = 50;
+    let mut token_count = 0;
+    let mut chars = value.chars();
+    while let Some(ch) = chars.next() {
+        if ch != '%' {
+            continue;
+        }
+        let token = chars.next().ok_or_else(|| {
+            anyhow::anyhow!(
+                "Incomplete token '%' at end of {option_name} at line {line_number}; valid tokens are {}",
+                token_set.description()
+            )
+        })?;
+        if !token_set.accepts(token) {
+            anyhow::bail!(
+                "Invalid token '%{token}' in {option_name} at line {line_number}; valid tokens are {}",
+                token_set.description()
+            );
+        }
+        if token != '%' {
+            token_count += 1;
+            if token_count > MAX_TOKENS {
+                anyhow::bail!(
+                    "Security violation: {option_name} contains excessive token usage ({token_count} tokens) at line {line_number}. Maximum allowed is {MAX_TOKENS} tokens."
+                );
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Validate a locally executed command after replacing its accepted tokens
+/// with inert placeholders. Runtime expansion performs a second validation at
+/// the actual local-shell boundary.
 fn validate_command_with_tokens(
     command: &str,
     option_name: &str,
     line_number: usize,
 ) -> Result<()> {
-    // First, check if the command is empty or just whitespace
     if command.trim().is_empty() {
         anyhow::bail!("{option_name} cannot be empty at line {line_number}");
     }
+    let token_set = if option_name == "LocalCommand" {
+        PercentTokenSet::LocalCommand
+    } else {
+        PercentTokenSet::KnownHostsCommand
+    };
+    validate_percent_tokens(command, option_name, line_number, token_set, 16 * 1024)?;
 
-    // Security: Check for excessive token usage that could cause DoS
-    // Count the number of tokens (excluding %%)
-    let token_count = command.matches("%h").count()
-        + command.matches("%C").count()
-        + command.matches("%d").count()
-        + command.matches("%H").count()
-        + command.matches("%i").count()
-        + command.matches("%k").count()
-        + command.matches("%L").count()
-        + command.matches("%l").count()
-        + command.matches("%n").count()
-        + command.matches("%p").count()
-        + command.matches("%r").count()
-        + command.matches("%T").count()
-        + command.matches("%u").count();
-
-    const MAX_TOKENS: usize = 50; // Reasonable limit for token expansion
-    if token_count > MAX_TOKENS {
-        anyhow::bail!(
-            "Security violation: {option_name} contains excessive token usage ({token_count} tokens) at line {line_number}. \
-             Maximum allowed is {MAX_TOKENS} tokens to prevent resource exhaustion."
-        );
-    }
-
-    // Check command length after potential expansion (worst case)
-    // Assume each token could expand to 255 chars (max hostname/username length)
-    const MAX_EXPANDED_LENGTH: usize = 8192; // 8KB reasonable limit
-    let potential_length = command.len() + (token_count * 255);
-    if potential_length > MAX_EXPANDED_LENGTH {
-        anyhow::bail!(
-            "Security violation: {option_name} could expand to {potential_length} bytes at line {line_number}. \
-             Maximum allowed expanded length is {MAX_EXPANDED_LENGTH} bytes."
-        );
-    }
-
-    // Validate tokens before substitution
-    // We need to check for invalid tokens (% followed by invalid char)
-    let chars: Vec<char> = command.chars().collect();
-    let mut i = 0;
-    while i < chars.len() {
-        if chars[i] == '%' {
-            if i + 1 < chars.len() {
-                let next_char = chars[i + 1];
-                let valid_token = if option_name == "LocalCommand" {
-                    matches!(
-                        next_char,
-                        'C' | 'd'
-                            | 'h'
-                            | 'H'
-                            | 'i'
-                            | 'k'
-                            | 'L'
-                            | 'l'
-                            | 'n'
-                            | 'p'
-                            | 'r'
-                            | 'T'
-                            | 'u'
-                            | '%'
-                    )
-                } else {
-                    matches!(next_char, 'h' | 'H' | 'n' | 'p' | 'r' | 'u' | '%')
-                };
-                if !valid_token {
-                    anyhow::bail!(
-                        "Invalid token '%{next_char}' in {option_name} at line {line_number}"
-                    );
-                }
-                i += 2;
-            } else {
-                // % at end of string
-                anyhow::bail!(
-                    "Incomplete token '%' at end of {option_name} at line {line_number}. \
-                     Valid tokens are: %C, %d, %h, %H, %i, %k, %L, %l, %n, %p, %r, %T, %u, %%"
-                );
-            }
-        } else {
-            i += 1;
-        }
-    }
-
-    // Create a temporary command with tokens replaced for validation
-    // Replace valid tokens with safe placeholder strings
-    let mut sanitized = command.to_string();
-
-    // Replace %% with a temporary marker to avoid issues
-    sanitized = sanitized.replace("%%", "__DOUBLE_PERCENT__");
-
-    // Replace all valid tokens with safe placeholders
+    let mut sanitized = command.replace("%%", "__DOUBLE_PERCENT__");
     let tokens = [
         ("%C", "CONNECTIONHASH"),
         ("%d", "HOME"),
+        ("%f", "FINGERPRINT"),
+        ("%H", "KNOWNHOST"),
         ("%h", "HOSTNAME"),
-        ("%H", "HOSTNAME"),
+        ("%I", "REASON"),
         ("%i", "1000"),
+        ("%j", "JUMPHOST"),
+        ("%K", "HOSTKEY"),
         ("%k", "HOSTKEYALIAS"),
         ("%L", "LOCALHOSTSHORT"),
         ("%l", "LOCALHOST"),
@@ -289,17 +301,14 @@ fn validate_command_with_tokens(
         ("%p", "22"),
         ("%r", "USER"),
         ("%T", "NONE"),
+        ("%t", "HOSTKEYTYPE"),
         ("%u", "LOCALUSER"),
     ];
-
-    for (token, replacement) in tokens.iter() {
+    for (token, replacement) in tokens {
         sanitized = sanitized.replace(token, replacement);
     }
-
-    // Restore the %% marker as a single % for accurate validation
     sanitized = sanitized.replace("__DOUBLE_PERCENT__", "%");
 
-    // Now validate the sanitized command for injection attacks
     validate_executable_string(&sanitized, option_name, line_number).with_context(|| {
         format!("Security validation failed for {option_name} at line {line_number}")
     })
@@ -337,7 +346,7 @@ mod tests {
 
         assert!(
             validate_command_with_tokens(
-                "echo %C %d %h %H %i %k %L %l %n %p %r %T %u %%",
+                "echo %C %d %h %i %j %k %L %l %n %p %r %T %u %%",
                 "LocalCommand",
                 1,
             )
@@ -353,8 +362,9 @@ mod tests {
 
     #[test]
     fn test_validate_command_with_tokens_invalid() {
-        // Invalid token
+        // Invalid token, and %H is KnownHostsCommand-only.
         assert!(validate_command_with_tokens("echo %x", "LocalCommand", 1).is_err());
+        assert!(validate_command_with_tokens("echo %H", "LocalCommand", 1).is_err());
 
         // Command with dangerous characters (after token substitution)
         assert!(validate_command_with_tokens("echo test; rm -rf /", "LocalCommand", 1).is_err());
@@ -379,13 +389,16 @@ mod tests {
         let ok_tokens = format!("echo {}", "%h ".repeat(20)); // 20 tokens, expands to ~5KB
         assert!(validate_command_with_tokens(&ok_tokens, "LocalCommand", 1).is_ok());
 
-        // Token count OK but would expand to huge size
-        let huge_expansion = format!("{} {}", "%h".repeat(30), "x".repeat(1000));
-        assert!(validate_command_with_tokens(&huge_expansion, "LocalCommand", 1).is_err());
+        // Actual post-expansion bounds are enforced with concrete runtime
+        // values; the parser bounds the raw command without guessing lengths.
+        let under_raw_limit = format!("{} {}", "%h".repeat(30), "x".repeat(1000));
+        assert!(validate_command_with_tokens(&under_raw_limit, "LocalCommand", 1).is_ok());
+        let over_raw_limit = "x".repeat(16 * 1024 + 1);
+        assert!(validate_command_with_tokens(&over_raw_limit, "LocalCommand", 1).is_err());
 
-        // Exactly at token limit (50 tokens) but would exceed size after expansion
+        // Exactly at the token limit remains valid.
         let at_limit = "%p ".repeat(50);
-        assert!(validate_command_with_tokens(&at_limit, "LocalCommand", 1).is_err());
+        assert!(validate_command_with_tokens(&at_limit, "LocalCommand", 1).is_ok());
 
         // Just over token limit (51 tokens)
         let over_limit = "%p ".repeat(51);
@@ -482,6 +495,23 @@ mod tests {
             config.remote_command,
             Some("tmux attach -t dev || tmux new".to_string())
         );
+
+        let default_tokens = "echo %% %C %d %h %i %j %k %L %l %n %p %r %u";
+        assert!(
+            parse_command_option(
+                &mut config,
+                "remotecommand",
+                &[default_tokens.to_string()],
+                1,
+            )
+            .is_ok()
+        );
+        for invalid in ["echo %H", "echo %T"] {
+            assert!(
+                parse_command_option(&mut config, "remotecommand", &[invalid.to_string()], 1,)
+                    .is_err()
+            );
+        }
 
         // Missing value
         assert!(parse_command_option(&mut config, "remotecommand", &[], 1).is_err());

--- a/src/ssh/ssh_config/parser/options/command.rs
+++ b/src/ssh/ssh_config/parser/options/command.rs
@@ -173,14 +173,8 @@ fn validate_remote_command_warnings(command: &str, line_number: usize) {
 /// Validate command strings that support token substitution
 ///
 /// This function validates commands while allowing SSH token substitution patterns.
-/// Supported tokens:
-/// - %h - remote hostname (from config)
-/// - %H - remote hostname (as specified on command line)
-/// - %n - original hostname
-/// - %p - remote port
-/// - %r - remote username
-/// - %u - local username
-/// - %% - literal %
+/// Supports the OpenSSH LocalCommand percent-token set: `%C`, `%d`, `%h`, `%H`,
+/// `%i`, `%k`, `%L`, `%l`, `%n`, `%p`, `%r`, `%T`, `%u`, and `%%`.
 ///
 /// The actual token substitution is performed by the SSH client, not the parser.
 fn validate_command_with_tokens(
@@ -196,10 +190,17 @@ fn validate_command_with_tokens(
     // Security: Check for excessive token usage that could cause DoS
     // Count the number of tokens (excluding %%)
     let token_count = command.matches("%h").count()
+        + command.matches("%C").count()
+        + command.matches("%d").count()
         + command.matches("%H").count()
+        + command.matches("%i").count()
+        + command.matches("%k").count()
+        + command.matches("%L").count()
+        + command.matches("%l").count()
         + command.matches("%n").count()
         + command.matches("%p").count()
         + command.matches("%r").count()
+        + command.matches("%T").count()
         + command.matches("%u").count();
 
     const MAX_TOKENS: usize = 50; // Reasonable limit for token expansion
@@ -229,23 +230,37 @@ fn validate_command_with_tokens(
         if chars[i] == '%' {
             if i + 1 < chars.len() {
                 let next_char = chars[i + 1];
-                match next_char {
-                    'h' | 'H' | 'n' | 'p' | 'r' | 'u' | '%' => {
-                        // Valid token, skip both characters
-                        i += 2;
-                    }
-                    _ => {
-                        anyhow::bail!(
-                            "Invalid token '%{next_char}' in {option_name} at line {line_number}. \
-                             Valid tokens are: %h, %H, %n, %p, %r, %u, %%"
-                        );
-                    }
+                let valid_token = if option_name == "LocalCommand" {
+                    matches!(
+                        next_char,
+                        'C' | 'd'
+                            | 'h'
+                            | 'H'
+                            | 'i'
+                            | 'k'
+                            | 'L'
+                            | 'l'
+                            | 'n'
+                            | 'p'
+                            | 'r'
+                            | 'T'
+                            | 'u'
+                            | '%'
+                    )
+                } else {
+                    matches!(next_char, 'h' | 'H' | 'n' | 'p' | 'r' | 'u' | '%')
+                };
+                if !valid_token {
+                    anyhow::bail!(
+                        "Invalid token '%{next_char}' in {option_name} at line {line_number}"
+                    );
                 }
+                i += 2;
             } else {
                 // % at end of string
                 anyhow::bail!(
                     "Incomplete token '%' at end of {option_name} at line {line_number}. \
-                     Valid tokens are: %h, %H, %n, %p, %r, %u, %%"
+                     Valid tokens are: %C, %d, %h, %H, %i, %k, %L, %l, %n, %p, %r, %T, %u, %%"
                 );
             }
         } else {
@@ -262,11 +277,18 @@ fn validate_command_with_tokens(
 
     // Replace all valid tokens with safe placeholders
     let tokens = [
+        ("%C", "CONNECTIONHASH"),
+        ("%d", "HOME"),
         ("%h", "HOSTNAME"),
         ("%H", "HOSTNAME"),
+        ("%i", "1000"),
+        ("%k", "HOSTKEYALIAS"),
+        ("%L", "LOCALHOSTSHORT"),
+        ("%l", "LOCALHOST"),
         ("%n", "ORIGINAL"),
         ("%p", "22"),
         ("%r", "USER"),
+        ("%T", "NONE"),
         ("%u", "LOCALUSER"),
     ];
 
@@ -309,6 +331,15 @@ mod tests {
                 "/usr/local/bin/fetch-host-key %H",
                 "KnownHostsCommand",
                 1
+            )
+            .is_ok()
+        );
+
+        assert!(
+            validate_command_with_tokens(
+                "echo %C %d %h %H %i %k %L %l %n %p %r %T %u %%",
+                "LocalCommand",
+                1,
             )
             .is_ok()
         );

--- a/src/ssh/ssh_config/parser/options/environment.rs
+++ b/src/ssh/ssh_config/parser/options/environment.rs
@@ -17,8 +17,9 @@
 //! Handles environment-related configuration options including SendEnv
 //! and SetEnv settings for passing environment variables to remote hosts.
 
+use crate::ssh::session_policy::validate_environment;
 use crate::ssh::ssh_config::types::SshHostConfig;
-use anyhow::Result;
+use anyhow::{Context, Result};
 
 /// Parse environment-related SSH configuration options
 pub(super) fn parse_environment_option(
@@ -52,6 +53,8 @@ pub(super) fn parse_environment_option(
                 if let Some(eq_pos) = pair.find('=') {
                     let name = pair[..eq_pos].to_string();
                     let value = pair[eq_pos + 1..].to_string();
+                    validate_environment(&name, &value)
+                        .with_context(|| format!("Invalid SetEnv entry at line {line_number}"))?;
                     host.set_env.entry(name).or_insert(value);
                 } else {
                     anyhow::bail!(

--- a/src/ssh/ssh_config/parser/options/environment.rs
+++ b/src/ssh/ssh_config/parser/options/environment.rs
@@ -17,7 +17,8 @@
 //! Handles environment-related configuration options including SendEnv
 //! and SetEnv settings for passing environment variables to remote hosts.
 
-use crate::ssh::session_policy::validate_environment;
+use super::command::validate_default_percent_tokens;
+use crate::ssh::session_policy::{MAX_ENVIRONMENT_VALUE_BYTES, validate_environment};
 use crate::ssh::ssh_config::types::SshHostConfig;
 use anyhow::{Context, Result};
 
@@ -55,6 +56,13 @@ pub(super) fn parse_environment_option(
                     let value = pair[eq_pos + 1..].to_string();
                     validate_environment(&name, &value)
                         .with_context(|| format!("Invalid SetEnv entry at line {line_number}"))?;
+                    validate_default_percent_tokens(
+                        &value,
+                        "SetEnv value",
+                        line_number,
+                        MAX_ENVIRONMENT_VALUE_BYTES,
+                    )?;
+                    validate_dollar_expansions(&value, line_number)?;
                     host.set_env.entry(name).or_insert(value);
                 } else {
                     anyhow::bail!(
@@ -70,4 +78,59 @@ pub(super) fn parse_environment_option(
     }
 
     Ok(())
+}
+
+fn validate_dollar_expansions(value: &str, line_number: usize) -> Result<()> {
+    let mut remaining = value;
+    while let Some(start) = remaining.find("${") {
+        let variable = &remaining[start + 2..];
+        let Some(end) = variable.find('}') else {
+            anyhow::bail!(
+                "SetEnv environment variable expansion is missing closing '}}' at line {line_number}"
+            );
+        };
+        if end == 0 {
+            anyhow::bail!(
+                "SetEnv environment variable expansion has an empty name at line {line_number}"
+            );
+        }
+        remaining = &variable[end + 1..];
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn setenv_accepts_default_tokens_and_dollar_expansion_syntax() {
+        let mut config = SshHostConfig::default();
+        let value = "VALUE=%%:%C:%d:%h:%i:%j:%k:%L:%l:%n:%p:%r:%u:${HOME}";
+        parse_environment_option(&mut config, "setenv", &[value.into()], 7).unwrap();
+        assert_eq!(
+            config.set_env.get("VALUE").map(String::as_str),
+            Some("%%:%C:%d:%h:%i:%j:%k:%L:%l:%n:%p:%r:%u:${HOME}")
+        );
+
+        parse_environment_option(&mut config, "setenv", &["EMPTY=".into()], 8).unwrap();
+        assert_eq!(config.set_env.get("EMPTY").map(String::as_str), Some(""));
+    }
+
+    #[test]
+    fn setenv_rejects_directive_foreign_tokens_and_malformed_dollar_syntax() {
+        for value in [
+            "VALUE=%H",
+            "VALUE=%T",
+            "VALUE=%x",
+            "VALUE=${BROKEN",
+            "VALUE=${}",
+        ] {
+            let mut config = SshHostConfig::default();
+            assert!(
+                parse_environment_option(&mut config, "setenv", &[value.into()], 9).is_err(),
+                "{value} must be rejected"
+            );
+        }
+    }
 }

--- a/src/ssh/ssh_config/parser/options/support.rs
+++ b/src/ssh/ssh_config/parser/options/support.rs
@@ -14,6 +14,7 @@ pub(super) enum RuntimeConsumer {
     HostVerification,
     Transport,
     Proxy,
+    Session,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -23,7 +24,9 @@ pub(super) struct KeywordSpec {
 }
 
 use KeywordSupport::{Delegated, Runtime, Unimplemented};
-use RuntimeConsumer::{Authentication, HostVerification, NodeResolution, Proxy, Transport};
+use RuntimeConsumer::{
+    Authentication, HostVerification, NodeResolution, Proxy, Session, Transport,
+};
 
 pub(super) const ACCEPTED_KEYWORDS: &[(&str, &str, KeywordSupport)] = &[
     ("hostname", "hostname", Runtime(NodeResolution)),
@@ -178,23 +181,23 @@ pub(super) const ACCEPTED_KEYWORDS: &[(&str, &str, KeywordSupport)] = &[
     ("controlmaster", "controlmaster", Unimplemented),
     ("controlpath", "controlpath", Unimplemented),
     ("controlpersist", "controlpersist", Unimplemented),
-    ("sendenv", "sendenv", Delegated(297)),
-    ("setenv", "setenv", Delegated(297)),
-    ("requesttty", "requesttty", Delegated(297)),
+    ("sendenv", "sendenv", Runtime(Session)),
+    ("setenv", "setenv", Runtime(Session)),
+    ("requesttty", "requesttty", Runtime(Session)),
     ("escapechar", "escapechar", Unimplemented),
     ("loglevel", "loglevel", Unimplemented),
     ("syslogfacility", "syslogfacility", Unimplemented),
     ("protocol", "protocol", Unimplemented),
-    ("permitlocalcommand", "permitlocalcommand", Delegated(297)),
-    ("localcommand", "localcommand", Delegated(297)),
-    ("remotecommand", "remotecommand", Delegated(297)),
+    ("permitlocalcommand", "permitlocalcommand", Runtime(Session)),
+    ("localcommand", "localcommand", Runtime(Session)),
+    ("remotecommand", "remotecommand", Runtime(Session)),
     ("knownhostscommand", "knownhostscommand", Delegated(299)),
     (
         "forkafterauthentication",
         "forkafterauthentication",
         Unimplemented,
     ),
-    ("sessiontype", "sessiontype", Delegated(297)),
+    ("sessiontype", "sessiontype", Runtime(Session)),
     ("stdinnull", "stdinnull", Unimplemented),
     ("cipher", "cipher", Unimplemented),
     ("fallbacktorsh", "fallbacktorsh", Unimplemented),
@@ -279,6 +282,13 @@ mod tests {
             ("proxyjump", Proxy),
             ("proxycommand", Proxy),
             ("proxyusefdpass", Proxy),
+            ("sendenv", Session),
+            ("setenv", Session),
+            ("requesttty", Session),
+            ("permitlocalcommand", Session),
+            ("localcommand", Session),
+            ("remotecommand", Session),
+            ("sessiontype", Session),
         ];
         let runtime = ACCEPTED_KEYWORDS
             .iter()
@@ -306,13 +316,6 @@ mod tests {
             ("passwordauthentication", 296),
             ("numberofpasswordprompts", 296),
             ("batchmode", 296),
-            ("sendenv", 297),
-            ("setenv", 297),
-            ("localcommand", 297),
-            ("permitlocalcommand", 297),
-            ("requesttty", 297),
-            ("sessiontype", 297),
-            ("remotecommand", 297),
             ("localforward", 298),
             ("remoteforward", 298),
             ("dynamicforward", 298),

--- a/src/ssh/ssh_config/parser/options/ui.rs
+++ b/src/ssh/ssh_config/parser/options/ui.rs
@@ -32,7 +32,13 @@ pub(super) fn parse_ui_option(
             if args.is_empty() {
                 anyhow::bail!("RequestTTY requires a value at line {line_number}");
             }
-            host.request_tty = Some(args[0].clone());
+            let value = args[0].to_ascii_lowercase();
+            if !matches!(value.as_str(), "yes" | "force" | "auto" | "no") {
+                anyhow::bail!(
+                    "Invalid RequestTTY value '{value}' at line {line_number} (expected: yes, force, auto, or no)"
+                );
+            }
+            host.request_tty = Some(value);
         }
         "escapechar" => {
             if args.is_empty() {

--- a/src/ssh/tokio_client/channel_manager.rs
+++ b/src/ssh/tokio_client/channel_manager.rs
@@ -421,6 +421,17 @@ impl Client {
         sender: Sender<CommandOutput>,
         sudo_password: &SudoPassword,
     ) -> Result<u32, super::Error> {
+        self.execute_with_sudo_policy(command, sender, sudo_password, None)
+            .await
+    }
+
+    pub(crate) async fn execute_with_sudo_policy(
+        &self,
+        command: &str,
+        sender: Sender<CommandOutput>,
+        sudo_password: &SudoPassword,
+        session_policy: Option<&crate::ssh::SessionPolicy>,
+    ) -> Result<u32, super::Error> {
         // Sanitize command to prevent injection attacks
         let sanitized_command = crate::utils::sanitize_command(command)
             .map_err(|e| super::Error::CommandValidationFailed(e.to_string()))?;
@@ -433,24 +444,32 @@ impl Client {
             .await
             .map_err(|source| self.session_error_or(super::Error::ChannelOpen { source }))?;
 
-        // Request PTY with reasonable defaults for sudo
-        channel
-            .request_pty(
-                true,    // want reply
-                "xterm", // term type
-                80,      // columns
-                24,      // rows
-                0,       // pixel width
-                0,       // pixel height
-                &[],     // terminal modes (empty for defaults)
-            )
-            .await
-            .map_err(|source| {
-                self.session_error_or(super::Error::CommandExecution {
-                    action: "PTY request",
-                    source,
-                })
-            })?;
+        // Preserve the legacy sudo PTY default unless a resolved session policy
+        // carries explicit RequestTTY/CLI precedence.
+        if session_policy.is_none_or(|policy| policy.request_pty) {
+            channel
+                .request_pty(true, "xterm", 80, 24, 0, 0, &[])
+                .await
+                .map_err(|source| {
+                    self.session_error_or(super::Error::CommandExecution {
+                        action: "PTY request",
+                        source,
+                    })
+                })?;
+        }
+        if let Some(policy) = session_policy {
+            for (name, value) in &policy.environment {
+                channel
+                    .set_env(false, name, value)
+                    .await
+                    .map_err(|source| {
+                        self.session_error_or(super::Error::CommandExecution {
+                            action: "environment request",
+                            source,
+                        })
+                    })?;
+            }
+        }
 
         channel
             .exec(true, sanitized_command.as_str())

--- a/src/ssh/tokio_client/mod.rs
+++ b/src/ssh/tokio_client/mod.rs
@@ -24,6 +24,7 @@ mod connection_tests;
 pub mod error;
 pub mod file_transfer;
 mod proxy_command;
+mod session;
 // `pub(crate)` so the client-facing error message builders in `ssh::client` can
 // reuse `known_hosts_entry_name` instead of duplicating the `[host]:port` rule.
 pub(crate) mod host_verification;

--- a/src/ssh/tokio_client/session.rs
+++ b/src/ssh/tokio_client/session.rs
@@ -1,0 +1,144 @@
+// Copyright 2025 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Ordered application of resolved session policy to live SSH channels.
+
+use russh::client::Msg;
+use russh::{Channel, ChannelMsg};
+use tokio::sync::mpsc::Sender;
+
+use crate::ssh::{SessionPolicy, SessionRequest};
+
+use super::channel_manager::{CommandExecutedResult, CommandOutput, CommandOutputBuffer};
+use super::connection::Client;
+
+impl Client {
+    pub async fn execute_session_streaming(
+        &self,
+        policy: &SessionPolicy,
+        sender: Sender<CommandOutput>,
+    ) -> Result<u32, super::Error> {
+        if matches!(policy.request, SessionRequest::None) {
+            return Ok(0);
+        }
+        let channel = self.open_policy_channel(policy).await?;
+        self.drain_policy_channel(channel, sender).await
+    }
+
+    pub async fn execute_session(
+        &self,
+        policy: &SessionPolicy,
+    ) -> Result<CommandExecutedResult, super::Error> {
+        let output_buffer = CommandOutputBuffer::new();
+        let sender = output_buffer.sender.clone();
+        let exit_status = self.execute_session_streaming(policy, sender).await?;
+        drop(output_buffer.sender);
+        let (stdout, stderr) = output_buffer
+            .receiver_task
+            .await
+            .map_err(super::Error::JoinError)?;
+        Ok(CommandExecutedResult {
+            stdout: String::from_utf8_lossy(&stdout).into_owned(),
+            stderr: String::from_utf8_lossy(&stderr).into_owned(),
+            exit_status,
+        })
+    }
+
+    async fn open_policy_channel(
+        &self,
+        policy: &SessionPolicy,
+    ) -> Result<Channel<Msg>, super::Error> {
+        let channel = self
+            .connection_handle
+            .channel_open_session()
+            .await
+            .map_err(|source| self.session_error_or(super::Error::ChannelOpen { source }))?;
+
+        if policy.request_pty {
+            let terminal = std::env::var("TERM").unwrap_or_else(|_| "xterm".to_string());
+            channel
+                .request_pty(true, &terminal, 80, 24, 0, 0, &[])
+                .await
+                .map_err(|source| {
+                    self.session_error_or(super::Error::CommandExecution {
+                        action: "PTY request",
+                        source,
+                    })
+                })?;
+        }
+        for (name, value) in &policy.environment {
+            channel
+                .set_env(false, name, value)
+                .await
+                .map_err(|source| {
+                    self.session_error_or(super::Error::CommandExecution {
+                        action: "environment request",
+                        source,
+                    })
+                })?;
+        }
+
+        match &policy.request {
+            SessionRequest::Exec(command) => {
+                let command = crate::utils::sanitize_command(command)
+                    .map_err(|error| super::Error::CommandValidationFailed(error.to_string()))?;
+                channel.exec(true, command.as_bytes()).await
+            }
+            SessionRequest::Shell => channel.request_shell(true).await,
+            SessionRequest::Subsystem(name) => channel.request_subsystem(true, name).await,
+            SessionRequest::None => {
+                return Err(super::Error::CommandValidationFailed(
+                    "SessionType none does not create a command channel".to_string(),
+                ));
+            }
+        }
+        .map_err(|source| {
+            self.session_error_or(super::Error::CommandExecution {
+                action: "session request",
+                source,
+            })
+        })?;
+        Ok(channel)
+    }
+
+    async fn drain_policy_channel(
+        &self,
+        mut channel: Channel<Msg>,
+        sender: Sender<CommandOutput>,
+    ) -> Result<u32, super::Error> {
+        let mut exit_status = None;
+        let mut receiver_open = true;
+        while let Some(message) = channel.wait().await {
+            let output = match message {
+                ChannelMsg::Data { data } => Some(CommandOutput::StdOut(data)),
+                ChannelMsg::ExtendedData { data, ext: 1 } => Some(CommandOutput::StdErr(data)),
+                ChannelMsg::ExitStatus {
+                    exit_status: status,
+                } => {
+                    exit_status = Some(status);
+                    None
+                }
+                _ => None,
+            };
+            if receiver_open
+                && let Some(output) = output
+                && sender.send(output).await.is_err()
+            {
+                receiver_open = false;
+            }
+        }
+        drop(sender);
+        exit_status.ok_or_else(|| self.session_error_or(super::Error::CommandDidntExit))
+    }
+}

--- a/tests/interactive_integration_test.rs
+++ b/tests/interactive_integration_test.rs
@@ -53,6 +53,7 @@ fn test_interactive_command_builder() {
         strict_mode: StrictHostKeyChecking::AcceptNew,
         pty_config: PtyConfig::default(),
         use_pty: None,
+        session_policy: None,
         jump_hosts: None,
         ssh_connection_config: SshConnectionConfig::default(),
     };
@@ -89,6 +90,7 @@ fn test_history_file_handling() {
         strict_mode: StrictHostKeyChecking::AcceptNew,
         pty_config: PtyConfig::default(),
         use_pty: None,
+        session_policy: None,
         jump_hosts: None,
         ssh_connection_config: SshConnectionConfig::default(),
     };
@@ -188,6 +190,7 @@ async fn test_interactive_with_unreachable_nodes() {
         strict_mode: StrictHostKeyChecking::AcceptNew,
         pty_config: PtyConfig::default(),
         use_pty: None,
+        session_policy: None,
         jump_hosts: None,
         ssh_connection_config: SshConnectionConfig::default(),
     };
@@ -224,6 +227,7 @@ async fn test_interactive_with_no_nodes() {
         strict_mode: StrictHostKeyChecking::AcceptNew,
         pty_config: PtyConfig::default(),
         use_pty: None,
+        session_policy: None,
         jump_hosts: None,
         ssh_connection_config: SshConnectionConfig::default(),
     };
@@ -270,6 +274,7 @@ fn test_mode_configuration() {
         strict_mode: StrictHostKeyChecking::AcceptNew,
         pty_config: PtyConfig::default(),
         use_pty: None,
+        session_policy: None,
         jump_hosts: None,
         ssh_connection_config: SshConnectionConfig::default(),
     };
@@ -297,6 +302,7 @@ fn test_mode_configuration() {
         strict_mode: StrictHostKeyChecking::AcceptNew,
         pty_config: PtyConfig::default(),
         use_pty: None,
+        session_policy: None,
         jump_hosts: None,
         ssh_connection_config: SshConnectionConfig::default(),
     };
@@ -327,6 +333,7 @@ fn test_working_directory_config() {
         strict_mode: StrictHostKeyChecking::AcceptNew,
         pty_config: PtyConfig::default(),
         use_pty: None,
+        session_policy: None,
         jump_hosts: None,
         ssh_connection_config: SshConnectionConfig::default(),
     };
@@ -352,6 +359,7 @@ fn test_working_directory_config() {
         strict_mode: StrictHostKeyChecking::AcceptNew,
         pty_config: PtyConfig::default(),
         use_pty: None,
+        session_policy: None,
         jump_hosts: None,
         ssh_connection_config: SshConnectionConfig::default(),
     };
@@ -389,6 +397,7 @@ fn test_prompt_format() {
             strict_mode: StrictHostKeyChecking::AcceptNew,
             pty_config: PtyConfig::default(),
             use_pty: None,
+            session_policy: None,
             jump_hosts: None,
             ssh_connection_config: SshConnectionConfig::default(),
         };

--- a/tests/interactive_test.rs
+++ b/tests/interactive_test.rs
@@ -43,6 +43,7 @@ async fn test_interactive_command_creation() {
         strict_mode: StrictHostKeyChecking::AcceptNew,
         pty_config: PtyConfig::default(),
         use_pty: None,
+        session_policy: None,
         jump_hosts: None,
         ssh_connection_config: SshConnectionConfig::default(),
     };
@@ -73,6 +74,7 @@ async fn test_interactive_with_no_nodes() {
         strict_mode: StrictHostKeyChecking::AcceptNew,
         pty_config: PtyConfig::default(),
         use_pty: None,
+        session_policy: None,
         jump_hosts: None,
         ssh_connection_config: SshConnectionConfig::default(),
     };

--- a/tests/pty_integration_test.rs
+++ b/tests/pty_integration_test.rs
@@ -39,6 +39,7 @@ fn create_test_pty_config() -> PtyConfig {
         term_type: "xterm-256color".to_string(),
         force_pty: true,
         disable_pty: false,
+        environment: Vec::new(),
         enable_mouse: false,
         timeout: Duration::from_millis(10),
     }
@@ -78,6 +79,7 @@ fn test_pty_config_cloning() {
         term_type: "custom-term".to_string(),
         force_pty: true,
         disable_pty: false,
+        environment: Vec::new(),
         enable_mouse: true,
         timeout: Duration::from_secs(1),
     };

--- a/tests/pty_utils_test.rs
+++ b/tests/pty_utils_test.rs
@@ -168,6 +168,7 @@ fn test_pty_config_clone() {
         term_type: "custom-term".to_string(),
         force_pty: true,
         disable_pty: false,
+        environment: Vec::new(),
         enable_mouse: true,
         timeout: Duration::from_secs(1),
     };

--- a/tests/ssh_config_command_options_advanced_test.rs
+++ b/tests/ssh_config_command_options_advanced_test.rs
@@ -173,7 +173,7 @@ Host test3
 fn test_command_with_all_tokens() {
     let config = r#"
 Host test
-    LocalCommand echo "Host:%h Hostname:%H Original:%n Port:%p Remote:%r Local:%u Percent:%%"
+    LocalCommand echo "Host:%h Jump:%j Original:%n Port:%p Remote:%r Local:%u Percent:%%"
 "#;
 
     let config_parsed = SshConfig::parse(config).unwrap();
@@ -183,7 +183,7 @@ Host test
     assert_eq!(
         hosts[0].local_command,
         Some(
-            "echo \"Host:%h Hostname:%H Original:%n Port:%p Remote:%r Local:%u Percent:%%\""
+            "echo \"Host:%h Jump:%j Original:%n Port:%p Remote:%r Local:%u Percent:%%\""
                 .to_string()
         )
     );

--- a/tests/ssh_config_command_options_test.rs
+++ b/tests/ssh_config_command_options_test.rs
@@ -54,7 +54,7 @@ Host test3
     LocalCommand /usr/local/bin/script %u@%r:%p
 
 Host test4
-    LocalCommand echo "Hostname: %h, %H, Original: %n, Port: %p, User: %r, Local: %u"
+    LocalCommand echo "Hostname: %h, %j, Original: %n, Port: %p, User: %r, Local: %u"
 
 Host test5
     LocalCommand echo "Literal percent: %% done"
@@ -78,7 +78,7 @@ Host test5
     );
     assert_eq!(
         hosts[3].local_command,
-        Some("echo \"Hostname: %h, %H, Original: %n, Port: %p, User: %r, Local: %u\"".to_string())
+        Some("echo \"Hostname: %h, %j, Original: %n, Port: %p, User: %r, Local: %u\"".to_string())
     );
     assert_eq!(
         hosts[4].local_command,

--- a/tests/ssh_keepalive_test.rs
+++ b/tests/ssh_keepalive_test.rs
@@ -696,6 +696,7 @@ fn test_interactive_mode_ssh_connection_config_default() {
         jump_hosts: None,
         pty_config: PtyConfig::default(),
         use_pty: None,
+        session_policy: None,
         ssh_connection_config: SshConnectionConfig::default(),
     };
 
@@ -744,6 +745,7 @@ fn test_interactive_mode_ssh_connection_config_custom() {
         jump_hosts: None,
         pty_config: PtyConfig::default(),
         use_pty: None,
+        session_policy: None,
         ssh_connection_config: custom_config,
     };
 
@@ -790,6 +792,7 @@ fn test_interactive_mode_ssh_connection_config_disabled_keepalive() {
         jump_hosts: None,
         pty_config: PtyConfig::default(),
         use_pty: None,
+        session_policy: None,
         ssh_connection_config: disabled_config,
     };
 


### PR DESCRIPTION
## Summary

- Resolve `SendEnv` and `SetEnv` into bounded, deterministic per-host requests with removal and collision semantics, default percent tokens, and SetEnv environment expansion.
- Apply permitted `LocalCommand` once after authentication, expand the exact OpenSSH 10.3 directive-specific token sets including `%j`, and include ProxyJump in `%C`.
- Select expanded `RemoteCommand`, reject explicit-command conflicts, apply `RequestTTY` with `-t`/`-T` precedence, and map `SessionType` to exec, shell, subsystem, or no channel.
- Use the resolved policy in normal, fail-fast, streaming, sudo, and plain ssh-compatible shell paths.
- Preserve stdin bytes delivered by the local OS and remote stdout and stderr bytes for ssh-compatible shells even without a remote PTY; keep the local terminal canonical, disable SSH escape filtering, and skip mouse protocols and resize handling when no PTY is requested.

## Validation

- `cargo check`
- `cargo check --tests`
- `cargo test ssh::session_policy::tests --lib` (7 passed)
- `cargo test ssh::ssh_config::parser::options::command::tests --lib` (6 passed)
- `cargo test ssh::ssh_config::parser::options::environment::tests --lib` (2 passed)
- `cargo test ssh::ssh_config::parser::options::support::tests --lib` (3 passed)
- `cargo test pty::session::session_manager::tests --lib` (2 passed)
- `cargo test pty::session::raw_input_task::tests --lib` (2 passed)
- `cargo test pty::session --lib` (181 passed)
- `cargo test pty::session::output_delivery::tests --lib` (4 passed)
- `cargo test commands::interactive::utils::tests --lib` (3 passed)
- `cargo test --bin bssh app::dispatcher::tests` (3 passed)
- `cargo test --test ssh_config_command_options_test` (16 passed)
- `cargo test --test ssh_config_command_options_advanced_test` (15 passed)
- `cargo clippy --lib -- -D warnings`
- `cargo clippy --bin bssh -- -D warnings`
- `cargo fmt --all -- --check`
- `cargo build --locked --bin bssh`
- Pinned OpenSSH regress: `host-expand` passed and `localcommand` passed.

## Regress dependencies

- `envpass` reaches a heredoc-driven remote `sh` and requires exec-channel stdin forwarding and pipe EOF completion. The ssh-compatible shell path now forwards the bytes delivered by stdin, while the adjacent exec stdin and `-n` work remains tracked in #285.
- `percent` stops at the first unsupported `-G` invocation, tracked in #282; its later ControlPath and connection-multiplexing coverage remains tracked in #286. The issue-owned token sets, `%j`, and jump-inclusive `%C` are covered directly.

Closes #297

